### PR TITLE
fix curl method

### DIFF
--- a/macos/Onit/Data/Fetching/FetchingClient+Execute.swift
+++ b/macos/Onit/Data/Fetching/FetchingClient+Execute.swift
@@ -135,21 +135,21 @@ extension FetchingClient {
 
     private func printCurlRequest<E: Endpoint>(endpoint: E, url: URL) {
         // Helpful debugging method
+        print("CURL Request:")
+        print("curl -X \(endpoint.method.rawValue) \(url.absoluteString) \\")
+        print("  -H 'Content-Type: application/json' \\")
+        if let token = endpoint.token {
+            print("  -H 'Authorization: Bearer \(token)' \\")
+        }
+        if let additionalHeaders = endpoint.additionalHeaders {
+            for (header, value) in additionalHeaders {
+                print("  -H '\(header): \(value)' \\")
+            }
+        }
         if let requestBody = endpoint.requestBody {
             if let jsonData = try? encoder.encode(requestBody),
                 let jsonString = String(data: jsonData, encoding: .utf8)
             {
-                print("CURL Request:")
-                print("curl -X \(endpoint.method.rawValue) \(url.absoluteString) \\")
-                print("  -H 'Content-Type: application/json' \\")
-                if let token = endpoint.token {
-                    print("  -H 'Authorization: Bearer \(token)' \\")
-                }
-                if let additionalHeaders = endpoint.additionalHeaders {
-                    for (header, value) in additionalHeaders {
-                        print("  -H '\(header): \(value)' \\")
-                    }
-                }
                 print("  -d '\(jsonString)'")
             }
         }


### PR DESCRIPTION
Small change- as it's currently written, the printCurlRequest debugging method will only print requests that have a requestBody. As we now have many requests without a request body, we should make this optional!