### PR TITLE
Add model name to response and display it in toolbar

### DIFF
--- a/macos/Onit/Data/Model/Model+Chat.swift
+++ b/macos/Onit/Data/Model/Model+Chat.swift
@@ -68,6 +68,7 @@ extension OnitModel {
             var responsesHistory: [String] = []
 
             // Go through prior prompts and add them to the history
+            let currentModelName = Defaults[.mode] == .local ? Defaults[.localModel] ?? "" : Defaults[.remoteModel]?.displayName ?? ""
             var currentPrompt: Prompt? = prompt.priorPrompt
             while currentPrompt != nil {
                 let response = currentPrompt!.responses[currentPrompt!.generationIndex]
@@ -100,6 +101,8 @@ extension OnitModel {
                     "Based on the provided instructions, either provide the output or answer any questions related to it. Provide the response without any additional comments. Provide the output ready to go."
                 
                 streamedResponse = ""
+                
+                
                 
                 switch Defaults[.mode] {
                 case .remote:
@@ -165,7 +168,7 @@ extension OnitModel {
                     }
                 }
                 
-                let response = Response(text: String(streamedResponse), type: .success)
+                let response = Response(text: String(streamedResponse), type: .success, model: currentModelName)
                 updatePrompt(prompt: prompt, response: response, instruction: curInstruction)
                 setTokenIsValid(true)
             } catch let error as FetchingError {
@@ -176,11 +179,11 @@ extension OnitModel {
                 if case .unauthorized = error {
                     setTokenIsValid(false)
                 }
-                let response = Response(text: error.localizedDescription, type: .error)
+                let response = Response(text: error.localizedDescription, type: .error, model: currentModelName)
                 updatePrompt(prompt: prompt, response: response, instruction: curInstruction)
             } catch {
                 print("Unexpected Error: \(error.localizedDescription)")
-                let response = Response(text: error.localizedDescription, type: .error)
+                let response = Response(text: error.localizedDescription, type: .error, model: currentModelName)
                 updatePrompt(prompt: prompt, response: response, instruction: curInstruction)
             }
         }

--- a/macos/Onit/Data/Persistence/Response.swift
+++ b/macos/Onit/Data/Persistence/Response.swift
@@ -13,15 +13,17 @@ class Response {
     var text: String
     var timestamp: Date
     var type: ResponseType
+    var model: String?
 
-    init(text: String, type: ResponseType, time: Date = .now) {
+    init(text: String, type: ResponseType, model: String, time: Date = .now) {
         self.text = text
         self.timestamp = time
         self.type = type
+        self.model = model
     }
     
     static var partial: Response {
-        .init(text: "", type: .partial)
+        .init(text: "", type: .partial, model: "")
     }
     
     var isPartial: Bool {

--- a/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
@@ -18,10 +18,12 @@ struct GeneratedToolbar: View {
         HStack(spacing: 8) {
             copy
             regenerate
-            more
-            Spacer()
             selector
-            //            insert
+            Spacer()
+            if let model = prompt.responses[prompt.generationIndex].model {
+                Text("\(model)")
+                    .foregroundColor(Color.gray300)
+            }
         }
         .foregroundStyle(.FG)
     }


### PR DESCRIPTION
This PR adds the model name to the the response field. That way, if you change models and regenerate, you can see which model was used!

Before: 
- Model name is not displayed
- "..." button that doesn't do anything
- "<2/2>" is right aligned

<img width="446" alt="Screenshot 2025-02-13 at 12 49 00 PM" src="https://github.com/user-attachments/assets/b45b670f-7754-491c-ba7c-874fc63bf283" />

After: 
- Model name displayed
- "..." menu is removed
- "<2/2> is left aligned

<img width="435" alt="Screenshot 2025-02-13 at 12 47 45 PM" src="https://github.com/user-attachments/assets/0ff00ec5-12d0-4827-a8d5-0d70d7de701c" />

