### PR TITLE
implement experiment feature to create new chat when new panel is opened

### DIFF
--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -20,6 +20,11 @@ extension OnitModel: NSWindowDelegate {
             return
         }
 
+        // Create a new chat when creating a new panel if the setting is enabled
+        if Defaults[.createNewChatOnPanelOpen] {
+            newChat()
+        }
+
         let newPanel = CustomPanel(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 0),
             styleMask: [.resizable, .nonactivatingPanel, .fullSizeContentView],

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -96,6 +96,7 @@ extension Defaults.Keys {
     
     // Debug settings
     static let launchShortcutToggleEnabled = Key<Bool>("launchShortcutToggleEnabled", default: false)
+    static let createNewChatOnPanelOpen = Key<Bool>("createNewChatOnPanelOpen", default: false)
 }
 
 extension NSRect: Defaults.Serializable {

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -31,6 +31,13 @@ struct DebugModeTab: View {
                 HStack {
                     Text("Launch shortcut toggle mode")
                         .font(.system(size: 13))
+                    SettingInfoButton(
+                        title: "Launch Shortcut Toggle Mode",
+                        description:
+                            "Enable this to use the launch shortcut (CMD+Zero by default) as a toggle: press once to show the panel, press again to hide it.",
+                        defaultValue: "off",
+                        valueType: "Bool"
+                    )
                     Spacer()
                     Toggle(
                         "",
@@ -43,7 +50,13 @@ struct DebugModeTab: View {
                 HStack {
                     Text("Create new chat on panel open")
                         .font(.system(size: 13))
-                        .help("When enabled, a new chat will be created each time the panel is opened after being closed. When disabled, the previous chat will be restored.")
+                    SettingInfoButton(
+                        title: "Create New Chat on Panel Open",
+                        description:
+                            "Enable this to start a new chat each time the panel opens. You still access your previous conversations with the up arrow.",
+                        defaultValue: "off",
+                        valueType: "Bool"
+                    )
                     Spacer()
                     Toggle(
                         "",
@@ -51,7 +64,6 @@ struct DebugModeTab: View {
                     )
                     .toggleStyle(.switch)
                     .controlSize(.small)
-                    .help("When enabled, a new chat will be created each time the panel is opened after being closed. When disabled, the previous chat will be restored.")
                 }
             }
         }

--- a/macos/Onit/UI/Settings/DebugModeTab.swift
+++ b/macos/Onit/UI/Settings/DebugModeTab.swift
@@ -6,7 +6,8 @@ struct DebugModeTab: View {
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
 
     @Default(.launchShortcutToggleEnabled) var launchShortcutToggleEnabled
-    
+    @Default(.createNewChatOnPanelOpen) var createNewChatOnPanelOpen
+
     var body: some View {
         VStack(spacing: 25) {
             VStack(alignment: .leading, spacing: 20) {
@@ -37,6 +38,20 @@ struct DebugModeTab: View {
                     )
                     .toggleStyle(.switch)
                     .controlSize(.small)
+                }
+
+                HStack {
+                    Text("Create new chat on panel open")
+                        .font(.system(size: 13))
+                        .help("When enabled, a new chat will be created each time the panel is opened after being closed. When disabled, the previous chat will be restored.")
+                    Spacer()
+                    Toggle(
+                        "",
+                        isOn: $createNewChatOnPanelOpen
+                    )
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .help("When enabled, a new chat will be created each time the panel is opened after being closed. When disabled, the previous chat will be restored.")
                 }
             }
         }


### PR DESCRIPTION
This adds an experimental setting to create a new chat each time the window is dismissed. I'm testing this out for myself. I think I prefer it for now, but we will see how it ages!