### PR TITLE
feat(ui) Strip markdown on copy generated content

### DIFF
--- a/macos/Onit.xcodeproj/project.pbxproj
+++ b/macos/Onit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		28F57E292CAC9262006AAA8C /* MenuBarExtraAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 28F57E282CAC9262006AAA8C /* MenuBarExtraAccess */; };
 		863817352D3FB5F700919BC7 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 863817342D3FB5F700919BC7 /* PostHog */; };
 		863817372D3FB5F700919BC7 /* phlibwebp in Frameworks */ = {isa = PBXBuildFile; productRef = 863817362D3FB5F700919BC7 /* phlibwebp */; };
+		86A974C12D4A76F800CF6FCE /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 86A974C02D4A76F800CF6FCE /* Markdown */; };
 		A782C1982D383493009976F8 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = A782C1972D383493009976F8 /* FirebaseCrashlytics */; };
 /* End PBXBuildFile section */
 
@@ -51,6 +52,7 @@
 				28BF71682CAB72A200DE7C03 /* SageKit in Frameworks */,
 				280F35002CB9BF4300D60130 /* Sparkle in Frameworks */,
 				28F57E292CAC9262006AAA8C /* MenuBarExtraAccess in Frameworks */,
+				86A974C12D4A76F800CF6FCE /* Markdown in Frameworks */,
 				863817352D3FB5F700919BC7 /* PostHog in Frameworks */,
 				A782C1982D383493009976F8 /* FirebaseCrashlytics in Frameworks */,
 				863817372D3FB5F700919BC7 /* phlibwebp in Frameworks */,
@@ -109,6 +111,7 @@
 				A782C1972D383493009976F8 /* FirebaseCrashlytics */,
 				863817342D3FB5F700919BC7 /* PostHog */,
 				863817362D3FB5F700919BC7 /* phlibwebp */,
+				86A974C02D4A76F800CF6FCE /* Markdown */,
 			);
 			productName = Onit;
 			productReference = 2883E4B32CA5ECBB00F79A48 /* Onit.app */;
@@ -147,6 +150,7 @@
 				2842875C2CD0B6A5000C6C67 /* XCRemoteSwiftPackageReference "HighlightSwift" */,
 				A782C1962D383493009976F8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				863817332D3FB5F700919BC7 /* XCRemoteSwiftPackageReference "posthog-ios" */,
+				86A974BF2D4A76F800CF6FCE /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2883E4B42CA5ECBB00F79A48 /* Products */;
@@ -478,6 +482,14 @@
 				minimumVersion = 3.19.1;
 			};
 		};
+		86A974BF2D4A76F800CF6FCE /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-markdown.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 		A782C1962D383493009976F8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -528,6 +540,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 863817332D3FB5F700919BC7 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = phlibwebp;
+		};
+		86A974C02D4A76F800CF6FCE /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 86A974BF2D4A76F800CF6FCE /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 		A782C1972D383493009976F8 /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9e52b4c573cbde3ab05eb032211c237e7d80d046f2903029e7f14c52f9a86d73",
+  "originHash" : "ad4e37c03809c86b75edf0cbf2ec73542463832b324b6b5a6bcd34dabf53f26c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -178,6 +178,15 @@
       "location" : "https://github.com/swiftlang/swift-cmark",
       "state" : {
         "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "8f79cb175981458a0a27e76cb42fee8e17b1a993",
         "version" : "0.5.0"
       }
     },

--- a/macos/Onit/General/Extensions/String+Markdown.swift
+++ b/macos/Onit/General/Extensions/String+Markdown.swift
@@ -14,7 +14,10 @@ extension String {
         let document = Document(parsing: self)
         var plainText = document.plainText
         
-        plainText.removeLast()
+        // Remove the last '\n'
+        if plainText.last == "\n" {
+            plainText.removeLast()
+        }
         
         return plainText
     }
