### PR TITLE
fix issue with 'no local models' dialog showing up repeated

### DIFF
--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -95,11 +95,13 @@ import SwiftUI
             }
             localFetchFailed = false
 
+            // Reset the closedNoLocalModels flag when local models are successfully fetched.
+            Defaults[.closedNoLocalModels] = false
+
             // If relevant shrink the dialog box to account for the removed SetupDialog.
             shrinkContent()
         } catch {
             print("Error fetching local models:", error)
-
             localFetchFailed = true
             Defaults[.availableLocalModels] = []
             Defaults[.localModel] = nil

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -46,6 +46,8 @@ extension Defaults.Keys {
     static let closedXAI = Key<Bool>("closedXAI", default: false)
     static let closedGoogleAI = Key<Bool>("closedGoogleAI", default: false)
     static let closedDeepSeek = Key<Bool>("closedDeepSeek", default: false)
+    static let closedNoLocalModels = Key<Bool>("closedNoLocalModels", default: false)
+    static let closedNoRemoteModels = Key<Bool>("closedNoRemoteModels", default: false)
     static let closedNewRemoteData = Key<Data>("closedNewRemoteData", default: Data())
     static let closedDeprecatedRemoteData = Key<Data>("closedDeprecatedRemoteData", default: Data())
     static let closedAutoContextDialog = Key<Bool>("closedAutoContext", default: false)

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -13,8 +13,7 @@ struct SetUpDialogs: View {
     @Environment(\.remoteModels) var remoteModels
     @Environment(\.openSettings) var openSettings
 
-    @State var closedNoLocalModels = false
-    @State var closedNoRemoteModels = false
+    
 
     @State private var fetchingRemote = false
     @State private var fetchingLocal = false
@@ -26,6 +25,8 @@ struct SetUpDialogs: View {
     @Default(.closedXAI) var closedXAI
     @Default(.closedGoogleAI) var closedGoogleAI
     @Default(.closedDeepSeek) var closedDeepSeek
+    @Default(.closedNoLocalModels) var closedNoLocalModels
+    @Default(.closedNoRemoteModels) var closedNoRemoteModels
     @Default(.seenLocal) var seenLocal
     @Default(.closedNewRemoteData) var closedNewRemoteData
     @Default(.closedDeprecatedRemoteData) var closedDeprecatedRemoteData


### PR DESCRIPTION
This was an annoying issue: if you had enabled local models once, but then turned off Ollama, you'd get a dialog saying "no local models available" every time you opened the app, even if you had dismissed it! 

This was caused by using @State variables to store the dismissal rather than Default variables. @State variables are tied to the view lifecycle, so get reset when the app is closed and re-opened. Instead, our Defaults abstraction stores state in the UserDefaults object, which persists between sessions. 

I also added a reset of the dismissal if Ollama is successfully loaded. So, the dialog will show every time we _lose_ access to Ollama, but not everytime we open the app. 