### PR TITLE
wrap previews in debug conditional

### DIFF
--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
@@ -38,6 +38,8 @@ struct SystemPromptSelectionRowView: View {
     }
 }
 
-#Preview {
-    SystemPromptSelectionRowView(prompt: PreviewSampleData.systemPrompt)
-}
+#if DEBUG
+    #Preview {
+        SystemPromptSelectionRowView(prompt: PreviewSampleData.systemPrompt)
+    }
+#endif

--- a/macos/Onit/UI/Settings/SystemPrompt/SettingsSystemPromptDetail.swift
+++ b/macos/Onit/UI/Settings/SystemPrompt/SettingsSystemPromptDetail.swift
@@ -111,8 +111,10 @@ struct SettingsSystemPromptDetail: View {
     }
 }
 
-#Preview {
-    SettingsSystemPromptDetail(prompt: .constant(PreviewSampleData.systemPrompt),
-                       shouldBeDeleted: .constant(false),
-                       shortcutChanged: .constant(false))
-}
+#if DEBUG
+    #Preview {
+        SettingsSystemPromptDetail(prompt: .constant(PreviewSampleData.systemPrompt),
+                           shouldBeDeleted: .constant(false),
+                           shortcutChanged: .constant(false))
+    }
+#endif


### PR DESCRIPTION
Small fix here: I can't archive the app for release unless these previews are wrapped in a DEBUG conditional. I'm not entirely sure why, but it's consistent with what we have elsewhere in the codebase. @Niduank do you know why? 