### PR TITLE
Fix - Scrolling issue on ChatsView

### DIFF
--- a/macos/Onit/UI/Modifiers/ScreenHeightModifier.swift
+++ b/macos/Onit/UI/Modifiers/ScreenHeightModifier.swift
@@ -18,11 +18,11 @@ struct ScreenHeightModifier: ViewModifier {
                 GeometryReader { geometry in
                     Color.clear
                         .onAppear {
-                            print("ScreenHeightModifier: onAppear")
+//                            print("ScreenHeightModifier: onAppear")
                             updateFromGeometry(geometry)
                         }
                         .onChange(of: geometry.frame(in: .global)) { _, frame in
-                            print("ScreenHeightModifier: onChange frame=\(frame)")
+//                            print("ScreenHeightModifier: onChange frame=\(frame)")
                             
                             let now = Date()
 //                            if now.timeIntervalSince(lastUpdateTime) >= debounceInterval {
@@ -36,15 +36,16 @@ struct ScreenHeightModifier: ViewModifier {
     
     private func updateFromGeometry(_ geometry: GeometryProxy) {
         let point = convertToScreenCoordinates(geometry.frame(in: .global).origin)
-        print("ScreenHeightModifier: converted point=\(point)")
+//        print("ScreenHeightModifier: converted point=\(point)")
         
         if let window = findWindow(at: point) {
             if let screen = window.screen {
-                print("ScreenHeightModifier: found screen frame=\(screen.frame)")
+//                print("ScreenHeightModifier: found screen frame=\(screen.frame)")
             }
             updateScreenHeight(from: window)
         } else {
-            print("ScreenHeightModifier: no window found at point")
+            
+//            print("ScreenHeightModifier: no window found at point")
         }
     }
     
@@ -70,7 +71,7 @@ struct ScreenHeightModifier: ViewModifier {
     
     private func updateScreenHeight(from window: NSWindow) {
         if let screen = window.screen {
-            print("ScreenHeightModifier: updateScreenHeight \(screen.visibleFrame.size.height)")
+//            print("ScreenHeightModifier: updateScreenHeight \(screen.visibleFrame.size.height)")
             DispatchQueue.main.async {
                 self.screenHeight = screen.visibleFrame.size.height
             }

--- a/macos/Onit/UI/Prompt/ChatsView.swift
+++ b/macos/Onit/UI/Prompt/ChatsView.swift
@@ -58,7 +58,7 @@ struct ChatsView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 0) {
+                LazyVStack(spacing: -16) {
                     ForEach(model.currentPrompts ?? []) { prompt in
                         PromptView(prompt: prompt)
                     }

--- a/macos/Onit/UI/Prompt/ChatsView.swift
+++ b/macos/Onit/UI/Prompt/ChatsView.swift
@@ -41,12 +41,9 @@ struct ChatsView: View {
         scrollTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 100_000_000)
             
-            guard !Task.isCancelled else {
-                isScrolling = false
-                return
-            }
+            guard !Task.isCancelled else { return }
             
-            withAnimation(.easeInOut(duration: 0.1)) {
+            withAnimation(.smooth(duration: 0.1)) {
                 proxy.scrollTo(chatsID, anchor: .bottom)
             }
             


### PR DESCRIPTION
Hey @timlenardo,
This is the fix for the strange scroll top/bottom.
Actually there is still a bug when you ask to a model to display a list because of the `Markdown` view in `GeneratedContentView`.
When the height of the Markdown view changes quickly, it becomes inconsistent, which break the auto-scrolling. 
If you replace `Markdown` by a simple `Text`, it's working as expected.

We should change this view someday.