### PR TITLE
Add an option to adjust the line height

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -82,6 +82,7 @@ extension Defaults.Keys {
     // General settings
     static let launchOnStartupRequested = Key<Bool>("launchOnStartupRequested", default: false)
     static let fontSize = Key<Double>("fontSize", default: 14.0)
+    static let lineHeight = Key<Double>("lineHeight", default: 1.5)
 
     // Local model advanced options
     static let localKeepAlive = Key<String?>("localKeepAlive", default: nil)

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -6,12 +6,14 @@
 //
 
 import Defaults
+import Foundation
 import MarkdownUI
 import SwiftUI
 
 struct GeneratedContentView: View {
     @Environment(\.model) var model
     @State private var contentHeight: CGFloat = 1000
+
     
     var prompt: Prompt
     
@@ -30,8 +32,9 @@ struct GeneratedContentView: View {
     var height: CGFloat {
         min(contentHeight, 500)
     }
-
+    
     var body: some View {
+
         VStack(alignment: .leading) {
             ParsedContentView(text: textToRead)
                 .padding(.horizontal, 16)
@@ -60,7 +63,8 @@ struct GeneratedContentView: View {
 extension Theme {
     @MainActor static var custom: Theme {
         @Default(.fontSize) var fontSize
-
+        @Default(.lineHeight) var lineHeight
+        
         return Theme()
             .text {
                 FontFamily(.custom("Inter"))
@@ -76,8 +80,14 @@ extension Theme {
             .codeBlock { configuration in
                 CodeBlockView(configuration: configuration)
             }
+            .paragraph { configuration in
+                configuration.label
+                    .markdownMargin(top: fontSize + (lineHeight * fontSize) - fontSize) // This works
+            }
     }
 }
+
+
 
 #Preview {
     GeneratedContentView(prompt: Prompt.sample)
@@ -87,6 +97,9 @@ extension Theme {
 
 struct ParsedContentView: View {
     let text: String
+    
+    @Default(.lineHeight) var lineHeight
+    @Default(.fontSize) var fontSize
     
     // ContentSegment represents either normal text or a thought block
     struct ContentSegment {
@@ -139,6 +152,7 @@ struct ParsedContentView: View {
                     Markdown(segment.content)
                         .markdownTheme(.custom)
                         .textSelection(.enabled)
+                        .lineSpacing((lineHeight * fontSize) - fontSize)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -151,6 +165,8 @@ struct ThoughtProcessView: View {
     let content: String
     let streaming: Bool
     
+    @Default(.lineHeight) var lineHeight
+    @Default(.fontSize) var fontSize
     @State private var isExpanded: Bool = false
     
     var title: String {
@@ -184,6 +200,7 @@ struct ThoughtProcessView: View {
             if isExpanded && !streaming {
                 Text(content)
                     .padding(.leading, 20)
+                    .lineSpacing((lineHeight * fontSize) - fontSize)
             }
         }
         .padding(8)

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct GeneralTab: View {
     @Default(.fontSize) var fontSize
+    @Default(.lineHeight) var lineHeight
     @Default(.panelPosition) var panelPosition
 
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
@@ -68,6 +69,27 @@ struct GeneralTab: View {
                     }
                 }
 
+                VStack(spacing: 8) {
+                    HStack {
+                        Text("Line Height")
+                        Slider(
+                            value: $lineHeight,
+                            in: 1.0...2.5,
+                            step: 0.1
+                        )
+                        Text(String(format: "%.1f", lineHeight))
+                            .monospacedDigit()
+                            .frame(width: 40)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Button("Restore Default") {
+                            _lineHeight.reset()
+                        }
+                        .controlSize(.small)
+                    }
+                }
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Panel Position")
                         .font(.system(size: 13))


### PR DESCRIPTION
As requested in #62 , this PR adds a setting to adjust line-height manually.

<img width="1368" alt="Screenshot 2025-02-12 at 7 12 19 PM" src="https://github.com/user-attachments/assets/cdd24291-1843-4374-a3f1-0b3ec7211f64" />


<img width="1379" alt="Screenshot 2025-02-12 at 7 12 09 PM" src="https://github.com/user-attachments/assets/b37753da-e145-4ed8-bedd-828cae5890e6" />
