### PR TITLE
New user improvements

### DIFF
--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -41,6 +41,8 @@ struct App: SwiftUI.App {
         }
 
         featureFlagsManager.configure()
+        // For testing new user experience
+        // model.clearTokens()
         model.showPanel()
         
 

--- a/macos/Onit/Data/Model/Model+Tokens.swift
+++ b/macos/Onit/Data/Model/Model+Tokens.swift
@@ -140,5 +140,22 @@ extension OnitModel {
         !useOpenAI && !useAnthropic && !useXAI && !useGoogleAI
     }
 
-    
+    func clearTokens() {
+        // Helpful for debugging the new-user-experience
+        UserDefaults.standard.removeObject(forKey: TokenKeys.openAIToken.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenKeys.anthropicToken.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenKeys.xAIToken.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenKeys.googleAIToken.rawValue)
+        
+        UserDefaults.standard.removeObject(forKey: TokenValidationKeys.openAITokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenValidationKeys.anthropicTokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenValidationKeys.xAITokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: TokenValidationKeys.googleAITokenValidated.rawValue)
+
+        UserDefaults.standard.removeObject(forKey: UseModelKeys.openAITokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: UseModelKeys.anthropicTokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: UseModelKeys.xAITokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: UseModelKeys.googleAITokenValidated.rawValue)
+        UserDefaults.standard.removeObject(forKey: UseModelKeys.localModelValidated.rawValue)
+    }
 }

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -40,6 +40,7 @@ struct ModelSelectionView: View {
 
             if model.listedModels.isEmpty {
                 Button("Setup remote models") {
+                    model.settingsTab = .models
                     openSettings()
                 }
                 .buttonStyle(SetUpButtonStyle(showArrow: true))
@@ -92,6 +93,7 @@ struct ModelSelectionView: View {
 
             if model.preferences.availableLocalModels.isEmpty {
                 Button("Setup local models") {
+                    model.settingsTab = .models
                     openSettings()
                 }
                 .buttonStyle(SetUpButtonStyle(showArrow: true))

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -38,7 +38,19 @@ struct ModelSelectionView: View {
             }
             .padding(.horizontal, 12)
 
-            remoteModels
+            if model.listedModels.isEmpty {
+                Button("Setup remote models") {
+                    openSettings()
+                }
+                .buttonStyle(SetUpButtonStyle(showArrow: true))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.top, 6)
+                .padding(.bottom, 10)
+                
+            } else {
+                remoteModels
+            }
         }
     }
 
@@ -78,7 +90,19 @@ struct ModelSelectionView: View {
             }
             .padding(.horizontal, 12)
 
-            localModels
+            if model.preferences.availableLocalModels.isEmpty {
+                Button("Setup local models") {
+                    openSettings()
+                }
+                .buttonStyle(SetUpButtonStyle(showArrow: true))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.top, 6)
+                .padding(.bottom, 10)
+                
+            } else {
+                localModels
+            }
         }
         .padding(.top, 8)
         .padding(.bottom, 4)

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -95,8 +95,8 @@ struct Toolbar: View {
         } label: {
             HStack(spacing: 0) {
                 Text(model.preferences.mode == .local ?
-                     (model.preferences.localModel?.split(separator: ":").first.map(String.init) ?? "") :
-                     (model.preferences.remoteModel?.displayName ?? ""))
+                     (model.preferences.localModel?.split(separator: ":").first.map(String.init) ?? "Choose model") :
+                     (model.preferences.remoteModel?.displayName ?? "Choose model"))
                     .appFont(.medium13)
                     .padding(.leading, 2)
                 Image(.smallChevDown)

--- a/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
+++ b/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
@@ -46,6 +46,7 @@ struct RemoteModelSection: View {
         }
         .onChange(of: use) {
             save(use: use)
+            save(validated: validated)
             // If we've turned off everything go into local mode.
             if model.listedModels.isEmpty {
                 model.preferences.mode = .local
@@ -240,10 +241,26 @@ struct RemoteModelSection: View {
         }
     }
 
+    func save(validated: Bool) {
+        switch provider {
+        case .openAI:
+            model.isOpenAITokenValidated = validated
+        case .anthropic:
+            model.isAnthropicTokenValidated = validated
+        case .xAI:
+            model.isXAITokenValidated = validated
+        case .googleAI:
+            model.isGoogleAITokenValidated = validated
+        }
+    }
+
     func updateUse() {
         if state == .valid {
             use = true
             validated = true
+        } else if case .invalid(_) = state {
+            use = false
+            validated = false
         }
     }
 }


### PR DESCRIPTION
I've added a few things here to  make the new user experience better. Notable, I've added a "setup Local models" and "setup remote models" button to the model dropdown, when the user does not have any local or remote models available. 

I've also changed the model dropdown to say "choose model" when there is no model set, instead of being blank. 

In general, the logic for keeping track of which model providers are validated and which model is selected is disparate and confusing, which means there are inevitably bugs. I'm seeing weird behavior in the edge cases (for example, when you submit an invalid token for a provider you had previously verified). We should do a bigger cleanup at some point in the future. 


<img width="253" alt="Screenshot 2025-01-29 at 1 58 13 PM" src="https://github.com/user-attachments/assets/93038c70-292c-45e9-9867-ff90b8061a76" />


<img width="409" alt="Screenshot 2025-01-29 at 1 58 06 PM" src="https://github.com/user-attachments/assets/bf0812a6-0a00-4a30-80b9-1acb78e7dd81" />
