### PR TITLE
Make prompt view copyable

### DIFF
--- a/macos/Onit/UI/Prompt/FinalContextView.swift
+++ b/macos/Onit/UI/Prompt/FinalContextView.swift
@@ -66,6 +66,7 @@ struct FinalContextView: View {
                     RoundedRectangle(cornerRadius: 8)
                         .strokeBorder(.gray500)
                 }
+                .textSelection(.enabled)
         }
         .padding()
     }


### PR DESCRIPTION
Small change to make the text in prior prompts _copyable_:

<img width="396" alt="Screenshot 2025-02-09 at 9 37 45 PM" src="https://github.com/user-attachments/assets/05d16e20-805d-4be9-a8b8-03375d24255c" />
