### PR TITLE
fix(ui): Prevent auto-context duplication

### DIFF
--- a/macos/Onit/Data/Model/Model+Input.swift
+++ b/macos/Onit/Data/Model/Model+Input.swift
@@ -16,6 +16,18 @@ extension OnitModel {
             return
         }
         
+        /** Prevent duplication */
+        let contextDuplicated = pendingContextList.contains { context in
+            if case .auto(let contextApp, let contextContent) = context {
+                return contextApp == appName && contextContent == appContent
+            }
+            return false
+        }
+        guard !contextDuplicated else {
+            // TODO: KNA - Display duplicated context to user
+            return
+        }
+        
         let autoContext = Context(appName: appName, appContent: appContent)
         pendingContextList.insert(autoContext, at: 0)
     }


### PR DESCRIPTION
When adding an Auto context prevent duplication based on `appName` & `appContent`
We can add multiple context from same App (tabs).