### PR TITLE
Fix issue #117: Panel Position Blue should match the blue elsewhere in settings.

### DIFF
--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -144,7 +144,7 @@ struct GeneralTab: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
                                 .background {
                                     if panelPosition == position {
-                                        Color(.blue300)
+                                        Color.accentColor
                                     }
                                 }
                             }


### PR DESCRIPTION
This pull request fixes #117.

The issue has been successfully resolved. The specific change made replaces the custom `Color(.blue300)` (which was described as appearing more purple than blue) with `Color.accentColor`, which is the system's default accent color on macOS. This change will ensure that the selected panel position uses the same blue color that's used for other selected elements in the settings interface, like toggles.

The modification is straightforward and directly addresses the reported issue:
1. Removes the custom color that was causing the purple appearance
2. Uses the system accent color which is the standard blue used throughout macOS
3. Creates consistency with other selected elements in the settings interface

The change is contained within the GeneralTab.swift file and only affects the background color of the selected panel position, which is exactly what was requested in the issue description. Since this is purely a visual change using standard system colors, it will maintain system-level consistency and accessibility standards.

Automatic fix generated by Onitbot 🤖