### PR TITLE
Feature/launch shortcut toggle

### DIFF
--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -236,7 +236,11 @@ extension OnitModel: NSWindowDelegate {
     }
 
     func launchShortcutAction() {
-        launchPanel()
+        if Defaults[.launchShortcutToggleEnabled] {
+            togglePanel()
+        } else {
+            launchPanel()
+        }
     }
 
     func toggleLocalVsRemoteShortcutAction() {

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -93,6 +93,9 @@ extension Defaults.Keys {
     static let localTopP = Key<Double?>("localTopP", default: nil)
     static let localTopK = Key<Int?>("localTopK", default: nil)
     static let localRequestTimeout = Key<TimeInterval?>("localRequestTimeout", default: 60.0)
+    
+    // Debug settings
+    static let launchShortcutToggleEnabled = Key<Bool>("launchShortcutToggleEnabled", default: false)
 }
 
 extension NSRect: Defaults.Serializable {

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import Defaults
 
 struct DebugModeTab: View {
     @Environment(\.model) var model
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
 
+    @Default(.launchShortcutToggleEnabled) var launchShortcutToggleEnabled
+    
     var body: some View {
         VStack(spacing: 25) {
             VStack(alignment: .leading, spacing: 20) {
@@ -30,7 +33,7 @@ struct DebugModeTab: View {
                     Spacer()
                     Toggle(
                         "",
-                        isOn: Defaults.$launchShortcutToggleEnabled
+                        isOn: $launchShortcutToggleEnabled
                     )
                     .toggleStyle(.switch)
                     .controlSize(.small)

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -23,6 +23,18 @@ struct DebugModeTab: View {
                     .toggleStyle(.switch)
                     .controlSize(.small)
                 }
+                
+                HStack {
+                    Text("Launch shortcut toggle mode")
+                        .font(.system(size: 13))
+                    Spacer()
+                    Toggle(
+                        "",
+                        isOn: Defaults.$launchShortcutToggleEnabled
+                    )
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                }
             }
         }
         .padding(.vertical, 20)


### PR DESCRIPTION
This was suggested by a user on our initial hackernews post.  This PR makes the Onit dialog dismissable with the same shortcut as launching. So, if you press CMD+0 to launch the dialog and then CMD+0 again, the dialog will launch the first time, and then dismiss the 2nd time. 

I'm not sure about this change. On one hand, it's easier to only need to remember one shortcut. On the other hand, it could cause you to accidentally dismiss the dialog in some cases.  

So, I added it as a flag in the "Debug" settings. I've enabled it for myself and will see how I like using it in production before making a call on whether to enable by default. 