### PR TITLE
fix case where escape key is permanently disabled

### DIFF
--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -15,6 +15,7 @@ struct KeyboardShortcutsManager {
     
     static func configure(model: OnitModel) {
         registerSettingsShortcuts(model: model)
+        
         registerSystemPromptsShortcuts(modelContainer: model.container)
     }
     
@@ -72,9 +73,6 @@ struct KeyboardShortcutsManager {
     /// - parameter model: Instance of `OnitModel`
     private static func registerSettingsShortcuts(model: OnitModel) {
         KeyboardShortcuts.Name.allCases.forEach { name in
-            if name == .escape && Defaults[.escapeShortcutDisabled] {
-                return
-            }
             KeyboardShortcuts.onKeyUp(for: name) {
                 switch name {
                 case .launch:
@@ -107,6 +105,11 @@ struct KeyboardShortcutsManager {
                 }
             }
         }
+        // Since we support turning on and off shortcuts, we should disable these all after registering.
+        // Then, the shortcuts that are on will be enabled when enable() is called. 
+        var names = KeyboardShortcuts.Name.allCases
+            .filter { ![.launch, .launchWithAutoContext].contains($0) }
+        KeyboardShortcuts.disable(names)
     }
     
     /// Registering keyboard shortcuts for all stored `SystemPrompt`


### PR DESCRIPTION
This should solve the issue reported by @craigz in #110. 

The failure occurred when a user restarted the app while the ESC key was disabled. Before this PR, when we restart the app with the ESC key disabled, we weren't even _registering_ the shortcut. So, if the user then enabled the ESC key again, it won't work because the shortcut was never registered in the first place!

The clear fix was to remove the logic from registerSettingsShortcuts that prevents the escape key from being disabled. 

This introduced a second issue though! In this case, when the user starts up the app with the ESC key disabled, it will _work_ the first time the app opens, even though it's supposed to be disabled! That's because it's enabled by default after being registered in registerSettingsShortcuts. So, the fix is to disable the non-launch shortcuts by default after registering then, and then let the enable() function handle enabling the correct shortcuts. 