### PR TITLE
Open settings to general tab from Toolbar and Menu

### DIFF
--- a/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eaa06714ba82815bc579e99d21cebc0a6966a4a6663d1cf3a795cfb13366e288",
+  "originHash" : "2b89a53bedeadf3847244f213b3172c697179bb7f901f7d80ad2b1f4f8bf691d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
+++ b/macos/Onit/Menu Bar/Content Rows/MenuSettings.swift
@@ -16,6 +16,7 @@ struct MenuSettings: View {
         MenuBarRow {
             NSApp.activate()
             if NSApp.isActive {
+                model.setSettingsTab(tab: .general)
                 openSettings()
             }
         } leading: {

--- a/macos/Onit/UI/Prompt/Toolbar.swift
+++ b/macos/Onit/UI/Prompt/Toolbar.swift
@@ -257,6 +257,7 @@ struct Toolbar: View {
         Button {
             NSApp.activate()
             if NSApp.isActive {
+                model.setSettingsTab(tab: .general)
                 openSettings()
             }
         } label: {


### PR DESCRIPTION
Small fix to open the 'general' tab of settings when you click on settings from the MacOS toolbar or our toolbar in Onit: 

<img width="1002" alt="Screenshot 2025-03-31 at 10 38 55 AM" src="https://github.com/user-attachments/assets/78870cbc-4d26-4a10-b802-923f28e791a2" />

Our model has a "settingsTab" variable that determines which settings tab to open. Our other buttons open to specific sections (like the Setup Dialogs for models open to the models tab). So, if you don't actively set this to 'general' it will always open the the models tab, which is a bit annoying. 