### PR TITLE
User selected system prompts should take priority over recommendations

### DIFF
--- a/macos/Onit/Data/Model/Model+Input.swift
+++ b/macos/Onit/Data/Model/Model+Input.swift
@@ -91,6 +91,7 @@ extension OnitModel {
         shrinkContent()
         
         SystemPromptState.shared.shouldShowSelection = false
+        SystemPromptState.shared.userSelectedPrompt = false
         let suggestedPrompts = promptSuggestionService?.suggestedPrompts ?? []
         SystemPromptState.shared.shouldShowSystemPrompt = shouldSystemPrompt || !suggestedPrompts.isEmpty
     }

--- a/macos/Onit/Data/Services/SystemPromptSuggestionService.swift
+++ b/macos/Onit/Data/Services/SystemPromptSuggestionService.swift
@@ -78,7 +78,8 @@ class SystemPromptSuggestionService {
                 apps: app
             )
             
-            guard model.currentChat?.systemPrompt == nil else { return }
+            guard model.currentChat?.systemPrompt == nil && 
+                  !SystemPromptState.shared.userSelectedPrompt else { return }
             
             if let firstPrompt = self.suggestedPrompts.first {
                 Defaults[.systemPromptId] = firstPrompt.id

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
@@ -18,6 +18,7 @@ struct SystemPromptSelectionRowView: View {
         Button(action: {
             systemPromptId = prompt.id
             prompt.lastUsed = Date()
+            SystemPromptState.shared.userSelectedPrompt = true
         }) {
             HStack {
                 Text(prompt.name)

--- a/macos/Onit/UI/SystemPromptState.swift
+++ b/macos/Onit/UI/SystemPromptState.swift
@@ -15,4 +15,5 @@ final class SystemPromptState {
     var activeApplication: String?
     var shouldShowSystemPrompt: Bool = false
     var shouldShowSelection: Bool = false
+    var userSelectedPrompt: Bool = false
 }


### PR DESCRIPTION
This is a simple fix: If the user has selected a specific SystemPrompt, we shouldn't override that with something from the recommendation system. User selections should always take priority. This PR adds a variable to track user selections and respects it in the recommender. This gets reset when the user creates a new chat so that the recommender can kick back in then!

One thought: it might actually be better to only reset this when the panel is closed and re-opened. If you're in the same session, you might not want the system prompt to change. Let's try this implementation for now and see if it's irritating. 