### PR TITLE
Main window selection waterfall

### DIFF
--- a/macos/Onit/Accessibility/AXUIElement+Accessors.swift
+++ b/macos/Onit/Accessibility/AXUIElement+Accessors.swift
@@ -287,6 +287,39 @@ extension AXUIElement {
     func bringToFront() {
         AXUIElementPerformAction(self, kAXRaiseAction as CFString)
     }
+
+    public func frontmost() -> AXUIElement? {
+        if let value = self.attribute(forAttribute: kAXFrontmostAttribute as CFString) {
+            return (value as! AXUIElement)
+        }
+        return nil
+    }
+
+    public func mainWindow() -> AXUIElement? {
+        if let value = self.attribute(forAttribute: kAXMainWindowAttribute as CFString) {
+            return (value as! AXUIElement)
+        }
+        return nil    
+    }
+
+    public func focusedWindow() -> AXUIElement? {
+        if let value = self.attribute(forAttribute: kAXFocusedWindowAttribute as CFString) {
+            return (value as! AXUIElement)
+        }
+        return nil
+    }
+
+    public func topLevelUIElement() -> AXUIElement? {
+        if let value = self.attribute(forAttribute: kAXTopLevelUIElementAttribute as CFString) {
+            return (value as! AXUIElement)
+        }
+        return nil
+    }
+
+    // This only returns true if it the element has the keyboard focus. 
+    public func focused() -> Bool? {
+        return self.attribute(forAttribute: kAXFocusedAttribute as CFString) as? Bool
+    }
 }
 
 //

--- a/macos/Onit/Accessibility/Notifications/AccessibilityWindowsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityWindowsManager.swift
@@ -44,21 +44,58 @@ class AccessibilityWindowsManager {
             activeTrackedWindow = trackedWindow
             
             return trackedWindow
-        } else if let window = element.findFirstTargetWindow() {
-
-            let title = window.title() ?? "NA"
-            let trackedWindow = TrackedWindow(element: window, pid: pid, hash: CFHash(window), title: title)
-            
-            if !trackedWindows.contains(trackedWindow) {
-                trackedWindows.append(trackedWindow)
-            }
-            activeTrackedWindow = trackedWindow
-            return trackedWindow
         } else {
-            log.debug("Skipping append for element with role \(element.role() ?? "") title: \(element.title() ?? "")")
+            // Get the application and target windows. 
+            let windows = element.findTargetWindows()
+            let application = AXUIElementCreateApplication(pid)
+            
+            // Try to find a suitable window in this priority order:
+            // 1. A single main window from target windows
+            // 2. The application's mainWindow if it's in our target windows
+            // 3. The application's focusedWindow if it's in our target windows
+            // 4. The first window in the target windows list
+            
+            var selectedWindow: AXUIElement? = nil
+            
+            // First, check if there's exactly one main window in the target windows
+            let mainWindows = windows.filter { $0.isMain() == true }
+            if mainWindows.count == 1 {
+                selectedWindow = mainWindows.first
+            }
+            
+            // If no single main window, try the application's mainWindow
+            if selectedWindow == nil, 
+               let mainWindow = application.mainWindow(), 
+               windows.contains(where: { CFHash($0) == CFHash(mainWindow) }) {
+                selectedWindow = mainWindow
+            }
+            
+            // If no main window, try the application's focusedWindow
+            if selectedWindow == nil, 
+               let focusedWindow = application.focusedWindow(), 
+               windows.contains(where: { CFHash($0) == CFHash(focusedWindow) }) {
+                selectedWindow = focusedWindow
+            }
+            
+            // If all else fails, take the first window
+            if selectedWindow == nil {
+                selectedWindow = windows.first
+            }
+            
+            // Create and return a TrackedWindow if we found a suitable window
+            if let window = selectedWindow {
+                let title = window.title() ?? "NA"
+                let trackedWindow = TrackedWindow(element: window, pid: pid, hash: CFHash(window), title: title)
+                
+                if !trackedWindows.contains(trackedWindow) {
+                    trackedWindows.append(trackedWindow)
+                }
+                activeTrackedWindow = trackedWindow
+                return trackedWindow
+            } else {
+                return nil
+            }
         }
-        
-        return nil
     }
     
     func remove(_ trackedWindow: TrackedWindow) -> TrackedWindow? {


### PR DESCRIPTION
This is to replace findFirstTargetWindow(), which works a surprisingly well, but fails in some cases. My selection waterfall is as follows:

1. A single main window from target windows
.isMain returns true for one window for all the apps I've tested. This is optional though, so we have other fallbacks:

2. The application's mainWindow if it's in our target windows
.mainWindow() returns the correct window for the apps I've tested, but is also an optional attribute. 


3. The application's focusedWindow if it's in our target windows
.focusedWindow() also returns the correct window for apps I've tested. but is also an optional attribute. 

4. The first window in the target windows list
I'm not sure about this. In situations where the 'main' or 'focused' window is not a target window (like if you've selected the Google Hangouts overlay), it may be better to return Nil and not create the target window. What do you think @Niduank ? 