### PR TITLE
Feature/accessibility settings reorganization

### DIFF
--- a/macos/Onit.xcodeproj/project.pbxproj
+++ b/macos/Onit.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Onit/Preview Content\"";
@@ -355,7 +355,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = inc.synth.Onit.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -376,7 +376,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Onit/Preview Content\"";
 				DEVELOPMENT_TEAM = TYC9PKBMB6;
@@ -391,7 +391,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = inc.synth.Onit;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/macos/Onit/Data/Persistence/Preferences.swift
+++ b/macos/Onit/Data/Persistence/Preferences.swift
@@ -40,6 +40,7 @@ class Preferences: Codable {
     var localEndpointURL: URL = URL(string: "http://localhost:11434")!
     
     // Feature flags
+    var accessibilityEnabled: Bool? = nil
     var accessibilityInputEnabled: Bool? = nil
     var accessibilityAutoContextEnabled: Bool? = nil
     var highlightHintMode: HighlightHintMode? = nil

--- a/macos/Onit/UI/OS/AutoContextView.swift
+++ b/macos/Onit/UI/OS/AutoContextView.swift
@@ -41,7 +41,7 @@ struct AutoContextView: View {
     
     var dialog: some View {
         SetUpDialog(title: "Auto-context", showButton: false) {
-            Text("Auto-context is collected as plain text from your current window and only stored once you submit your prompt. You can manage your preferences and data in settings.")
+            Text("Auto-context is collected as plain text from your current window. You can manage your autocontext preferences in settings.")
         } action: {
             
         } closeAction: {

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -44,10 +44,10 @@ struct AccessibilityTab: View {
     var body: some View {
         VStack(spacing: 25) {
             VStack(alignment: .leading, spacing: 20) {
-                Text("Accessibility Features")
+                Text("Autocontext Features")
                     .font(.system(size: 14))
                 HStack {
-                    Text("Enable accessibility features")
+                    Text("Enable Autocontext")
                         .font(.system(size: 13))
                     Spacer()
                     Toggle("", isOn: Binding(
@@ -60,7 +60,7 @@ struct AccessibilityTab: View {
                 
                 if featureFlagsManager.accessibility {
                     HStack {
-                        Text("Enable accessibility input")
+                        Text("Autocontext for Highlighted Text")
                             .font(.system(size: 13))
                         Spacer()
                         Toggle("", isOn: Binding(
@@ -69,10 +69,16 @@ struct AccessibilityTab: View {
                         ))
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                        SettingInfoButton(
+                            title: "Autocontext from Highlighted Text",
+                            description: "When enabled, Onit will read highlighted text from any application, and add it as context to your conversation. Context is not uploaded until you submit your conversation. In local mode, no context is ever uploaded." ,
+                            defaultValue: "off",
+                            valueType: "Bool"
+                        )
                     }
                     
                     HStack {
-                        Text("Enable auto context")
+                        Text("Autocontext + Screen-Reader Shortcut")
                             .font(.system(size: 13))
                         Spacer()
                         Toggle("", isOn: Binding(
@@ -81,27 +87,33 @@ struct AccessibilityTab: View {
                         ))
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                        SettingInfoButton(
+                            title: "Autocontext, Screen Reader Shortcut",
+                            description: "When enabled, Onit adds a shortcut that, when triggered, will read the text from the foregrounded application and add it as context to your conversation. Context is not uploaded until you submit your conversation. In local mode, no context is ever uploaded.",
+                            defaultValue: "off",
+                            valueType: "Bool"
+                        )
+                    }
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text("Autocontext Hint Position")
+                            .font(.system(size: 14))
+                        Picker("Choose hint position", selection: $selectedMode) {
+                            ForEach(modes, id: \.self) { mode in
+                                Text(mode.text)
+                                    .appFont(.medium14)
+                                    .padding(.vertical, 4)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .pickerStyle(MenuPickerStyle())
+                        .padding(.vertical, 4)
+                        .padding(.bottom, 5)
+                        .padding(.leading, 5)
+                        .tint(.blue600)
                     }
                 }
             }
             
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Hint Position")
-                    .font(.system(size: 14))
-                Picker("Choose hint position", selection: $selectedMode) {
-                    ForEach(modes, id: \.self) { mode in
-                        Text(mode.text)
-                            .appFont(.medium14)
-                            .padding(.vertical, 4)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .pickerStyle(MenuPickerStyle())
-                .padding(.vertical, 4)
-                .padding(.bottom, 5)
-                .padding(.leading, 5)
-                .tint(.blue600)
-            }
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 86)

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -39,21 +39,69 @@ struct AccessibilityTab: View {
     
     @State private var selectedMode: HighlightHintModeUI = HighlightHintModeUI.from(mode: FeatureFlagManager.shared.highlightHintMode)
     
+    @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
+    
     var body: some View {
         VStack(spacing: 25) {
-            Picker("Choose hint position", selection: $selectedMode) {
-                ForEach(modes, id: \.self) { mode in
-                    Text(mode.text)
-                        .appFont(.medium14)
-                        .padding(.vertical, 4)
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Accessibility Features")
+                    .font(.system(size: 14))
+                HStack {
+                    Text("Enable accessibility features")
+                        .font(.system(size: 13))
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { featureFlagsManager.accessibility },
+                        set: { featureFlagsManager.overrideAccessibility($0) }
+                    ))
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                }
+                
+                if featureFlagsManager.accessibility {
+                    HStack {
+                        Text("Enable accessibility input")
+                            .font(.system(size: 13))
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { featureFlagsManager.accessibilityInput },
+                            set: { featureFlagsManager.overrideAccessibilityInput($0) }
+                        ))
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    }
+                    
+                    HStack {
+                        Text("Enable auto context")
+                            .font(.system(size: 13))
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { featureFlagsManager.accessibilityAutoContext },
+                            set: { featureFlagsManager.overrideAccessibilityAutoContext($0) }
+                        ))
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .pickerStyle(MenuPickerStyle())
-            .padding(.vertical, 4)
-            .padding(.bottom, 5)
-            .padding(.leading, 5)
-            .tint(.blue600)
+            
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Hint Position")
+                    .font(.system(size: 14))
+                Picker("Choose hint position", selection: $selectedMode) {
+                    ForEach(modes, id: \.self) { mode in
+                        Text(mode.text)
+                            .appFont(.medium14)
+                            .padding(.vertical, 4)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .pickerStyle(MenuPickerStyle())
+                .padding(.vertical, 4)
+                .padding(.bottom, 5)
+                .padding(.leading, 5)
+                .tint(.blue600)
+            }
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 86)

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -4,15 +4,6 @@ struct DebugModeTab: View {
     @Environment(\.model) var model
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
     
-    // MARK: - Feature Flag Keys
-    
-    enum FeatureFlagKey: String, CaseIterable, Identifiable {
-        var id : String { UUID().uuidString }
-        
-        case accessibilityInput = "Accessibility Input"
-        case accessibilityAutoContext = "Accessibility Auto Context"
-    }
-    
     var body: some View {
         VStack(spacing: 25) {
             VStack(alignment: .leading, spacing: 20) {
@@ -30,47 +21,9 @@ struct DebugModeTab: View {
                     .controlSize(.small)
                 }
             }
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Feature flags")
-                    .font(.system(size: 14))
-                
-                featureFlagView(key: .accessibilityInput)
-                featureFlagView(key: .accessibilityAutoContext)
-                
-            }
-            .fontWeight(.medium)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 86)
-    }
-    
-    func featureFlagView(key: FeatureFlagKey) -> some View {
-        HStack {
-            Text(key.rawValue)
-                .font(.system(size: 13))
-            Spacer()
-            Toggle("", isOn: Binding(
-                get: {
-                    switch key {
-                    case .accessibilityInput:
-                        featureFlagsManager.accessibilityInput
-                    case .accessibilityAutoContext:
-                        featureFlagsManager.accessibilityAutoContext
-                    }
-                },
-                set: {
-                    switch key {
-                    case .accessibilityInput:
-                        featureFlagsManager.overrideAccessibilityInput($0)
-                    case .accessibilityAutoContext:
-                        featureFlagsManager.overrideAccessibilityAutoContext($0)
-                    }
-                }
-            ))
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
     }
 }
 

--- a/macos/Onit/UI/Settings/SettingsView.swift
+++ b/macos/Onit/UI/Settings/SettingsView.swift
@@ -32,13 +32,16 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.shortcuts)
             
-            if accessibilityInputEnabled {
-                AccessibilityTab()
-                    .tabItem {
-                        Label("Accessibility", systemImage: "accessibility")
+            
+            AccessibilityTab()
+                .tabItem {
+                    if featureFlagsManager.accessibility {
+                        Label("Autocontext", systemImage: "lightbulb")
+                    } else {
+                        Label("Autocontext", systemImage: "lightbulb.slash")
                     }
-                    .tag(SettingsTab.accessibility)
-            }
+                }
+                .tag(SettingsTab.accessibility)
             
             #if DEBUG
             DebugModeTab()


### PR DESCRIPTION
I've changed the Accessibility settings. Namely, I'm renaming it from "accessibility" to "autocontext", because the user-facing _features_ are autocontext features, not accessibility features. 

I also added a global "autocontext" (fka accessibility) toggle to settings so users can fully opt-out if they don't want the features. 