### PR TITLE
Add an option to adjust the line height

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -80,6 +80,7 @@ extension Defaults.Keys {
     // General settings
     static let launchOnStartupRequested = Key<Bool>("launchOnStartupRequested", default: false)
     static let fontSize = Key<Double>("fontSize", default: 14.0)
+    static let lineHeight = Key<Double>("lineHeight", default: 1.5)
 
     // Local model advanced options
     static let localKeepAlive = Key<String?>("localKeepAlive", default: nil)

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -6,19 +6,24 @@
 //
 
 import Defaults
+import Foundation
 import MarkdownUI
 import SwiftUI
 
 struct GeneratedContentView: View {
     @Environment(\.model) var model
     @State private var contentHeight: CGFloat = 1000
-
+    @Default(.lineHeight) var lineHeight
+    @Default(.fontSize) var fontSize
+    
     var result: String
 
     var height: CGFloat {
         min(contentHeight, 500)
     }
 
+    
+    
     var body: some View {
         //        ViewThatFits(in: .vertical) {
         content
@@ -34,6 +39,7 @@ struct GeneratedContentView: View {
             .markdownTheme(.custom)
             .textSelection(.enabled)
             .multilineTextAlignment(.leading)
+            .lineSpacing((lineHeight * fontSize) - fontSize)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 16)
@@ -51,7 +57,8 @@ struct GeneratedContentView: View {
 extension Theme {
     @MainActor static var custom: Theme {
         @Default(.fontSize) var fontSize
-
+        @Default(.lineHeight) var lineHeight
+        
         return Theme()
             .text {
                 FontFamily(.custom("Inter"))
@@ -67,8 +74,14 @@ extension Theme {
             .codeBlock { configuration in
                 CodeBlockView(configuration: configuration)
             }
+            .paragraph { configuration in
+                configuration.label
+                    .markdownMargin(top: fontSize + (lineHeight * fontSize) - fontSize) // This works
+            }
     }
 }
+
+
 
 #Preview {
     GeneratedContentView(

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct GeneralTab: View {
     @Default(.fontSize) var fontSize
+    @Default(.lineHeight) var lineHeight
     @Default(.panelPosition) var panelPosition
 
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
@@ -68,6 +69,27 @@ struct GeneralTab: View {
                     }
                 }
 
+                VStack(spacing: 8) {
+                    HStack {
+                        Text("Line Height")
+                        Slider(
+                            value: $lineHeight,
+                            in: 1.0...2.5,
+                            step: 0.1
+                        )
+                        Text(String(format: "%.1f", lineHeight))
+                            .monospacedDigit()
+                            .frame(width: 40)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Button("Restore Default") {
+                            _lineHeight.reset()
+                        }
+                        .controlSize(.small)
+                    }
+                }
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Panel Position")
                         .font(.system(size: 13))


### PR DESCRIPTION
For readability, we're adding an option to adjust the line height of responses with a default of 1.4x. 

<img width="1368" alt="Screenshot 2025-02-12 at 7 12 19 PM" src="https://github.com/user-attachments/assets/0436e413-80e3-46e5-b3e2-050cdc7466b4" />

<img width="1379" alt="Screenshot 2025-02-12 at 7 12 09 PM" src="https://github.com/user-attachments/assets/ccbdd49e-119a-4e5a-999e-4a9696048629" />
