### PR TITLE
Settings tab selection

### DIFF
--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -44,7 +44,6 @@ import AppKit
     var imageUploads: [URL: UploadProgress] = [:]
     var uploadTasks: [URL: Task<URL?, Never>] = [:]
     var textFocusTrigger = false
-    var isOpeningSettings = false
     var settingsTab: SettingsTab = .models
     var historyIndex = -1
 
@@ -188,9 +187,8 @@ import AppKit
         Preferences.save(preferences)
     }
     
-    func openSettings(tab: SettingsTab) {
+    func setSettingsTab(tab: SettingsTab) {
         settingsTab = tab
-        isOpeningSettings = true
     }
 }
 

--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -45,6 +45,7 @@ import AppKit
     var uploadTasks: [URL: Task<URL?, Never>] = [:]
     var textFocusTrigger = false
     var isOpeningSettings = false
+    var settingsTab: SettingsTab = .models
     var historyIndex = -1
 
     var headerHeight: CGFloat = 0
@@ -185,6 +186,11 @@ import AppKit
     func updatePreferences(_ update: (inout Preferences) -> Void) {
         update(&preferences)
         Preferences.save(preferences)
+    }
+    
+    func openSettings(tab: SettingsTab) {
+        settingsTab = tab
+        isOpeningSettings = true
     }
 }
 

--- a/macos/Onit/Data/Structures/SettingsTab.swift
+++ b/macos/Onit/Data/Structures/SettingsTab.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum SettingsTab: String {
+    case models
+    case shortcuts
+    case about
+    #if DEBUG
+    case debug
+    #endif
+}

--- a/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
+++ b/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
@@ -10,11 +10,13 @@ import KeyboardShortcuts
 
 struct MenuSettings: View {
     @Environment(\.openSettings) var openSettings
+    @Environment(\.model) var model
     
     var body: some View {
         MenuBarRow {
             NSApp.activate()
             if NSApp.isActive {
+                model.openSettings(tab: .models)
                 openSettings()
             }
         } leading: {

--- a/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
+++ b/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
@@ -16,7 +16,6 @@ struct MenuSettings: View {
         MenuBarRow {
             NSApp.activate()
             if NSApp.isActive {
-                model.openSettings(tab: .models)
                 openSettings()
             }
         } leading: {

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -217,7 +217,7 @@ struct SetUpDialogs: View {
     func settings() {
         NSApp.activate()
         if NSApp.isActive {
-            model.openSettings(tab: .models)
+            model.setSettingsTab(tab: .models)
             openSettings()
         }
     }

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -217,6 +217,7 @@ struct SetUpDialogs: View {
     func settings() {
         NSApp.activate()
         if NSApp.isActive {
+            model.openSettings(tab: .models)
             openSettings()
         }
     }

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -118,7 +118,7 @@ struct ModelSelectionView: View {
         Button {
             NSApp.activate()
             if NSApp.isActive {
-                model.openSettings(tab: .models)
+                model.setSettingsTab(tab: .models)
                 openSettings()
                 model.closeModelSelectionOverlay()
             }

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -118,6 +118,7 @@ struct ModelSelectionView: View {
         Button {
             NSApp.activate()
             if NSApp.isActive {
+                model.openSettings(tab: .models)
                 openSettings()
                 model.closeModelSelectionOverlay()
             }

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -154,6 +154,7 @@ struct Toolbar: View {
         Button {
             NSApp.activate()
             if NSApp.isActive {
+                model.openSettings(tab: .models)
                 openSettings()
             }
         } label: {

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -154,7 +154,6 @@ struct Toolbar: View {
         Button {
             NSApp.activate()
             if NSApp.isActive {
-                model.openSettings(tab: .models)
                 openSettings()
             }
         } label: {

--- a/macos/Onit/UI/Settings/SettingsView.swift
+++ b/macos/Onit/UI/Settings/SettingsView.swift
@@ -5,28 +5,35 @@ struct SettingsView: View {
     @Environment(\.model) var model
     
     var body: some View {
-        TabView {
+        TabView(selection: Binding(
+            get: { model.settingsTab },
+            set: { model.settingsTab = $0 }
+        )) {
             ModelsTab()
                 .tabItem {
                     Label("Models", systemImage: "cpu")
                 }
+                .tag(SettingsTab.models)
             
             ShortcutsTab()
                 .tabItem {
                     Label("Shortcuts", systemImage: "keyboard")
                 }
+                .tag(SettingsTab.shortcuts)
             
             #if DEBUG
             DebugModeTab()
                 .tabItem {
                     Label("Debug", systemImage: "wrench.and.screwdriver")
                 }
+                .tag(SettingsTab.debug)
             #endif
             
             AboutTab()
                 .tabItem {
                     Label("About", systemImage: "info.circle")
                 }
+                .tag(SettingsTab.about)
         }
         .frame(idealWidth: 569, minHeight: 500)
         .fixedSize(horizontal: true, vertical: false)


### PR DESCRIPTION
Simple PR that let's us set the Settings tab before opening settings. For now, we use this to make sure settings gets opened to the Models page from model related setup pages. 