### PR TITLE
Try to switch screens first before checking if launch action should a…

### DIFF
--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -176,16 +176,7 @@ extension OnitModel: NSWindowDelegate {
 
         disableKeyboardShortcuts()
     }
-
-    @MainActor
-    func togglePanel() {
-        if panel != nil {
-            closePanel()
-        } else {
-            showPanel()
-        }
-    }
-
+    
     func launchPanel() {
         if panel == nil {
             showPanel()
@@ -236,20 +227,25 @@ extension OnitModel: NSWindowDelegate {
             let newFrame = NSRect(
                 x: finalXPosition, y: finalYPosition, width: windowWidth, height: windowHeight)
             panel.setFrame(newFrame, display: true, animate: false)
+            
+            panel.makeKeyAndOrderFront(nil)
+            panel.orderFrontRegardless()
+            self.textFocusTrigger.toggle()
+        } else {
+            // If we're using the shortcut as a Toggle, dismiss the panel.
+            if Defaults[.launchShortcutToggleEnabled] {
+                closePanel()
+            } else {
+                // Otherwise, bring it to the front
+                panel.makeKeyAndOrderFront(nil)
+                panel.orderFrontRegardless()
+                self.textFocusTrigger.toggle()
+            }
         }
-
-        panel.makeKeyAndOrderFront(nil)
-        panel.orderFrontRegardless()
-
-        self.textFocusTrigger.toggle()
     }
 
     func launchShortcutAction() {
-        if Defaults[.launchShortcutToggleEnabled] {
-            togglePanel()
-        } else {
-            launchPanel()
-        }
+        launchPanel()
     }
 
     func toggleLocalVsRemoteShortcutAction() {


### PR DESCRIPTION
…ct as a toggle

This is a minor update to the experimental feature, which uses the launch shortcut (CMD+0) as a toggle. If the panel is active AND the user has switched screens, the launch shortcut should pull the window to the new screen rather than dismissing the window. 

As part of this, I was able to remove the "togglePanel" function, which was only used in one place (now deleted). 