### PR TITLE
Adding a 10s timeout for the accessibility parsing code

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -327,7 +327,7 @@ class AccessibilityNotificationsManager: ObservableObject {
                 await MainActor.run {
                     print("Accessibility timeout")
                     // Assuming there's a Posthog tracking method available
-                    PostHogSDK.shared.capture("accessibiltyParseTimedOut", properties: ["applicationName": appName])
+                    PostHogSDK.shared.capture("accessibilityParseTimedOut", properties: ["applicationName": appName])
                     // Optionally, reset the screen result
                     self.screenResult = .init()
                     self.showDebug()

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -7,6 +7,7 @@
 
 import ApplicationServices
 import Foundation
+import PostHog
 import SwiftUI
 
 @MainActor
@@ -285,27 +286,52 @@ class AccessibilityNotificationsManager: ObservableObject {
     private func parseAccessibility(for pid: pid_t) {
         guard FeatureFlagManager.shared.accessibilityAutoContext else {
             self.screenResult = .init()
-
             return
         }
         
-        Task.detached(priority: .background) { [pid] in
-            var results = await AccessibilityParser.shared.getAllTextInElement(appElement: pid.getAXUIElement())
-            let elapsedTime = results?[AccessibilityParsedElements.elapsedTime]
-            let appName = results?[AccessibilityParsedElements.applicationName]
-            let appTitle = results?[AccessibilityParsedElements.applicationTitle]
-            
-            results?.removeValue(forKey: AccessibilityParsedElements.elapsedTime)
-            results?.removeValue(forKey: AccessibilityParsedElements.applicationName)
-            results?.removeValue(forKey: AccessibilityParsedElements.applicationTitle)
-
-            await MainActor.run {
-                self.screenResult.elapsedTime = elapsedTime
-                self.screenResult.applicationName = appName
-                self.screenResult.applicationTitle = appTitle
-                self.screenResult.others = results
-
-                self.showDebug()
+        Task.detached(priority: .background) { [pid, weak self] in
+            guard let self = self else { return }
+            do {
+                // Use a task group to race the parsing task against a 20 seconds timeout
+                var results = try await withThrowingTaskGroup(of: [String: String]?.self, body: { group -> [String: String]? in
+                    group.addTask {
+                        return await AccessibilityParser.shared.getAllTextInElement(appElement: pid.getAXUIElement())
+                    }
+                    group.addTask {
+                        try await Task.sleep(nanoseconds: 10_000_000_000) // 10 second timeout
+                        throw NSError(domain: "AccessibilityParsingTimeout", code: 1, userInfo: nil)
+                    }
+                    let firstCompleted = try await group.next()!
+                    group.cancelAll()
+                    return firstCompleted
+                })
+                
+                let elapsedTime = results?[AccessibilityParsedElements.elapsedTime]
+                let appName = results?[AccessibilityParsedElements.applicationName]
+                let appTitle = results?[AccessibilityParsedElements.applicationTitle]
+                
+                results?.removeValue(forKey: AccessibilityParsedElements.elapsedTime)
+                results?.removeValue(forKey: AccessibilityParsedElements.applicationName)
+                results?.removeValue(forKey: AccessibilityParsedElements.applicationTitle)
+                
+                await MainActor.run {
+                    self.screenResult.elapsedTime = elapsedTime
+                    self.screenResult.applicationName = appName
+                    self.screenResult.applicationTitle = appTitle
+                    self.screenResult.others = results
+                    self.showDebug()
+                }
+            } catch {
+                // Timeout occurred, send Posthog event with the application name
+                let appName = pid.getAppName() ?? "Unknown"
+                await MainActor.run {
+                    print("Accessibility timeout")
+                    // Assuming there's a Posthog tracking method available
+                    PostHogSDK.shared.capture("accessibiltyParseTimedOut", properties: ["applicationName": appName])
+                    // Optionally, reset the screen result
+                    self.screenResult = .init()
+                    self.showDebug()
+                }
             }
         }
     }
@@ -460,3 +486,4 @@ class AccessibilityNotificationsManager: ObservableObject {
         }
     }
 }
+

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -145,7 +145,7 @@ struct AccessibilityTab: View {
                 Section {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("Current Window Shortcut")
+                            Text("Current Window (Experimental)")
                                 .font(.system(size: 13))
                             Spacer()
                             Toggle(
@@ -162,14 +162,14 @@ struct AccessibilityTab: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                             SettingInfoButton(
-                                title: "Auto-Context, Screen Reader Shortcut",
+                                title: "Auto-Context, Screen Reader Shortcut (Experimental)",
                                 description:
                                     "When enabled, Onit adds a shortcut that, when triggered, will read the text from the foregrounded application and add it as context to your conversation. Context is not uploaded until you submit your conversation. In local mode, no context is ever uploaded.",
                                 defaultValue: "on",
                                 valueType: "Bool"
                             )
                         }
-                        Text("Loads context from the active window")
+                        Text("Loads context from the active window. Warning: If you notice the application freeze after enabling this, please disable it.")
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
                     }


### PR DESCRIPTION
@craigz reported in Issue #92 that the App sometimes freezes. I suspected this had to do with the AcccessibiltyParsing code, so I suggested he disable AutoContext, and sure enough, the app stopped freezing! 

It's virtually impossible to debug this without further information, so I'm added some logging to help diagnose the issue. Specifically I've updated the accessibility parsing code to timeout after 10 seconds and log which application caused the timeout. 