### PR TITLE
fix for loading indicator crash

### DIFF
--- a/macos/Onit/UI/Components/QLImage.swift
+++ b/macos/Onit/UI/Components/QLImage.swift
@@ -36,7 +36,13 @@ struct QLImage: NSViewRepresentable {
             let _ = print("Cannot get image \(name)")
             return
         }
-        nsView.previewItem = url as QLPreviewItem
+        
+        // Check if the nsView is still valid before setting the preview item
+        if nsView.window != nil {
+            nsView.previewItem = url as QLPreviewItem
+        } else {
+            print("Cannot set preview item on a closed preview view")
+        }
     }
     
     typealias NSViewType = QLPreviewView


### PR DESCRIPTION
Small fix for a crash I've seen a few times now with the loading indicator. The error message is " Trying to set a preview item on a closed preview view," implying that we are setting the URL after the view has been deallocated. I add a nil check to prevent this. 