### PR TITLE
Pinned mode - Feature flag + settings fix + renaming

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -625,7 +625,7 @@ class AccessibilityNotificationsManager: ObservableObject {
         self.showDebug()
         
         // Automatically add AutoContext is only available in Pinned mode.
-        if Defaults[.automaticallyAddAutoContext] && results != nil && !FeatureFlagManager.shared.useScreenModeWithAccessibility {
+        if Defaults[.automaticallyAddAutoContext] && results != nil && !FeatureFlagManager.shared.usePinnedMode {
             state.addAutoContext()
         }
     }

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -624,7 +624,7 @@ class AccessibilityNotificationsManager: ObservableObject {
         self.screenResult.errorMessage = nil
         self.showDebug()
         
-        // Automatically add AutoContext is only available in Pinned mode.
+        // Automatically add AutoContext is only available in tethered mode.
         if Defaults[.automaticallyAddAutoContext] && results != nil && !FeatureFlagManager.shared.usePinnedMode {
             state.addAutoContext()
         }

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -84,7 +84,7 @@ extension Defaults.Keys {
         "localEndpointURL", default: URL(string: "http://localhost:11434")!)
 
     // Feature flags
-    static let useScreenModeWithAccessibility = Key<Bool?>("use_screen_mode_with_accessibility", default: nil)
+    static let usePinnedMode = Key<Bool?>("use_screen_mode_with_accessibility", default: nil)
     
     static let autoContextFromCurrentWindow = Key<Bool>("autoContextFromCurrentWindow", default: true)
     static let autoContextFromHighlights = Key<Bool>("autoContextFromHighlights", default: true)

--- a/macos/Onit/FeatureFlag/FeatureFlagManager.swift
+++ b/macos/Onit/FeatureFlag/FeatureFlagManager.swift
@@ -21,7 +21,7 @@ class FeatureFlagManager: ObservableObject {
     // MARK: - Feature Flags
 
     @Published private(set) var autocontextDemoVideoUrl: String? = nil
-    @Published private(set) var useScreenModeWithAccessibility: Bool = true
+    @Published private(set) var usePinnedMode: Bool = true
 
     // MARK: - Functions
 
@@ -46,8 +46,8 @@ class FeatureFlagManager: ObservableObject {
     }
 
     func toggleScreenModeWithAccessibility(_ enabled: Bool) {
-        Defaults[.useScreenModeWithAccessibility] = enabled
-        useScreenModeWithAccessibility = enabled
+        Defaults[.usePinnedMode] = enabled
+        usePinnedMode = enabled
     }
 
     // MARK: - Objective-C Functions
@@ -70,6 +70,12 @@ class FeatureFlagManager: ObservableObject {
             autocontextDemoVideoUrl = nil
         }
         
-        useScreenModeWithAccessibility = Defaults[.useScreenModeWithAccessibility] ?? true
+        if let pinnedModeEnabled = Defaults[.usePinnedMode] {
+            usePinnedMode = pinnedModeEnabled
+        } else {
+            let pinnedModeFlag = PostHogSDK.shared.isFeatureEnabled("pinned_mode")
+            
+            toggleScreenModeWithAccessibility(pinnedModeFlag)
+        }
     }
 }

--- a/macos/Onit/FeatureFlag/FeatureFlagManager.swift
+++ b/macos/Onit/FeatureFlag/FeatureFlagManager.swift
@@ -45,7 +45,7 @@ class FeatureFlagManager: ObservableObject {
         PostHogSDK.shared.setup(config)
     }
 
-    func toggleScreenModeWithAccessibility(_ enabled: Bool) {
+    func togglePinnedMode(_ enabled: Bool) {
         Defaults[.usePinnedMode] = enabled
         usePinnedMode = enabled
     }
@@ -75,7 +75,7 @@ class FeatureFlagManager: ObservableObject {
         } else {
             let pinnedModeFlag = PostHogSDK.shared.isFeatureEnabled("pinned_mode")
             
-            toggleScreenModeWithAccessibility(pinnedModeFlag)
+            togglePinnedMode(pinnedModeFlag)
         }
     }
 }

