### PR TITLE
Route all overlays through a single controller

### DIFF
--- a/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-        "version" : "1.2024011602.0"
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
-        "revision" : "3d98a76aab39eedf957274e98e15ebe6bb390b87",
-        "version" : "9.0.1"
+        "revision" : "cc938ecf0bed848dc80a9726ac5455104e3f9dae",
+        "version" : "9.0.2"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "0d885d28250fb1196b614bc9455079b75c531f72",
-        "version" : "11.7.0"
+        "revision" : "eb523407e4293568ed55590728205c359cbecc5b",
+        "version" : "11.9.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "be0881ff728eca210ccb628092af400c086abda3",
-        "version" : "11.7.0"
+        "revision" : "d80e25104abe76d69a134d4ec18f011edd8df06c",
+        "version" : "11.9.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-        "version" : "1.65.1"
+        "revision" : "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+        "version" : "1.69.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "85b7b231882c3c472b8bda4fb495324d3f19bab6",
-        "version" : "4.2.0"
+        "revision" : "4d70340d55d7d07cc2fdf8e8125c4c126c1d5f35",
+        "version" : "4.4.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
       "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "9369a045a72a5296150879781321aecd228171db",
-        "version" : "2.1.0"
+        "revision" : "7ecc38bb6edf7d087d30e737057b8d8a9b7f51eb",
+        "version" : "2.2.4"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MenuBarExtraAccess",
       "state" : {
-        "revision" : "ada1c2d437272db0f25efc92337a624b69dd7713",
-        "version" : "1.1.1"
+        "revision" : "e911e6454f8cbfe34a52136fc48e1ceb989a60e7",
+        "version" : "1.2.1"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios.git",
       "state" : {
-        "revision" : "80208b1086ebd021efdba5826fd9e819f5e736cf",
-        "version" : "3.19.1"
+        "revision" : "f610677cca80eb0acbdd076856626ff82982178d",
+        "version" : "3.19.7"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "0ef1ee0220239b3776f433314515fd849025673f",
-        "version" : "2.6.4"
+        "revision" : "0ca3004e98712ea2b39dd881d28448630cce1c99",
+        "version" : "2.7.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+        "version" : "1.29.0"
       }
     },
     {

--- a/macos/Onit/Data/Model/Model+ContextPicker.swift
+++ b/macos/Onit/Data/Model/Model+ContextPicker.swift
@@ -11,17 +11,10 @@ import SwiftUI
 
 extension OnitModel {
     func showContextPickerOverlay() {
-        if contextPickerWindowController == nil {
-            contextPickerWindowController = OverlayWindowController(
-                model: self, content: ContextPickerView())
-        } else {
-            closeContextPickerOverlay()
-        }
+        OverlayManager.shared.showOverlay(model: self, content: ContextPickerView())
     }
 
     func closeContextPickerOverlay() {
-        contextPickerWindowController?.closeOverlay()
-        contextPickerWindowController = nil
+        OverlayManager.shared.dismissOverlay()
     }
-
 }

--- a/macos/Onit/Data/Model/Model+ModelSelection.swift
+++ b/macos/Onit/Data/Model/Model+ModelSelection.swift
@@ -12,17 +12,11 @@ import SwiftUI
 
 extension OnitModel {
     func showModelSelectionOverlay() {
-        if modelSelectionWindowController == nil {
-            modelSelectionWindowController = OverlayWindowController(
-                model: self, content: ModelSelectionView())
-        } else {
-            closeModelSelectionOverlay()
-        }
+        OverlayManager.shared.showOverlay(model: self, content: ModelSelectionView())
     }
 
     func closeModelSelectionOverlay() {
-        modelSelectionWindowController?.closeOverlay()
-        modelSelectionWindowController = nil
+        OverlayManager.shared.dismissOverlay()
     }
 
     func selectModel(_ modelItem: AIModel) {

--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -52,8 +52,6 @@ import SwiftUI
     var debugPanel: CustomPanel? = nil
     var debugText: String?
 
-    var modelSelectionWindowController: OverlayWindowController<ModelSelectionView>?
-    var contextPickerWindowController: OverlayWindowController<ContextPickerView>?
     var autoContextWindowControllers: [Context: AutoContextWindowController] = [:]
 
     var showFileImporter = false

--- a/macos/Onit/UI/OS/OverlayManager.swift
+++ b/macos/Onit/UI/OS/OverlayManager.swift
@@ -1,0 +1,35 @@
+//
+//  Model+ModelSelection.swift
+//  Onit
+//
+//  Created by Timl on 2/28/25.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+class OverlayManager {
+    static let shared = OverlayManager()
+    private var currentOverlay: OverlayWindowController<AnyView>?
+    
+    private init() {}
+    
+    /// Presents a new overlay by dismissing any existing one.
+    func showOverlay<Content: View>(model: OnitModel, content: Content) {
+        // Dismiss the current overlay (if any)
+        currentOverlay?.closeOverlay()
+        currentOverlay = nil
+        
+        // Create and store the new overlay
+        let overlay = OverlayWindowController(model: model, content: AnyView(content))
+        currentOverlay = overlay
+        // Additional logic to actually display the overlay if needed
+    }
+    
+    /// Dismisses the current overlay.
+    func dismissOverlay() {
+        currentOverlay?.closeOverlay()
+        currentOverlay = nil
+    }
+}

--- a/macos/Onit/UI/OS/OverlayWindowController.swift
+++ b/macos/Onit/UI/OS/OverlayWindowController.swift
@@ -164,18 +164,8 @@ class OverlayWindowController<Content: View>: NSObject, NSWindowDelegate {
     func closeOverlay() {
         guard let overlayWindow = overlayWindow else { return }
 
-        NSAnimationContext.runAnimationGroup(
-            { context in
-                context.duration = 0.2
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                overlayWindow.animator().alphaValue = 0.0
-            },
-            completionHandler: {
-                overlayWindow.orderOut(nil)
-                overlayWindow.alphaValue = 1.0
-                self.overlayWindow = nil
-                self.model?.contextPickerWindowController = nil
-                self.stopEventMonitoring()
-            })
+        overlayWindow.orderOut(nil)
+        self.overlayWindow = nil
+        self.stopEventMonitoring()
     }
 }

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -114,7 +114,7 @@ struct Toolbar: View {
             .contentShape(.rect)
             .background {
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(model.modelSelectionWindowController == nil ? Color.clear : .gray800)
+                    .fill(Color.clear)
             }
         }
         .tooltip(prompt: "Change model")


### PR DESCRIPTION
This solves issue #63  

We have two different ContextOverlayControllers: one for the Model Selector and one for the Context Menu. There were race conditions when both were active: only one would consume the mouse-down events; and not always the right one.!

So, if you had the Context Menu active and tapped the select Model dropdown, sometimes the mouse-down event would get consumed by the activating Model Selector. So the Model Selector wouldn't get shown (or it would appear briefly and then immediately get killed by the mouse-down event). Because the Model Selector was consuming the mouse-down event, the Context Menu wouldn't get it. But the reference to the ContextOverlayController _would_ get deallocated. So we'd end up with a hanging view that was never dismissed, but there was no longer reference to it. 

The 'close' button on the hanging view wouldn't work,  because it routes the action through the model, which no longer had reference to the relevant ContextOverlayController. 

My solution is to route all ContextOverlayControllers through a shared OverlayProvider. The OverlayProvider will make sure that any prior ContextOverlayController is dismissed before launching a new one. This means only one can be listening for the MouseDown events at any given time, and it's always the right one. 

Moving forward, **we'll have to be conscious of listening for these mouse-down events. Any time we have more than one active listener, there will be race conditions**! 

@Niduank -tagging you so you're aware of the issue. 