### PR TITLE
Turn on feature accessibility input

### DIFF
--- a/macos/Onit/Accessibility/AXUIElement+Accessors.swift
+++ b/macos/Onit/Accessibility/AXUIElement+Accessors.swift
@@ -75,6 +75,33 @@ extension AXUIElement {
     func visibleChildren() -> [AXUIElement]? {
         return self.attribute(forAttribute: kAXVisibleChildrenAttribute as CFString) as? [AXUIElement]
     }
+    
+    func selectedTextBound() -> CGRect? {
+        var rangeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(self, kAXSelectedTextRangeAttribute as CFString, &rangeValue) == .success else {
+            return nil
+        }
+        
+        var textRange = CFRange()
+        AXValueGetValue(rangeValue as! AXValue, .cfRange, &textRange)
+        
+        var bounds: CFTypeRef?
+        guard AXUIElementCopyParameterizedAttributeValue(
+            self,
+            kAXBoundsForRangeParameterizedAttribute as CFString,
+            rangeValue as CFTypeRef,
+            &bounds
+        ) == .success else {
+            return nil
+        }
+        
+        let boundsValue = bounds as! AXValue
+        
+        var rect = CGRect.zero
+        AXValueGetValue(boundsValue, .cgRect, &rect)
+        
+        return rect
+    }
 }
 
 //

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -349,6 +349,8 @@ class AccessibilityNotificationsManager {
     }
     
     private func handleSelectionChange(for element: AXUIElement) {
+        guard AccessibilityTextSelectionFilter.filter(element: element) == false else { return }
+        
         selectionDebounceWorkItem?.cancel()
         
         let workItem = DispatchWorkItem { [weak self] in

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -192,10 +192,6 @@ class AccessibilityNotificationsManager {
             print("\nApplication deactivated: \(app.localizedName ?? "Unknown") \(app.processIdentifier)")
             
             self.stopAccessibilityObservers(for: app.processIdentifier)
-            
-            DispatchQueue.main.async {
-                WindowHelper.shared.hide()
-            }
         }
     }
     

--- a/macos/Onit/Accessibility/Notifications/AccessibilityTextSelectionFilter.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityTextSelectionFilter.swift
@@ -1,0 +1,43 @@
+//
+//  AccessibilityTextSelectionFilter.swift
+//  Onit
+//
+//  Created by Kévin Naudin on 29/01/2025.
+//
+
+import ApplicationServices
+
+struct AccessibilityTextSelectionFilter {
+    
+    static func filter(element: AXUIElement) -> Bool {
+        guard element.role() == "AXTextField" else { return false }
+        
+        guard let description = element.description() else {
+            // Arc
+            if let placeholder = element.attribute(forAttribute: kAXPlaceholderValueAttribute as CFString) as? String,
+               placeholder == "Search or Enter URL…" {
+                return true
+            }
+            return false
+        }
+        
+        switch description {
+
+        // Chrome + Microsoft Edge
+        case "Address and search bar":
+            return true
+        // Firefox
+        case "Search or enter address":
+            return true
+        // Safari
+        case "Smart Search Field", "Enter website name":
+            return true
+        // Opera
+        case "Address field":
+            return true
+            
+        default:
+            return false
+        }
+    }
+}

--- a/macos/Onit/Accessibility/ProcessIdentifier+Helper.swift
+++ b/macos/Onit/Accessibility/ProcessIdentifier+Helper.swift
@@ -1,0 +1,22 @@
+//
+//  ProcessIdentifier+Helper.swift
+//  Onit
+//
+//  Created by Kévin Naudin on 24/01/2025.
+//
+
+import ApplicationServices
+import Foundation
+import SwiftUI
+
+extension pid_t {
+    func getAXUIElement() -> AXUIElement {
+        return AXUIElementCreateApplication(self)
+    }
+    
+    func getAppName() -> String? {
+        guard let app = NSRunningApplication(processIdentifier: self) else { return nil }
+
+        return app.localizedName
+    }
+}

--- a/macos/Onit/Accessibility/WindowHelper.swift
+++ b/macos/Onit/Accessibility/WindowHelper.swift
@@ -80,40 +80,27 @@ class WindowHelper {
     
     private func showWindowWithAnimation() {
         DispatchQueue.main.async {
-            // Ensure the contentView is layer-backed
-            self.window.contentView?.wantsLayer = true
-
-            // Get the contentView's layer
-            guard let layer = self.window.contentView?.layer else { return }
-
-            // Set the anchorPoint to the right and adjust the layer's position
-            let oldFrame = layer.frame
-            layer.anchorPoint = CGPoint(x: 1.0, y: 0.5)
-            layer.frame = oldFrame // Reset frame to keep the layer in the same place
-
-            // Set initial state
-            self.window.alphaValue = 0.0
+            guard let screen = NSScreen.main else { return }
+            
+            let screenFrame = screen.frame
+            var windowFrame = self.window.frame
+            
+            // Set initial position (not visible)
+            windowFrame.origin.x = screenFrame.maxX
+            self.window.setFrame(windowFrame, display: false)
+            self.window.alphaValue = 0
             self.window.makeKeyAndOrderFront(nil)
 
-            // Animate the window's alphaValue
+            // Set initial position (visible)
+            windowFrame.origin.x = screenFrame.maxX - windowFrame.width
+            
+            // Apply animation
             NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.3 // Adjust duration as needed
+                context.duration = 0.15
                 context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                self.window.animator().setFrame(windowFrame, display: true)
                 self.window.animator().alphaValue = 1.0
             }
-
-            // Create a width animation for the layer
-            let widthAnimation = CABasicAnimation(keyPath: "bounds.size.width")
-            widthAnimation.fromValue = 0.0
-            widthAnimation.toValue = oldFrame.size.width
-            widthAnimation.duration = 0.3 // Match duration with alphaValue animation
-            widthAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
-
-            // Apply the animation to the layer
-            layer.add(widthAnimation, forKey: "expandWidth")
-
-            // Set the final bounds to ensure the layer ends up at the correct size
-            layer.bounds.size.width = oldFrame.size.width
         }
     }
     

--- a/macos/Onit/Accessibility/WindowHelper.swift
+++ b/macos/Onit/Accessibility/WindowHelper.swift
@@ -49,8 +49,8 @@ class WindowHelper {
             return
         }
         
-        WindowHelper.shared.adjustWindowToTopRight()
-        WindowHelper.shared.showWindowWithAnimation()
+        adjustWindowToTopRight()
+        showWindowWithAnimation()
     }
     
     /** Hide the open app's shortcut window */
