### PR TITLE
fix background color in settings position

### DIFF
--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -107,10 +107,12 @@ struct GeneralTab: View {
                                 }
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 8)
-                                .background(
-                                    panelPosition == position ? Color(.blue300) : Color(.gray700)
-                                )
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
+                                .background {
+                                    if panelPosition == position {
+                                        Color(.blue300)
+                                    }
+                                }
                             }
                             .buttonStyle(.plain)
                         }


### PR DESCRIPTION
This is a small fix to help for people who are _not_ in dark mode. Previously, we were coloring the buttons a dark color. If users were not in dark mode, the icons would also be dark colored making the buttons hard to see: 

<img width="533" alt="Screenshot 2025-02-13 at 12 23 17 PM" src="https://github.com/user-attachments/assets/037aaf1b-2c46-40c5-9245-3f36caffc1ae" />

This fix leaves the background color the default, unless it's selected, which works in both light and dark mode:

<img width="566" alt="Screenshot 2025-02-13 at 12 22 39 PM" src="https://github.com/user-attachments/assets/143fa8fc-22d3-4fa4-bde2-a7c1ded39bcd" />


