### PR TITLE
Add local model options

### DIFF
--- a/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
@@ -102,7 +102,7 @@ struct LocalChatEndpoint: Endpoint {
     var token: String? { nil }
     var requestBody: LocalChatRequestJSON? {
         var options: LocalChatOptions?
-        var keepAlive: Bool?
+        var keepAlive: String?
         
         DispatchQueue.main.sync {
             let prefs = Preferences.shared

--- a/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
@@ -135,7 +135,7 @@ struct LocalChatRequestJSON: Codable {
     let model: String?
     let messages: [LocalChatMessage]
     var stream: Bool = false
-    var keep_alive: Bool?
+    var keep_alive: String?
     var options: LocalChatOptions?
 }
 

--- a/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/LocalChatEndpoint.swift
@@ -110,12 +110,12 @@ struct LocalChatEndpoint: Endpoint {
             
             // Only create options if at least one parameter is set
             if prefs.localNumCtx != nil || prefs.localTemperature != nil || 
-               prefs.localTopP != nil || prefs.localMinP != nil {
+               prefs.localTopP != nil || prefs.localTopK != nil {
                 options = LocalChatOptions(
                     num_ctx: prefs.localNumCtx,
                     temperature: prefs.localTemperature,
                     top_p: prefs.localTopP,
-                    min_p: prefs.localMinP
+                    top_k: prefs.localTopK
                 )
             }
         }
@@ -143,7 +143,7 @@ struct LocalChatOptions: Codable {
     var num_ctx: Int?
     var temperature: Double?
     var top_p: Double?
-    var min_p: Double?
+    var top_k: Int?
 }
 
 struct LocalChatMessage: Codable {

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -42,7 +42,7 @@ class Preferences: Codable {
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
     
     // Local model advanced options
-    var localKeepAlive: Bool = false
+    var localKeepAlive: String?
     var localNumCtx: Int?
     var localTemperature: Double?
     var localTopP: Double?

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -40,6 +40,13 @@ class Preferences: Codable {
     var availableRemoteModels: [AIModel] = []
     var visibleModelIds: Set<String> = Set([])
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
+    
+    // Local model advanced options
+    var localKeepAlive: Bool = false
+    var localNumCtx: Int?
+    var localTemperature: Double?
+    var localTopP: Double?
+    var localMinP: Double?
 
     func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -46,7 +46,7 @@ class Preferences: Codable {
     var localNumCtx: Int?
     var localTemperature: Double?
     var localTopP: Double?
-    var localMinP: Double?
+    var localTopK: Int?
 
     func markRemoteModelAsNotNew(modelId: String) {
         if let index = availableRemoteModels.firstIndex(where: { $0.id == modelId }) {

--- a/macos/Onit/UI/Settings/Models/LocalModelValidation.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelValidation.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct LocalModelValidation {
+    static func validateKeepAlive(_ value: String) -> Bool {
+        if value.isEmpty { return true }
+        
+        // Check for duration string format (e.g., "10m", "24h")
+        let durationPattern = #"^-?\d+[mh]$"#
+        if value.range(of: durationPattern, options: .regularExpression) != nil {
+            return true
+        }
+        
+        // Check for integer format
+        if let intValue = Int(value) {
+            return true // Any integer is valid (including negative and zero)
+        }
+        
+        return false
+    }
+    
+    static func validateFloat(_ value: String, min: Double? = nil, max: Double? = nil) -> Bool {
+        if value.isEmpty { return true }
+        
+        guard let floatValue = Double(value) else { return false }
+        
+        if let min = min, floatValue < min { return false }
+        if let max = max, floatValue > max { return false }
+        
+        return true
+    }
+    
+    static func validateInt(_ value: String, min: Int? = nil, max: Int? = nil) -> Bool {
+        if value.isEmpty { return true }
+        
+        guard let intValue = Int(value) else { return false }
+        
+        if let min = min, intValue < min { return false }
+        if let max = max, intValue > max { return false }
+        
+        return true
+    }
+}

--- a/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
@@ -14,6 +14,12 @@ struct LocalModelsSection: View {
     @State private var fetching: Bool = false
     @State private var message: String? = nil
     @State private var localEndpointString: String = ""
+    @State private var showAdvanced: Bool = false
+    @State private var keepAlive: Bool = false
+    @State private var numCtx: String = ""
+    @State private var temperature: String = ""
+    @State private var topP: String = ""
+    @State private var minP: String = ""
 
     var body: some View {
         ModelsSection(title: "Local Models") {
@@ -31,6 +37,11 @@ struct LocalModelsSection: View {
         .onAppear {
             isOn = model.useLocal
             localEndpointString = model.preferences.localEndpointURL.absoluteString
+            keepAlive = model.preferences.localKeepAlive
+            if let value = model.preferences.localNumCtx { numCtx = String(value) }
+            if let value = model.preferences.localTemperature { temperature = String(value) }
+            if let value = model.preferences.localTopP { topP = String(value) }
+            if let value = model.preferences.localMinP { minP = String(value) }
         }
         .onChange(of: isOn) {
             model.useLocal = isOn
@@ -81,6 +92,96 @@ struct LocalModelsSection: View {
                 .frame(height: 22)
                 .fontWeight(.regular)
             }
+            
+            DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Keep model alive", isOn: $keepAlive)
+                        .onChange(of: keepAlive) {
+                            model.updatePreferences { prefs in
+                                prefs.localKeepAlive = keepAlive
+                            }
+                        }
+                    
+                    Group {
+                        HStack {
+                            Text("Context window:")
+                            TextField("", text: $numCtx)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: 100)
+                                .onChange(of: numCtx) {
+                                    if let value = Int(numCtx) {
+                                        model.updatePreferences { prefs in
+                                            prefs.localNumCtx = value
+                                        }
+                                    } else if numCtx.isEmpty {
+                                        model.updatePreferences { prefs in
+                                            prefs.localNumCtx = nil
+                                        }
+                                    }
+                                }
+                        }
+                        
+                        HStack {
+                            Text("Temperature:")
+                            TextField("", text: $temperature)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: 100)
+                                .onChange(of: temperature) {
+                                    if let value = Double(temperature) {
+                                        model.updatePreferences { prefs in
+                                            prefs.localTemperature = value
+                                        }
+                                    } else if temperature.isEmpty {
+                                        model.updatePreferences { prefs in
+                                            prefs.localTemperature = nil
+                                        }
+                                    }
+                                }
+                        }
+                        
+                        HStack {
+                            Text("Top P:")
+                            TextField("", text: $topP)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: 100)
+                                .onChange(of: topP) {
+                                    if let value = Double(topP) {
+                                        model.updatePreferences { prefs in
+                                            prefs.localTopP = value
+                                        }
+                                    } else if topP.isEmpty {
+                                        model.updatePreferences { prefs in
+                                            prefs.localTopP = nil
+                                        }
+                                    }
+                                }
+                        }
+                        
+                        HStack {
+                            Text("Min P:")
+                            TextField("", text: $minP)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: 100)
+                                .onChange(of: minP) {
+                                    if let value = Double(minP) {
+                                        model.updatePreferences { prefs in
+                                            prefs.localMinP = value
+                                        }
+                                    } else if minP.isEmpty {
+                                        model.updatePreferences { prefs in
+                                            prefs.localMinP = nil
+                                        }
+                                    }
+                                }
+                        }
+                    }
+                    .font(.system(size: 12))
+                }
+                .padding(.leading, 8)
+                .padding(.top, 4)
+            }
+            .font(.system(size: 12))
+            .fontWeight(.regular)
         }
     }
 

--- a/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
@@ -15,7 +15,7 @@ struct LocalModelsSection: View {
     @State private var message: String? = nil
     @State private var localEndpointString: String = ""
     @State private var showAdvanced: Bool = false
-    @State private var keepAlive: Bool = false
+    @State private var keepAlive: String = ""
     @State private var numCtx: String = ""
     @State private var temperature: String = ""
     @State private var topP: String = ""
@@ -37,7 +37,7 @@ struct LocalModelsSection: View {
         .onAppear {
             isOn = model.useLocal
             localEndpointString = model.preferences.localEndpointURL.absoluteString
-            keepAlive = model.preferences.localKeepAlive
+            if let value = model.preferences.localKeepAlive { keepAlive = value }
             if let value = model.preferences.localNumCtx { numCtx = String(value) }
             if let value = model.preferences.localTemperature { temperature = String(value) }
             if let value = model.preferences.localTopP { topP = String(value) }
@@ -95,12 +95,17 @@ struct LocalModelsSection: View {
             
             DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Toggle("Keep model alive", isOn: $keepAlive)
-                        .onChange(of: keepAlive) {
-                            model.updatePreferences { prefs in
-                                prefs.localKeepAlive = keepAlive
+                    HStack {
+                        Text("Keep alive:")
+                        TextField("e.g. 10m, 24h, -1, 3600", text: $keepAlive)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: 150)
+                            .onChange(of: keepAlive) {
+                                model.updatePreferences { prefs in
+                                    prefs.localKeepAlive = keepAlive.isEmpty ? nil : keepAlive
+                                }
                             }
-                        }
+                    }
                     
                     Group {
                         HStack {

--- a/macos/Onit/UI/Settings/Models/SettingErrorMessage.swift
+++ b/macos/Onit/UI/Settings/Models/SettingErrorMessage.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct SettingErrorMessage: View {
+    let message: String?
+    
+    var body: some View {
+        if let message = message {
+            Text(message)
+                .foregroundStyle(.red)
+                .font(.system(size: 10))
+                .padding(.leading, 4)
+        }
+    }
+}

--- a/macos/Onit/UI/Settings/Models/SettingInfoButton.swift
+++ b/macos/Onit/UI/Settings/Models/SettingInfoButton.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SettingInfoButton: View {
+    let title: String
+    let description: String
+    let defaultValue: String
+    let valueType: String
+    
+    @State private var showTooltip: Bool = false
+    
+    var body: some View {
+        Button {
+            showTooltip.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.primary.opacity(0.65))
+                .font(.system(size: 12))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showTooltip) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                Text(description)
+                    .font(.system(size: 12))
+                Divider()
+                Group {
+                    Text("Type: ").font(.system(size: 12, weight: .medium)) +
+                    Text(valueType).font(.system(size: 12))
+                }
+                Group {
+                    Text("Default: ").font(.system(size: 12, weight: .medium)) +
+                    Text(defaultValue).font(.system(size: 12))
+                }
+            }
+            .padding(12)
+            .frame(width: 300)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds advanced settings to Onit, as requested by @sammjc in #28. These include, keep_alive, num_ctx, top_p, min_p, and temperature. We also add an "advanced" section to the local models section in settings:

<img width="473" alt="Screenshot 2025-02-01 at 11 45 15 AM" src="https://github.com/user-attachments/assets/374a7c7d-36ee-41fd-bded-3ddb1139e54e" />

I've validated that these parameters are being sent to Ollama correctly and that Ollama is successfully responding: 
<img width="604" alt="Screenshot 2025-02-01 at 11 45 57 AM" src="https://github.com/user-attachments/assets/c65fed06-5d32-41fb-9f82-9d0dee9609b3" />