@@ -35,18 +38,57 @@ extension Markup {
         switch self {
         case is Paragraph:
             return children.map { $0.plainText }.joined() + "\n"
-        case let text as Text:
-            return text.string
+            
         case is LineBreak:
             return "\n"
         case is SoftBreak:
             return " "
-        case is InlineCode, is InlineHTML:
-            return ""
+        
+        case let codeBlock as CodeBlock:
+            let code = codeBlock.code
+            return "\n\(code)\n"
+        
+        case let inlineCode as InlineCode:
+            return inlineCode.code
+            
+        case let unorderedList as UnorderedList:
+            return formatUnorderedList(unorderedList)
+            
+        case let orderedList as OrderedList:
+            return formatOrderedList(orderedList)
+        
+        case let heading as Heading:
+            return heading.children.map { $0.plainText }.joined() + "\n"
+            
+        case let text as Text:
+            return text.string
         case let link as Link:
             return link.children.map { $0.plainText }.joined()
         default:
             return children.map { $0.plainText }.joined()
         }
+    }
+    
+    private func formatUnorderedList(_ list: UnorderedList) -> String {
+        var result = ""
+        
+        for item in list.listItems {
+            let itemText = item.children.map { $0.plainText }.joined()
+            
+            result += "• \(itemText)"
+        }
+        
+        return result
+    }
+    
+    private func formatOrderedList(_ list: OrderedList) -> String {
+        var result = ""
+        
+        for (index, item) in list.listItems.enumerated() {
+            let itemText = item.children.map { $0.plainText }.joined()
+            result += "\(index + 1). \(itemText)"
+        }
+        
+        return result
     }
 }

--- a/macos/Onit/General/Extensions/String+Markdown.swift
+++ b/macos/Onit/General/Extensions/String+Markdown.swift
@@ -1,0 +1,52 @@
+//
+//  String+Markdown.swift
+//  Onit
+//
+//  Created by Kévin Naudin on 29/01/2025.
+//
+
+import Markdown
+
+extension String {
+    
+    /** Remove all markdown from code */
+    func stripMarkdown() -> String {
+        let document = Document(parsing: self)
+        var plainText = document.plainText
+        
+        plainText.removeLast()
+        
+        return plainText
+    }
+}
+
+extension Document {
+    var plainText: String {
+        var text = ""
+        for child in children {
+            text += child.plainText
+        }
+        return text
+    }
+}
+
+extension Markup {
+    var plainText: String {
+        switch self {
+        case is Paragraph:
+            return children.map { $0.plainText }.joined() + "\n"
+        case let text as Text:
+            return text.string
+        case is LineBreak:
+            return "\n"
+        case is SoftBreak:
+            return " "
+        case is InlineCode, is InlineHTML:
+            return ""
+        case let link as Link:
+            return link.children.map { $0.plainText }.joined()
+        default:
+            return children.map { $0.plainText }.joined()
+        }
+    }
+}

--- a/macos/Onit/UI/Components/CopyButton.swift
+++ b/macos/Onit/UI/Components/CopyButton.swift
@@ -8,15 +8,20 @@
 import SwiftUI
 
 struct CopyButton: View {
-    var text: String
-
     @State var showCheckmark = false
+    
+    var text: String
+    var stripMarkdown = false
+    
+    private var textToCopy: String {
+        stripMarkdown ? text.stripMarkdown() : text
+    }
 
     var body: some View {
         Button {
             let pasteboard = NSPasteboard.general
             pasteboard.declareTypes([.string], owner: nil)
-            pasteboard.setString(text, forType: .string)
+            pasteboard.setString(textToCopy, forType: .string)
             showCheckmark = true
 
             Task {

--- a/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
@@ -26,7 +26,7 @@ struct GeneratedToolbar: View {
     @ViewBuilder
     var copy: some View {
         if let generation = prompt.generation {
-            CopyButton(text: generation)
+            CopyButton(text: generation, stripMarkdown: true)
         }
     }
 


### PR DESCRIPTION
Added [Markdown](https://github.com/swiftlang/swift-markdown) library which is a markdown parser.

Function to strip markdown located in `String+Markdown.swift`
We have control on each Markdown item thanks to this, feel free to finetune it ⬇️ 

<img width="531" alt="Screenshot 2025-01-29 at 16 48 33" src="https://github.com/user-attachments/assets/6e58c227-8c16-4629-b29f-1b6ba18bbe92" />