@@ -78,7 +78,7 @@ class WindowHelper {
         }
     }
     
-    func showWindowWithAnimation() {
+    private func showWindowWithAnimation() {
         DispatchQueue.main.async {
             // Ensure the contentView is layer-backed
             self.window.contentView?.wantsLayer = true

--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -48,20 +48,8 @@ struct App: SwiftUI.App {
 
         #if !targetEnvironment(simulator)
         
-        let hostingController = NSHostingController(rootView: StaticPromptView())
-        let window = NSWindow(contentViewController: hostingController)
-        
-        window.styleMask = [.borderless]
-        window.isOpaque = false
-        window.backgroundColor = NSColor.clear
-        window.level = .floating
-        window.hasShadow = false
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        
         AccessibilityPermissionManager.shared.setModel(model)
         AccessibilityNotificationsManager.shared.setModel(model)
-        AccessibilityNotificationsManager.shared.setupWindow(window)
-        WindowHelper.shared.setupWindow(window)
         
         #endif
     }

--- a/macos/Onit/Data/Model/Model+Chat.swift
+++ b/macos/Onit/Data/Model/Model+Chat.swift
@@ -34,6 +34,7 @@ extension OnitModel {
         currentChat?.prompts.append(prompt)
         currentPrompts?.append(prompt)
         pendingInstruction = ""
+        pendingInput = nil
     
         do {
             try container.mainContext.save()
@@ -84,7 +85,7 @@ extension OnitModel {
                     // chat(instructions: [String], inputs: [Input?], files: [[URL]], images[[URL]], responses: [String], model: AIModel?, apiToken: String?)
                     chat = try await client.chat(
                         instructions: instructionsHistory,
-                        inputs: inputsHistory.map { _ in nil }, // Add back in inputs once we have accessibility
+                        inputs: inputsHistory,
                         files: filesHistory,
                         images: imagesHistory,
                         responses: responsesHistory,
@@ -95,7 +96,7 @@ extension OnitModel {
                     // TODO implement history for local chat!
                     chat = try await client.localChat(
                         instructions: instructionsHistory,
-                        inputs: inputsHistory.map { _ in nil },
+                        inputs: inputsHistory,
                         files: filesHistory,
                         images: imagesHistory,
                         responses: responsesHistory,

--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -126,14 +126,14 @@ extension OnitModel: NSWindowDelegate {
     func closeDebugWindow() {
         guard let panel = debugPanel else { return }
         panel.orderOut(nil)
-        WindowHelper.shared.adjustWindowToTopRight()
+        HighlightHintWindowController.shared.adjustWindow()
         self.debugPanel = nil
     }
 
     func closePanel() {
         guard let panel = panel else { return }
         panel.orderOut(nil)
-        WindowHelper.shared.adjustWindowToTopRight()
+        HighlightHintWindowController.shared.adjustWindow()
         self.panel = nil
         
         disableKeyboardShortcuts()

--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -24,7 +24,6 @@ import AppKit
     var isTooltipActive = false
     var showHistory: Bool = false
     var showMenuBarExtra: Bool = false
-    var inputExpanded = true
     var panel: CustomPanel? = nil
 
     var currentChat: Chat?

--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -167,8 +167,9 @@ import AppKit
     }
 
     init(container: ModelContainer) {
-        self.pendingInput = Input?.load()
-        self.pendingInstruction = String.load("instructions") ?? ""
+        // TODO: KNA - Checks this
+        // self.pendingInput = Input?.load()
+        // self.pendingInstruction = String.load("instructions") ?? ""
         self.container = container
         super.init()
         self.preferences = Preferences.shared

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -12,8 +12,6 @@ class Preferences: Codable {
     
     private static let key = "app_preferences"
     
-    let id: UUID = UUID()
-    
     static func save(_ preferences: Preferences) {
         if let data = try? JSONEncoder().encode(preferences) {
             UserDefaults.standard.set(data, forKey: key)
@@ -40,6 +38,7 @@ class Preferences: Codable {
     var availableRemoteModels: [AIModel] = []
     var visibleModelIds: Set<String> = Set([])
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
+    var featureFlags: FeatureFlagManager.FeatureFlags? = nil
 
     func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -39,6 +39,7 @@ class Preferences: Codable {
     var visibleModelIds: Set<String> = Set([])
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
     var featureFlags: FeatureFlagManager.FeatureFlags? = nil
+    var highlightHintMode: HighlightHintMode? = nil
 
     func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {

--- a/macos/Onit/Data/Structures/Input.swift
+++ b/macos/Onit/Data/Structures/Input.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Input: Codable {
+struct Input: Codable, Equatable {
     var selectedText: String
     var application: String?
 }

--- a/macos/Onit/Data/Structures/SettingsTab.swift
+++ b/macos/Onit/Data/Structures/SettingsTab.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SettingsTab: String {
     case models
     case shortcuts
+    case accessibility
     case about
     #if DEBUG
     case debug

--- a/macos/Onit/UI/OS/OnitPromptView.swift
+++ b/macos/Onit/UI/OS/OnitPromptView.swift
@@ -9,27 +9,31 @@ import SwiftUI
 import KeyboardShortcuts
 
 struct OnitPromptView: View {
+    @Environment(\.model) var model
+    
     var shortcut: KeyboardShortcut? {
         KeyboardShortcuts.getShortcut(for: .launch)?.native
     }
 
     var body: some View {
-        HStack(spacing: 3) {
-            Image(.smirk)
-                .resizable()
-                .renderingMode(.template)
-                .scaledToFit()
-                .frame(width: 14, height: 14)
-            KeyboardShortcutView(shortcut: shortcut, characterWidth: 12, spacing: 3)
-                .font(.system(size: 13, weight: .light))
+        if model.panel == nil {
+            HStack(spacing: 3) {
+                Image(.smirk)
+                    .resizable()
+                    .renderingMode(.template)
+                    .scaledToFit()
+                    .frame(width: 14, height: 14)
+                KeyboardShortcutView(shortcut: shortcut, characterWidth: 12, spacing: 3)
+                    .font(.system(size: 13, weight: .light))
+            }
+            .foregroundStyle(Color.secondary)
+            .padding(4)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(.thickMaterial)
+            }
+            .padding(.vertical, 5)
         }
-        .foregroundStyle(Color.secondary)
-        .padding(4)
-        .background {
-            RoundedRectangle(cornerRadius: 6)
-                .fill(.thickMaterial)
-        }
-        .padding(.vertical, 5)
     }
 }
 

--- a/macos/Onit/UI/OS/StaticPromptView.swift
+++ b/macos/Onit/UI/OS/StaticPromptView.swift
@@ -37,13 +37,15 @@ struct StaticPromptView: View {
                     )
             }
             .foregroundStyle(Color.white)
-            .padding(.bottom, 10)
-            .padding(.leading, 10)
-            .padding(.trailing, 20)
-            .padding(.top, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.black)
+            .padding(10)
+            .background(Color.black)
+            .clipShape(
+                .rect(
+                    topLeadingRadius: 10,
+                    bottomLeadingRadius: 10,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 0
+                )
             )
         }
     }

--- a/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
@@ -66,7 +66,7 @@ struct GeneratedToolbar: View {
         Button {
             if prompt.generationIndex != -1 && !prompt.responses.isEmpty {
                 let text = prompt.responses[prompt.generationIndex].text
-                WindowHelper.shared.insertText(text)
+                HighlightHintWindowController.shared.insertText(text)
                 model.closePanel()
             } else {
                 print("Not generated: \(prompt.generationState ?? .done)")

--- a/macos/Onit/UI/Prompt/Generated/GeneratedView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedView.swift
@@ -11,6 +11,9 @@ struct GeneratedView: View {
     var prompt: Prompt
 
     var body: some View {
+        if let input = prompt.input {
+            InputView(input: input)
+        }
         UserInputView(prompt: prompt, isSent: true)
         content
     }

--- a/macos/Onit/UI/Prompt/GeneratingView.swift
+++ b/macos/Onit/UI/Prompt/GeneratingView.swift
@@ -16,6 +16,9 @@ struct GeneratingView: View {
     }
 
     var body: some View {
+        if let input = prompt.input {
+            InputView(input: input)
+        }
         UserInputView(prompt: prompt, isSent: true)
         Button {
             model.cancelGenerate()

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -10,8 +10,9 @@ import SwiftUI
 struct InputBody: View {
     @Environment(\.model) var model
 
-    var text: String
-
+    @Binding var inputExpanded: Bool
+    var input: Input
+    
     @State var textHeight: CGFloat = 0
 
     var height: CGFloat {
@@ -25,11 +26,11 @@ struct InputBody: View {
                 textView
             }
         }
-        .frame(height: model.inputExpanded ? height : 0)
+        .frame(height: inputExpanded ? height : 0)
     }
 
     var textView: some View {
-        Text(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        Text(input.selectedText.trimmingCharacters(in: .whitespacesAndNewlines))
             .foregroundStyle(.white)
             .appFont(.medium16)
             .padding(10)
@@ -48,7 +49,7 @@ struct InputBody: View {
 #if DEBUG
 #Preview {
     ModelContainerPreview {
-        InputBody(text: "This is a long sample string")
+        InputBody(inputExpanded: .constant(true), input: .sample)
     }
 }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -6,14 +6,15 @@
 //
 
 import SwiftUI
+import HighlightSwift
+import MarkdownUI
 
 struct InputBody: View {
     @Environment(\.model) var model
-
     @Binding var inputExpanded: Bool
-    var input: Input
-    
     @State var textHeight: CGFloat = 0
+    
+    var input: Input
 
     var height: CGFloat {
         min(textHeight, 73)
@@ -28,13 +29,14 @@ struct InputBody: View {
         }
         .frame(height: inputExpanded ? height : 0)
     }
-
+    
     var textView: some View {
-        Text(input.selectedText.trimmingCharacters(in: .whitespacesAndNewlines))
-            .foregroundStyle(.white)
-            .appFont(.medium16)
-            .padding(10)
+        Markdown(formattedText)
+            .markdownTheme(customTheme)
+            .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(10)
             .background {
                 GeometryReader { proxy in
                     Color.clear
@@ -43,6 +45,32 @@ struct InputBody: View {
                         }
                 }
             }
+    }
+    
+    private let customTheme = Theme()
+        .text {
+            FontFamily(.custom("Inter"))
+            FontSize(16)
+            ForegroundColor(.FG)
+        }
+        .code {
+            FontFamily(.custom("SometypeMono"))
+            FontFamilyVariant(.monospaced)
+            ForegroundColor(.pink)
+        }
+        .codeBlock { configuration in
+            if let language = configuration.language,
+               let language = HighlightLanguage.language(for: language) {
+                CodeText(configuration.content)
+                    .codeFont(AppFont.code.nsFont)
+                    .highlightLanguage(language)
+            } else {
+                CodeText(configuration.content)
+            }
+        }
+    
+    private var formattedText: String {
+        "```\n" + input.selectedText + "\n```"
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -9,28 +9,33 @@ import SwiftUI
 
 struct InputButtons: View {
     @Environment(\.model) var model
+    @Binding var inputExpanded: Bool
+    
+    var input: Input
 
     var body: some View {
         @Bindable var model = model
 
         Group {
-            Button {
-                model.pendingInput = nil
-            } label: {
-                Image(.smallRemove)
-                    .renderingMode(.template)
+            if input == model.pendingInput {
+                Button {
+                    model.pendingInput = nil
+                } label: {
+                    Image(.smallRemove)
+                        .renderingMode(.template)
+                }
+                .buttonStyle(DarkerButtonStyle())
             }
-            .buttonStyle(DarkerButtonStyle())
-            
+                
             Button {
-                model.inputExpanded.toggle()
+                inputExpanded.toggle()
             } label: {
                 Color.clear
                     .frame(width: 20, height: 20)
                     .overlay {
                         Image(.smallChevRight)
                             .renderingMode(.template)
-                            .rotationEffect(model.inputExpanded ? .degrees(90) : .zero)
+                            .rotationEffect(inputExpanded ? .degrees(90) : .zero)
                     }
             }
         }
@@ -41,7 +46,7 @@ struct InputButtons: View {
 #if DEBUG
 #Preview {
     ModelContainerPreview {
-        InputButtons()
+        InputButtons(inputExpanded: .constant(true), input: .sample)
     }
 }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputTitle.swift
+++ b/macos/Onit/UI/Prompt/Input/InputTitle.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct InputTitle: View {
-    @Environment(\.model) var model
-//    var source: String?
+    @Binding var inputExpanded: Bool
+    var input: Input
 
     var sourceString: String {
-        guard let sourceText = model.pendingInput?.application else { return "" }
+        guard let sourceText = input.application else { return "" }
         return " - \(sourceText)"
     }
 
@@ -25,7 +25,7 @@ struct InputTitle: View {
             Text(inputString)
                 .appFont(.medium13)
             Spacer()
-            InputButtons()
+            InputButtons(inputExpanded: $inputExpanded, input: input)
         }
         .foregroundStyle(.gray100)
         .padding(.horizontal, 12)
@@ -34,5 +34,5 @@ struct InputTitle: View {
 }
 
 #Preview {
-    InputTitle()
+    InputTitle(inputExpanded: .constant(true), input: .sample)
 }

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -8,15 +8,16 @@
 import SwiftUI
 
 struct InputView: View {
-    @Environment(\.model) var model
+    
+    @State var inputExpanded: Bool = true
     
     var input: Input
     
     var body: some View {
         VStack(spacing: 0) {
-            InputTitle()
+            InputTitle(inputExpanded: $inputExpanded, input: input)
             divider
-            InputBody(text: input.selectedText)
+            InputBody(inputExpanded: $inputExpanded, input: input)
         }
         .background {
             RoundedRectangle(cornerRadius: 10)
@@ -29,7 +30,7 @@ struct InputView: View {
     var divider: some View {
         Color.gray600
             .frame(height: 1)
-            .opacity(model.inputExpanded ? 1 : 0)
+            .opacity(inputExpanded ? 1 : 0)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -16,7 +16,7 @@ struct InputView: View {
         VStack(spacing: 0) {
             InputTitle()
             divider
-            InputBody(text: model.pendingInput?.selectedText ?? "")
+            InputBody(text: input.selectedText)
         }
         .background {
             RoundedRectangle(cornerRadius: 10)

--- a/macos/Onit/UI/Prompt/InputBarView.swift
+++ b/macos/Onit/UI/Prompt/InputBarView.swift
@@ -24,12 +24,6 @@ struct InputBarView: View {
         .background {
             heightListener
         }
-        .onChange(of: model.pendingInput) { _, _ in
-            model.adjustPanelSize()
-        }
-        .onChange(of: model.inputExpanded) { _, _ in
-            model.adjustPanelSize()
-        }
     }
 
     var heightListener: some View {
@@ -37,9 +31,11 @@ struct InputBarView: View {
             Color.clear
                 .onAppear {
                     model.inputHeight = proxy.size.height
+                    model.adjustPanelSize()
                 }
                 .onChange(of: proxy.size.height) { _, new in
                     model.inputHeight = new
+                    model.adjustPanelSize()
                 }
         }
     }

--- a/macos/Onit/UI/Prompt/InputBarView.swift
+++ b/macos/Onit/UI/Prompt/InputBarView.swift
@@ -15,6 +15,9 @@ struct InputBarView: View {
             if model.currentPrompts?.count ?? 0 > 0 {
                 PromptDivider()
             }
+            if let pendingInput = model.pendingInput {
+                InputView(input: pendingInput)
+            }
             FileRow(contextList: model.pendingContextList, isSent: false)
             TextInputView()
         }

--- a/macos/Onit/UI/Prompt/InputBarView.swift
+++ b/macos/Onit/UI/Prompt/InputBarView.swift
@@ -24,6 +24,12 @@ struct InputBarView: View {
         .background {
             heightListener
         }
+        .onChange(of: model.pendingInput) { _, _ in
+            model.adjustPanelSize()
+        }
+        .onChange(of: model.inputExpanded) { _, _ in
+            model.adjustPanelSize()
+        }
     }
 
     var heightListener: some View {

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct AccessibilityTab: View {
+    
+    struct HighlightHintModeUI: Hashable {
+        let mode: HighlightHintMode
+        let text: String
+    }
+    
+    private let modes: [HighlightHintModeUI] = [
+        .init(mode: .topRight,
+              text: "Top-right corner of the screen"),
+        .init(mode: .textfield,
+              text: "Above the highlighted text"),
+    ]
+    
+    @Environment(\.model) var model
+    
+    @State private var selectedMode: HighlightHintMode? = Preferences.shared.highlightHintMode
+    @State private var showHint: Bool = Preferences.shared.highlightHintMode != nil
+    
+    var body: some View {
+        VStack(spacing: 25) {
+            highlightTextView
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 86)
+    }
+    
+    var highlightTextView: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Display hint when highlighting text")
+                .font(.system(size: 14))
+            
+            HStack {
+                Text("Show hint")
+                    .font(.system(size: 13))
+                Spacer()
+                Toggle("", isOn: $showHint)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .onChange(of: showHint, initial: false) { old, new in
+                    print("KNA - onChange \(old) \(new)")
+                    if new {
+                        highlightModeChange(mode: .topRight)
+                    } else {
+                        highlightModeChange(mode: nil)
+                    }
+                }
+            }
+            
+            if showHint {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Choose hint position")
+                        .font(.system(size: 13))
+                    ForEach(modes, id: \.self) { option in
+                        HStack {
+                            Image(systemName: selectedMode == option.mode ? "largecircle.fill.circle" : "circle")
+                                .foregroundColor(.blue)
+                            Text(option.text)
+                        }
+                        .onTapGesture {
+                            highlightModeChange(mode: option.mode)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    private func highlightModeChange(mode: HighlightHintMode?) {
+        let preferences = Preferences.shared
+        preferences.highlightHintMode = mode
+        Preferences.save(preferences)
+        
+        selectedMode = mode
+        
+        HighlightHintWindowController.shared.changeMode(mode)
+    }
+}
+
+#Preview {
+    ModelContainerPreview {
+        AccessibilityTab()
+    }
+}

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -42,7 +42,7 @@ struct DebugModeTab: View {
                 Spacer()
                 Toggle("", isOn: Binding(
                     get: { featureFlagsManager.getFeatureFlag(key) },
-                    set: { featureFlagsManager.setFeatureFlag($0, for: key) }
+                    set: { featureFlagsManager.overrideFeatureFlag($0, for: key) }
                 ))
                 .toggleStyle(.switch)
                 .controlSize(.small)

--- a/macos/Onit/UI/Settings/SettingsView.swift
+++ b/macos/Onit/UI/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import KeyboardShortcuts
 
 struct SettingsView: View {
     @Environment(\.model) var model
+    @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
     
     var body: some View {
         TabView(selection: Binding(
@@ -20,6 +21,14 @@ struct SettingsView: View {
                     Label("Shortcuts", systemImage: "keyboard")
                 }
                 .tag(SettingsTab.shortcuts)
+            
+            if featureFlagsManager.flags.accessibility {
+                AccessibilityTab()
+                    .tabItem {
+                        Label("Accessibility", systemImage: "accessibility")
+                    }
+                    .tag(SettingsTab.accessibility)
+            }
             
             #if DEBUG
             DebugModeTab()

--- a/macos/Onit/UI/Settings/ShortcutsTab.swift
+++ b/macos/Onit/UI/Settings/ShortcutsTab.swift
@@ -16,8 +16,8 @@ struct ShortcutsTab: View {
             Section {
                 KeyboardShortcuts.Recorder(
                     "Launch Onit", name: .launch
-                ) { _ in
-                    resetPrompt()
+                ) {
+                    resetPrompt(empty: $0 == nil)
                 }
                 .padding()
                 
@@ -47,9 +47,9 @@ struct ShortcutsTab: View {
         .padding()
     }
 
-    func resetPrompt() {
-        let view = StaticPromptView().environment(model)
-        WindowHelper.shared.resetPrompt(with: view)
+    func resetPrompt(empty: Bool) {
+        //let view = StaticPromptView().environment(model)
+        HighlightHintWindowController.shared.shortcutChanges(empty: empty)
     }
 }
 


### PR DESCRIPTION
* Display the "open app" shortcut on text selection
* Display the input view on text selection
* Handle app switching (multi text selection)
* Turned on Endpoint
* Display Input view in GeneratingContent & GeneratedContent (history)
* Resize the ContentView properly when switching apps

⚠️  We should test the local endpoint (code looks fine but I don't have ollama configured)
⚠️  I couldn’t find a way to highlights only code