--- a/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
+++ b/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
@@ -44,7 +44,7 @@ class PanelStateCoordinator {
         
         stateChangesCancellable = Publishers.CombineLatest(
             AccessibilityPermissionManager.shared.$accessibilityPermissionStatus,
-            FeatureFlagManager.shared.$useScreenModeWithAccessibility
+            FeatureFlagManager.shared.$usePinnedMode
         )
         .filter { $0.0 != .notDetermined }
         .debounce(for: .milliseconds(300), scheduler: RunLoop.main)

--- a/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
@@ -54,11 +54,11 @@ extension OnitRegularPanel {
     func panelResizeEnded(originalPanelWidth: CGFloat) {
         guard wasAnimated, !isAnimating, !state.isWindowDragging else { return }
 
-        // Check if we're in screen mode with accessibility
-        let useScreenWithAccess = FeatureFlagManager.shared.useScreenModeWithAccessibility
+        // Check if pinned mode is enabled
+        let usePinnedMode = FeatureFlagManager.shared.usePinnedMode
         
-        if state.isScreenMode && useScreenWithAccess {
-            // In screen mode, we need to resize all windows that overlap with the panel
+        if state.isScreenMode && usePinnedMode {
+            // In pinned mode, we need to resize all windows that overlap with the panel
             if let screen = state.trackedScreen ?? NSScreen.mouse,
                let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {
                 pinnedManager.resizeWindows(for: screen, isResize: true)

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Position.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Position.swift
@@ -382,7 +382,7 @@ extension OnitPanelState {
         self.showChatView = false
         
         // Check if pinned mode is enabled
-        let useScreenWithAccess = FeatureFlagManager.shared.usePinnedMode
+        let usePinnedMode = FeatureFlagManager.shared.usePinnedMode
         
         NSAnimationContext.runAnimationGroup { context in
             context.duration = animationDuration
@@ -390,8 +390,8 @@ extension OnitPanelState {
             
             panel.animator().setFrame(toPanel, display: false)
 
-            // Only animate other windows if not in accessibility mode
-            if !useScreenWithAccess, let activeWindow = activeWindow, let fromActive = fromActive, let toActive = toActive {
+            // Only animate other windows if not in pinned mode
+            if !usePinnedMode, let activeWindow = activeWindow, let fromActive = fromActive, let toActive = toActive {
                 DispatchQueue.main.asyncAfter(deadline: .now() + (animationDuration / 2)) {
                     self.animation(for: activeWindow, from: fromActive, to: toActive)
                 }
@@ -403,8 +403,8 @@ extension OnitPanelState {
             panel.wasAnimated = true
             panel.animatedFromLeft = abs(fromPanel.maxX - toPanel.minX) <= abs(fromPanel.maxX - toPanel.maxX)
             
-            // Call resizeWindows() AFTER panel animation is complete when in accessibility mode
-            if useScreenWithAccess, let screen = self.trackedScreen ?? NSScreen.mouse {
+            // Call resizeWindows() AFTER panel animation is complete when in pinned mode
+            if usePinnedMode, let screen = self.trackedScreen ?? NSScreen.mouse {
                 DispatchQueue.main.async {
                     do {
                         // Access PanelStateCoordinator and try to resize windows
@@ -434,18 +434,18 @@ extension OnitPanelState {
         self.showChatView = false
         
         // Check if pinned mode is enabled
-        let useScreenWithAccess = FeatureFlagManager.shared.usePinnedMode
+        let usePinnedMode = FeatureFlagManager.shared.usePinnedMode
         
         // Start an asynchronous block that waits for both animations to complete.
         Task { @MainActor in
-            // Reset frames BEFORE the animation starts when in accessibility mode
-            if useScreenWithAccess, let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {
+            // Reset frames BEFORE the animation starts when in pinned mode
+            if usePinnedMode, let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {
                 pinnedManager.resetFramesOnAppChange()
             }
                         
             // Capture the window animation task (if applicable)
             var windowAnimationTask: Task<Void, Never>? = nil
-            if !useScreenWithAccess, let activeWindow = activeWindow, let fromActive = fromActive, let toActive = toActive {
+            if !usePinnedMode, let activeWindow = activeWindow, let fromActive = fromActive, let toActive = toActive {
                 windowAnimationTask = self.animation(for: activeWindow, from: fromActive, to: toActive)
             }
             

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Position.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Position.swift
@@ -381,8 +381,8 @@ extension OnitPanelState {
         self.animateChatView = true
         self.showChatView = false
         
-        // Check if screen mode with accessibility is enabled
-        let useScreenWithAccess = FeatureFlagManager.shared.useScreenModeWithAccessibility
+        // Check if pinned mode is enabled
+        let useScreenWithAccess = FeatureFlagManager.shared.usePinnedMode
         
         NSAnimationContext.runAnimationGroup { context in
             context.duration = animationDuration
@@ -433,8 +433,8 @@ extension OnitPanelState {
         self.animateChatView = true
         self.showChatView = false
         
-        // Check if screen mode with accessibility is enabled
-        let useScreenWithAccess = FeatureFlagManager.shared.useScreenModeWithAccessibility
+        // Check if pinned mode is enabled
+        let useScreenWithAccess = FeatureFlagManager.shared.usePinnedMode
         
         // Start an asynchronous block that waits for both animations to complete.
         Task { @MainActor in

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -121,7 +121,7 @@ struct AccessibilityTab: View {
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
                     }
-                    if !featureFlagsManager.useScreenModeWithAccessibility {
+                    if !featureFlagsManager.usePinnedMode {
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
                                 Text("Automatically Read Current Window")

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -66,7 +66,7 @@ struct GeneralTab: View {
                 HStack(spacing: 8) {
                     Button {
                         isPinnedMode = true
-                        FeatureFlagManager.shared.toggleScreenModeWithAccessibility(true)
+                        FeatureFlagManager.shared.togglePinnedMode(true)
                     } label: {
                         VStack(spacing: 4) {
                             Image(systemName: "pin.fill")
@@ -87,7 +87,7 @@ struct GeneralTab: View {
                     
                     Button {
                         isPinnedMode = false
-                        FeatureFlagManager.shared.toggleScreenModeWithAccessibility(false)
+                        FeatureFlagManager.shared.togglePinnedMode(false)
                     } label: {
                         VStack(spacing: 4) {
                             Image(systemName: "rectangle.split.2x1")

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -13,10 +13,14 @@ struct GeneralTab: View {
     @Default(.launchShortcutToggleEnabled) var launchShortcutToggleEnabled
     @Default(.createNewChatOnPanelOpen) var createNewChatOnPanelOpen
     @Default(.openOnMouseMonitor) var openOnMouseMonitor
+    @Default(.usePinnedMode) var usePinnedMode
     
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
     @State var isAnalyticsEnabled: Bool = PostHogSDK.shared.isOptOut() == false
-    @State private var isPinnedMode: Bool = true
+    
+    var isPinnedMode: Bool {
+        usePinnedMode ?? true
+    }
     
     var body: some View {
         Form {
@@ -65,7 +69,6 @@ struct GeneralTab: View {
             VStack(alignment: .leading, spacing: 16) {
                 HStack(spacing: 8) {
                     Button {
-                        isPinnedMode = true
                         FeatureFlagManager.shared.togglePinnedMode(true)
                     } label: {
                         VStack(spacing: 4) {
@@ -86,7 +89,6 @@ struct GeneralTab: View {
                     .buttonStyle(.plain)
                     
                     Button {
-                        isPinnedMode = false
                         FeatureFlagManager.shared.togglePinnedMode(false)
                     } label: {
                         VStack(spacing: 4) {


### PR DESCRIPTION
* Add PostHog feature flag "pinned_mode" (experiment isn't launched)
* Fix - On app restart, the display mode in settings is always "pinned mode"
* Rename "screen mode with accessibility" by "pinned mode"