### PR TITLE
oneliner to fix bug where default remote model is reset each time app…

### DIFF
--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -114,7 +114,7 @@ import SwiftUI
             var models = try await AIModel.fetchModels()
 
             // This means we've never successfully fetched before
-            if Defaults[.availableLocalModels].isEmpty {
+            if Defaults[.availableRemoteModels].isEmpty {
                 if Defaults[.visibleModelIds].isEmpty {
                     Defaults[.visibleModelIds] = Set(
                         models.filter { $0.defaultOn }.map { $0.uniqueId })


### PR DESCRIPTION
… is restarted

There's a bug currently where, when the app is closed and reopened, the default 'remoteModel" gets reset to the first option in the list. It's really irritating me, because I restart the app all the time and it resets to o3 which is very slow. 

I looked into it and found a typo in the code. We were checking availableLOCALmodels, where we should've been checking availableREMOTEmodels. 