### PR TITLE
Don't clear out context on new panel launch

### DIFF
--- a/macos/Onit/Data/Model/Model+Input.swift
+++ b/macos/Onit/Data/Model/Model+Input.swift
@@ -72,15 +72,18 @@ extension OnitModel {
         addContext(urls: imageURLs)
     }
 
-    func newChat() {
+    func newChat(clearContext: Bool = true) {
         historyIndex = -1
         currentChat = nil
         currentPrompts = nil
         pendingInstruction = ""
-        pendingContextList.removeAll()
-        pendingInput = nil
+        if (clearContext) {
+            pendingContextList.removeAll()
+            pendingInput = nil
+        }
         focusText()
         shrinkContent()
+        
     }
 
     func shrinkContent() {

--- a/macos/Onit/Data/Model/Model+Panel.swift
+++ b/macos/Onit/Data/Model/Model+Panel.swift
@@ -21,8 +21,9 @@ extension OnitModel: NSWindowDelegate {
         }
 
         // Create a new chat when creating a new panel if the setting is enabled
+        // But we don't want to clear out the context, so that autocontext still works.
         if Defaults[.createNewChatOnPanelOpen] {
-            newChat()
+            newChat(clearContext: false)
         }
 
         var windowWidth: CGFloat = 400


### PR DESCRIPTION
Quick fix for #98 

When the 'createNewChatOnPanelOpen' option is enabled, we shouldn't clear out context: just everything else!