### PR TITLE
Save window size min

### DIFF
--- a/macos/Onit/ContentView.swift
+++ b/macos/Onit/ContentView.swift
@@ -40,8 +40,11 @@ struct ContentView: View {
         .background {
             GeometryReader { proxy in
                 Color.clear
-                    .onChange(of: proxy.frame(in: .global)) {
-                        print(proxy.frame(in: .global))
+                    .onChange(of: proxy.frame(in: .global)) { frame in
+                        // Save the frame to preferences
+                        model.updatePreferences { prefs in
+                            prefs.contentViewFrame = frame
+                        }
                     }
             }
         }

--- a/macos/Onit/ContentView.swift
+++ b/macos/Onit/ContentView.swift
@@ -37,17 +37,16 @@ struct ContentView: View {
             RoundedRectangle(cornerRadius: 14)
                 .strokeBorder(.gray600, lineWidth: 2)
         }
-        .background {
-            GeometryReader { proxy in
-                Color.clear
-                    .onChange(of: proxy.frame(in: .global)) { frame in
-                        // Save the frame to preferences
+        .gesture(
+            DragGesture(minimumDistance: 1)
+                .onEnded { value in
+                    if let panel = model.panel {
                         model.updatePreferences { prefs in
-                            prefs.contentViewFrame = frame
+                            prefs.contentViewFrame = panel.frame
                         }
                     }
-            }
-        }
+                }
+        )
     }
 }
 

--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -55,7 +55,9 @@ extension OnitModel: NSWindowDelegate {
         // Position the panel
         if let savedFrame = preferences.contentViewFrame {
             // Use the saved frame
-            newPanel.setFrame(savedFrame, display: false)
+            var adjustedFrame = savedFrame
+            adjustedFrame.size.height = newPanel.frame.height
+            newPanel.setFrame(adjustedFrame, display: false)
         } else if let screen = NSScreen.main {
             // Default position if no saved frame exists
             let visibleFrame = screen.visibleFrame

--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -52,7 +52,12 @@ extension OnitModel: NSWindowDelegate {
         newPanel.contentView?.setFrameOrigin(NSPoint(x: 0, y: 0))
         panel = newPanel
         
-        if let screen = NSScreen.main {
+        // Position the panel
+        if let savedFrame = preferences.contentViewFrame {
+            // Use the saved frame
+            newPanel.setFrame(savedFrame, display: false)
+        } else if let screen = NSScreen.main {
+            // Default position if no saved frame exists
             let visibleFrame = screen.visibleFrame
             let windowWidth = newPanel.frame.width
             let windowHeight = newPanel.frame.height
@@ -60,11 +65,33 @@ extension OnitModel: NSWindowDelegate {
             let finalXPosition = visibleFrame.origin.x + visibleFrame.width - 16 - windowWidth 
             let finalYPosition = visibleFrame.origin.y + visibleFrame.height - windowHeight
 
-            // Start off-screen to the right
             newPanel.setFrameOrigin(NSPoint(x: finalXPosition, y: finalYPosition))
-            newPanel.makeKeyAndOrderFront(nil)
-            newPanel.orderFrontRegardless()
         }
+        
+        // Ensure the panel is visible on screen
+        if let screen = NSScreen.main {
+            let visibleFrame = screen.visibleFrame
+            var panelFrame = newPanel.frame
+            
+            // Adjust if panel is outside visible area
+            if panelFrame.maxX > visibleFrame.maxX {
+                panelFrame.origin.x = visibleFrame.maxX - panelFrame.width - 16
+            }
+            if panelFrame.minX < visibleFrame.minX {
+                panelFrame.origin.x = visibleFrame.minX + 16
+            }
+            if panelFrame.maxY > visibleFrame.maxY {
+                panelFrame.origin.y = visibleFrame.maxY - panelFrame.height - 16
+            }
+            if panelFrame.minY < visibleFrame.minY {
+                panelFrame.origin.y = visibleFrame.minY + 16
+            }
+            
+            newPanel.setFrame(panelFrame, display: false)
+        }
+        
+        newPanel.makeKeyAndOrderFront(nil)
+        newPanel.orderFrontRegardless()
 
         enableKeyboardShortcuts()
 

--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -56,7 +56,9 @@ extension OnitModel: NSWindowDelegate {
         if let savedFrame = preferences.contentViewFrame {
             // Use the saved frame
             var adjustedFrame = savedFrame
+            let heightDifference = savedFrame.height - 100 // This will break if/when default components of window are changed. 
             adjustedFrame.size.height = newPanel.frame.height
+            adjustedFrame.origin.y += heightDifference
             newPanel.setFrame(adjustedFrame, display: false)
         } else if let screen = NSScreen.main {
             // Default position if no saved frame exists
@@ -161,6 +163,9 @@ extension OnitModel: NSWindowDelegate {
 
     func closePanel() {
         guard let panel = panel else { return }
+        updatePreferences { prefs in
+            prefs.contentViewFrame = panel.frame
+        }
         panel.orderOut(nil)
         WindowHelper.shared.adjustWindowToTopRight()
         self.panel = nil

--- a/macos/Onit/Data/Persistence/CGRect+Codable.swift
+++ b/macos/Onit/Data/Persistence/CGRect+Codable.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension CGRect: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let x = try container.decode(Double.self, forKey: .x)
+        let y = try container.decode(Double.self, forKey: .y)
+        let width = try container.decode(Double.self, forKey: .width)
+        let height = try container.decode(Double.self, forKey: .height)
+        self.init(x: x, y: y, width: width, height: height)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(origin.x, forKey: .x)
+        try container.encode(origin.y, forKey: .y)
+        try container.encode(size.width, forKey: .width)
+        try container.encode(size.height, forKey: .height)
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case x, y, width, height
+    }
+}

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -41,6 +41,9 @@ class Preferences: Codable {
     var visibleModelIds: Set<String> = Set([])
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
     
+    // Window state
+    var contentViewFrame: CGRect?
+    
     // Local model advanced options
     var localKeepAlive: String?
     var localNumCtx: Int?


### PR DESCRIPTION
@jonashaag pointed out that the default window size is often too small in #34 . This offers a catch-all solution: if the user repositions the Onit panel at all, that will become the default. So, users can move the panel anywhere on screen and make it as big or small as they wish!