### PR TITLE
Custom local endpoint

### DIFF
--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -43,6 +43,7 @@ struct App: SwiftUI.App {
         featureFlagsManager.configure()
         model.showPanel()
         
+
         #if !targetEnvironment(simulator)
         
         let hostingController = NSHostingController(rootView: StaticPromptView())

--- a/macos/Onit/AppDelegate.swift
+++ b/macos/Onit/AppDelegate.swift
@@ -12,6 +12,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         FirebaseApp.configure()
+
+
         // This is helpful for debugging the new user experience, but should never be committed!
 //        if let appDomain = Bundle.main.bundleIdentifier {
 //            UserDefaults.standard.removePersistentDomain(forName: appDomain)

--- a/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
@@ -88,7 +88,9 @@ struct LocalChatEndpoint: Endpoint {
 
     let model: String?
     let messages: [LocalChatMessage]
-    var baseURL: URL  = URL(string: "http://localhost:11434")!
+    var baseURL: URL {
+        URL(string: Preferences.shared.localEndpointURL)!
+    }
 
     var path: String { "/api/chat" }
     var getParams: [String: String]? { nil }

--- a/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
@@ -89,7 +89,11 @@ struct LocalChatEndpoint: Endpoint {
     let model: String?
     let messages: [LocalChatMessage]
     var baseURL: URL {
-        URL(string: Preferences.shared.localEndpointURL)!
+        var url: URL!
+        DispatchQueue.main.sync {
+            url = Preferences.shared.localEndpointURL
+        }
+        return url
     }
 
     var path: String { "/api/chat" }

--- a/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
@@ -23,7 +23,9 @@ struct LocalModelsEndpoint: Endpoint {
     typealias Request = EmptyRequest
     typealias Response = LocalModelsResponse
 
-    var baseURL: URL = URL(string: "http://localhost:11434")!
+    var baseURL: URL {
+        URL(string: Preferences.shared.localEndpointURL)!
+    }
 
     var path: String { "/api/tags" }
     var getParams: [String: String]? { nil }

--- a/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
@@ -10,6 +10,7 @@ import Foundation
 extension FetchingClient {
     func getLocalModels() async throws -> [String] {
         let endpoint = LocalModelsEndpoint()
+
         let response = try await execute(endpoint)
         let names = response.models.map { $0.name }
         return names
@@ -24,7 +25,11 @@ struct LocalModelsEndpoint: Endpoint {
     typealias Response = LocalModelsResponse
 
     var baseURL: URL {
-        URL(string: Preferences.shared.localEndpointURL)!
+        var url: URL!
+        DispatchQueue.main.sync {
+            url = Preferences.shared.localEndpointURL
+        }
+        return url
     }
 
     var path: String { "/api/tags" }

--- a/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalModelsEndpoint.swift
@@ -52,7 +52,7 @@ struct ModelDetails: Codable {
     let parentModel: String?
     let format: String?
     let family: String?
-    let families: [String]
+    let families: [String]?
     let parameterSize: String?
     let quantizationLevel: String?
 }

--- a/macos/Onit/Data/Model/Model+Preferences.swift
+++ b/macos/Onit/Data/Model/Model+Preferences.swift
@@ -11,7 +11,7 @@ extension OnitModel {
     var preferences: Preferences {
         get {
             access(keyPath: \.preferences)
-            return Preferences.load() ?? Preferences()
+            return Preferences.shared
         }
         set {
             withMutation (keyPath: \.preferences) {

--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -131,7 +131,7 @@ import AppKit
                     let newModelIds = Set(models.map { $0.id })
                     let existingModelIds = Set(prefs.availableRemoteModels.map { $0.id })
                     
-                    var newModels = models.filter { !existingModelIds.contains($0.id) }
+                    let newModels = models.filter { !existingModelIds.contains($0.id) }
                     var deprecatedModels = prefs.availableRemoteModels.filter { !newModelIds.contains($0.id) }
                     for index in models.indices where newModels.contains(models[index]) {
                         models[index].isNew = true
@@ -163,9 +163,6 @@ import AppKit
         } catch {
             print("Error fetching local models:", error)
             remoteFetchFailed = true
-//            updatePreferences { prefs in
-//                prefs.remoteFetchFailed = true
-//            }
         }
     }
 

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -38,6 +38,7 @@ struct Preferences: Codable {
     var availableRemoteModels: [AIModel] = []
     var remoteFetchFailed: Bool = false
     var visibleModelIds: Set<String> = Set([])
+    var localEndpointURL: String = "http://localhost:11434"
     
     mutating func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -7,10 +7,12 @@
 
 import Foundation
 
-struct Preferences: Codable {
-    static let shared = Preferences.load()
+class Preferences: Codable {
+    @MainActor static let shared = Preferences.load()
     
     private static let key = "app_preferences"
+    
+    let id: UUID = UUID()
     
     static func save(_ preferences: Preferences) {
         if let data = try? JSONEncoder().encode(preferences) {
@@ -36,17 +38,16 @@ struct Preferences: Codable {
     var mode: InferenceMode = .remote
     var availableLocalModels: [String] = []
     var availableRemoteModels: [AIModel] = []
-    var remoteFetchFailed: Bool = false
     var visibleModelIds: Set<String> = Set([])
-    var localEndpointURL: String = "http://localhost:11434"
-    
-    mutating func markRemoteModelAsNotNew(modelId: String) {
+    var localEndpointURL: URL = URL(string: "http://localhost:11434")!
+
+    func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {
             availableRemoteModels[index].isNew = false
         }
     }
 
-    mutating func initializeVisibleModelIds(from models: [AIModel]) {
+    func initializeVisibleModelIds(from models: [AIModel]) {
         if visibleModelIds.isEmpty {
             visibleModelIds = Set(models.filter { $0.defaultOn }.map { $0.id })
         }

--- a/macos/Onit/Info.plist
+++ b/macos/Onit/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSApplicationCrashOnExceptions</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -37,15 +35,17 @@
 	<string>public.app-category.utilities</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSApplicationCrashOnExceptions</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
-	<key>SUFeedURL</key>
-	<string>https://onit-server-b3c3746e04e9.herokuapp.com/appcast.xml</string>
-	<key>SUPublicEDKey</key>
-	<string>gGuBTEsab+N4JYjnp+kqvhChKQiZv69GKThr0ucKEl0=</string>
 	<key>PostHogApiKey</key>
 	<string>phc_AJyj4BpqxAyiE2T11hD1NKMLH6vlvnqUrpZD6aIJGNf</string>
 	<key>PostHogHost</key>
 	<string>https://us.i.posthog.com</string>
+	<key>SUFeedURL</key>
+	<string>https://onit-server-b3c3746e04e9.herokuapp.com/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>gGuBTEsab+N4JYjnp+kqvhChKQiZv69GKThr0ucKEl0=</string>
 </dict>
 </plist>

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -54,7 +54,7 @@ struct SetUpDialogs: View {
     @ViewBuilder
     var content: some View {
         Group {
-            if model.preferences.availableRemoteModels.isEmpty && model.preferences.remoteFetchFailed && !closedNoRemoteModels {
+            if model.preferences.availableRemoteModels.isEmpty && model.remoteFetchFailed && !closedNoRemoteModels {
                 noRemote
             }
             if model.remoteNeedsSetup && !closedRemote {

--- a/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
@@ -30,8 +30,30 @@ struct LocalModelsSection: View {
     }
 
     var title: some View {
-        // The implementation to turn off local models doesn't exist, so we never show the toggle.
-        ModelTitle(title: "Ollama", isOn: $isOn, showToggle: .constant(false))
+        VStack(alignment: .leading, spacing: 8) {
+            // The implementation to turn off local models doesn't exist, so we never show the toggle.
+            ModelTitle(title: "Ollama", isOn: $isOn, showToggle: .constant(false))
+            
+            HStack {
+                Text("Endpoint URL:")
+                    .foregroundStyle(.primary.opacity(0.65))
+                    .font(.system(size: 12))
+                    .fontWeight(.regular)
+                
+                TextField("", text: Binding(
+                    get: { model.preferences.localEndpointURL },
+                    set: { newValue in
+                        model.updatePreferences { prefs in
+                            prefs.localEndpointURL = newValue
+                        }
+                    }
+                ))
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 12))
+                .frame(maxWidth: 250)
+            }
+            .padding(.leading, 4)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Adding a customizable local endpoint URL per #21 

To achieve this, we needed to make some changes to Preferences - notably, we changed it from a Struct to a Class and only used a static MainActor instance of preferences. We also needed to update the local endpoints to pull a localEndpointURL from the preferences object. Finally, we add a field in Settings allowing users to set the localEndpointURL, and validate that it's a valid URL and that models can be loaded from it, with appropriate error messages in each failure case. 

@Niduank, can you test this on your home setup? 