### PR TITLE
Remove accessibility parsing for applications that have previously ti…

### DIFF
--- a/macos/Onit/Data/Model/Model+Input.swift
+++ b/macos/Onit/Data/Model/Model+Input.swift
@@ -15,10 +15,16 @@ extension OnitModel {
             return
         }
 
-        guard let appName = AccessibilityNotificationsManager.shared.screenResult.applicationName,
-            let appContent = AccessibilityNotificationsManager.shared.screenResult.others
-        else {
-            // TODO: KNA - notify user for empty context
+        let appName = AccessibilityNotificationsManager.shared.screenResult.applicationName ?? "AutoContext"
+        if let errorMessage = AccessibilityNotificationsManager.shared.screenResult.errorMessage {
+            let errorContext = Context(appName: "Unable to add \(appName)", appContent: ["error": errorMessage])
+            pendingContextList.insert(errorContext, at: 0)
+            return
+        }
+
+        guard let appContent = AccessibilityNotificationsManager.shared.screenResult.others else {
+            let errorContext = Context(appName: "Unable to add \(appName)", appContent: ["error": "Empty text"])
+            pendingContextList.insert(errorContext, at: 0)
             return
         }
 


### PR DESCRIPTION
…med out

I'm taking the changes from PR #107 a step further: If a process has previously timed out, let's not try to parse it anymore. At least in this session. I think this will create the most seamless users experience; if it's frozen once, let's not keep trying to parse it. 

I've also updated to context tag to display an error message when this happens: 

<img width="877" alt="Screenshot 2025-02-28 at 11 53 52 AM" src="https://github.com/user-attachments/assets/7ec4b804-cecb-482b-946c-cfabdfa1be13" />

@Niduank tagging you so you see these changes!