### PR TITLE
Add cancel generation feature

### DIFF
--- a/macos/Onit/Data/Model/OnitModel.swift
+++ b/macos/Onit/Data/Model/OnitModel.swift
@@ -81,7 +81,8 @@ import SwiftUI
     var generateTask: Task<Void, Never>? = nil
     var generatingPrompt: Prompt?
     var generatingPromptPriorState: GenerationState?
-
+    var generatingInput: Input?
+    
     var client = FetchingClient()
     var updater = SPUStandardUpdaterController(
         startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
@@ -18,6 +18,8 @@ extension KeyboardShortcuts.Name {
     static let resizeWindow = Self("resizeWindow", default: .init(.eight, modifiers: [.command]))
     static let toggleLocalMode = Self(
         "toggleLocalMode", default: .init(.seven, modifiers: [.shift, .command]))
+    static let cancelGeneration = Self(
+        "cancelGeneration", default: .init(.delete, modifiers: [.command]))
 }
 
 extension KeyboardShortcuts.Name: @retroactive CaseIterable {
@@ -27,6 +29,7 @@ extension KeyboardShortcuts.Name: @retroactive CaseIterable {
         .escape,
         .newChat,
         .resizeWindow,
-        .toggleLocalMode
+        .toggleLocalMode,
+        .cancelGeneration
     ]
 }

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -102,6 +102,9 @@ struct KeyboardShortcutsManager {
                     model.resizeWindow()
                 case .toggleLocalMode:
                     model.toggleLocalVsRemoteShortcutAction()
+                case .cancelGeneration:
+                    model.cancelGenerate()
+                    model.textFocusTrigger.toggle()
                 default:
                     print("KeyboardShortcut not handled: \(name)")
                 }

--- a/macos/Onit/UI/Chat/ChatSystemPromptView.swift
+++ b/macos/Onit/UI/Chat/ChatSystemPromptView.swift
@@ -34,6 +34,9 @@ struct ChatSystemPromptView: View {
             Button {
                 withAnimation {
                     isExpanded.toggle()
+                    if !isExpanded {
+                        model.shrinkContent()
+                    }
                 }
             } label: {
                 HStack(alignment: .center, spacing: 6) {

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -9,6 +9,7 @@ import Defaults
 import Foundation
 import MarkdownUI
 import SwiftUI
+import KeyboardShortcuts
 
 struct GeneratedContentView: View {
     @Environment(\.model) var model
@@ -42,8 +43,40 @@ struct GeneratedContentView: View {
                     Spacer()
                 }
             }
+            if isPartial {
+                HStack {
+                    Spacer()
+                    Text(cancelText)
+                        .foregroundStyle(.gray200)
+                        .appFont(.medium13)
+                        .underline()
+                        .onTapGesture {
+                            model.cancelGenerate()
+                            model.textFocusTrigger.toggle()
+                        }
+                        .onHover { isHovering in
+                            if isHovering {
+                                NSCursor.pointingHand.push()
+                            } else {
+                                NSCursor.pop()
+                            }
+                        }
+                    Spacer()
+                }
+            }
         }
     }
+    
+    var cancelText: String {
+        if let keyboardShortcutString = KeyboardShortcuts.getShortcut(for: .cancelGeneration)?
+            .description
+        {
+            "Cancel Generation " + keyboardShortcutString
+        } else {
+            "Cancel Generation"
+        }
+    }
+    
 }
 
 extension Theme {

--- a/macos/Onit/UI/Prompt/GeneratingView.swift
+++ b/macos/Onit/UI/Prompt/GeneratingView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import KeyboardShortcuts
 
 struct GeneratingView: View {
     @Environment(\.model) var model
@@ -28,7 +29,9 @@ struct GeneratingView: View {
             .padding(20)
         }
         .buttonStyle(.plain)
-        .keyboardShortcut(.delete)
+        .keyboardShortcut(delete)
+        .keyboardShortcut(.escape)
+        .help("Cancel generation and restore your prompt (CMD+Delete or Esc)")
     }
 
     var icon: some View {
@@ -38,7 +41,7 @@ struct GeneratingView: View {
 
     var text: some View {
         HStack(spacing: 4) {
-            Text("Cancel")
+            Text("Cancel Generation")
                 .foregroundStyle(.gray200)
             KeyboardShortcutView(shortcut: delete)
                 .foregroundStyle(.gray300)

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -164,7 +164,6 @@ struct GeneralTab: View {
     var experimentalSection: some View {
         Section {
             VStack(spacing: 16) {
-                
                 HStack {
                     Text("Use launch shortcut as a toggle")
                         .font(.system(size: 13))

--- a/macos/Onit/UI/Settings/ShortcutsTab.swift
+++ b/macos/Onit/UI/Settings/ShortcutsTab.swift
@@ -52,6 +52,11 @@ struct ShortcutsTab: View {
                 )
                 .padding()
                 
+                KeyboardShortcuts.Recorder(
+                    "Cancel Generation", name: .cancelGeneration
+                )
+                .padding()
+                
                 Toggle("Disable 'ESC' shortcut", isOn: $escapeShortcutDisabled)
                 .padding()
             }


### PR DESCRIPTION
This PR adds a "Cancel Generation" button, for the case where you send a message and realize it was wrong, but don't want to wait until the generation finishes before fixing it. This is particularly helpful with the reasoning or web search models, which can take a long time to finalize a response. 

I won't merge this PR until we get some cleaner designs, but I wanted to get @Niduank's review on some of the changes I made. 

<img width="266" alt="Screenshot 2025-03-21 at 3 56 11 PM" src="https://github.com/user-attachments/assets/494a8066-3216-4260-95ad-b332aa0fdf27" />
