### PR TITLE
Show overlays at the original click position

### DIFF
--- a/macos/Onit/UI/OS/OverlayManager.swift
+++ b/macos/Onit/UI/OS/OverlayManager.swift
@@ -13,7 +13,13 @@ import SwiftUI
 class OverlayManager {
     static let shared = OverlayManager()
     private var currentOverlay: OverlayWindowController<AnyView>?
+    private var clickPosition: NSPoint?
 
+    /// Captures the current mouse position for later use
+    func captureClickPosition() {
+        clickPosition = NSEvent.mouseLocation
+    }
+    
     /// Presents a new overlay by dismissing any existing one.
     func showOverlay<Content: View>(model: OnitModel, content: Content) {
         // Dismiss the current overlay (if any)
@@ -21,9 +27,11 @@ class OverlayManager {
         currentOverlay = nil
         
         // Create and store the new overlay
-        let overlay = OverlayWindowController(model: model, content: AnyView(content))
+        let overlay = OverlayWindowController(model: model, content: AnyView(content), clickPosition: clickPosition)
         currentOverlay = overlay
-        // Additional logic to actually display the overlay if needed
+        
+        // Reset click position after use
+        clickPosition = nil
     }
     
     /// Dismisses the current overlay.

--- a/macos/Onit/UI/OS/OverlayWindowController.swift
+++ b/macos/Onit/UI/OS/OverlayWindowController.swift
@@ -15,12 +15,14 @@ class OverlayWindowController<Content: View>: NSObject, NSWindowDelegate {
     weak var model: OnitModel?
     var eventMonitor: Any?
     var localEventMonitor: Any?
-
+    var clickPosition: NSPoint?
+    
     private let contentView: Content
 
-    init(model: OnitModel, content: Content) {
+    init(model: OnitModel, content: Content, clickPosition: NSPoint?) {
         self.model = model
         contentView = content
+        self.clickPosition = clickPosition
         super.init()
         createOverlayWindow()
         startEventMonitoring()
@@ -47,13 +49,6 @@ class OverlayWindowController<Content: View>: NSObject, NSWindowDelegate {
 
         overlayWindow = window
         updateOverlayWindowSize()
-
-        if Defaults[.openOnMouseMonitor] {
-            let mouseLocation = NSEvent.mouseLocation
-            if let mouseScreen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
-                window.setFrameOrigin(mouseScreen.frame.origin)
-            }
-        }
 
         positionWindow()
         overlayWindow?.alphaValue = 1.0
@@ -108,7 +103,7 @@ class OverlayWindowController<Content: View>: NSObject, NSWindowDelegate {
             return
         }
 
-        let mouseLocation = NSEvent.mouseLocation
+        let mouseLocation = clickPosition ?? NSEvent.mouseLocation
 
         guard
             let screen = NSScreen.screens.first(where: {

--- a/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
+++ b/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
@@ -77,6 +77,7 @@ struct PaperclipButton: View {
 
     private func handleAddContext() {
         if accessibilityAutoContextEnabled {
+            OverlayManager.shared.captureClickPosition()
             OverlayManager.shared.showOverlay(model: model, content: ContextPickerView())
         } else {
             model.showFileImporter = true

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -175,6 +175,7 @@ struct Toolbar: View {
         @Bindable var model = model
 
         Button {
+            OverlayManager.shared.captureClickPosition()
             OverlayManager.shared.showOverlay(model: model, content: ModelSelectionView())
         } label: {
             HStack(spacing: 0) {


### PR DESCRIPTION
This fixes issue #151: instead of showing the overlays at the mouse-up position, we should show them at the mouse-down position. This means they always show up in approximately the correct place.

https://github.com/user-attachments/assets/48ef1c5c-fc64-47a1-9485-71091f55e05c

