### PR TITLE
Update Onboarding Flow

### DIFF
--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -102,7 +102,7 @@ struct App: SwiftUI.App {
                 }
         }
         
-        Window("",id: windowOnboardingAuthId) {
+        Window("Create an Account or Log In",id: windowOnboardingAuthId) {
             if authFlowStatus != .hideAuth && appState.account == nil {
                 VStack {
                     AuthFlow()

--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -27,7 +27,7 @@ struct App: SwiftUI.App {
     @Default(.launchOnStartupRequested) var launchOnStartupRequested
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
     @Default(.autoContextFromHighlights) var autoContextFromHighlights
-    @Default(.onboardingAuthState) var onboardingAuthState
+    @Default(.authFlowStatus) var authFlowStatus
     
     private let appCoordinator: AppCoordinator
 
@@ -103,9 +103,9 @@ struct App: SwiftUI.App {
         }
         
         Window("",id: windowOnboardingAuthId) {
-            if onboardingAuthState != .hideAuth && appState.account == nil {
+            if authFlowStatus != .hideAuth && appState.account == nil {
                 VStack {
-                    OnboardingAuth(isSignUp: onboardingAuthState == .showSignUp)
+                    AuthFlow()
                 }
                 .background(Color.black)
                 .frame(width: 400, height: 800)
@@ -124,7 +124,7 @@ struct App: SwiftUI.App {
                 dismissWindow(id: windowOnboardingAuthId)
             }
         }
-        .onChange(of: onboardingAuthState) { _, new in
+        .onChange(of: authFlowStatus) { _, new in
             if new == .hideAuth {
                 dismissWindow(id: windowOnboardingAuthId)
             }

--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -122,9 +122,6 @@ class AppState: NSObject {
             } else if localModel == nil || !models.contains(localModel!) {
                 Defaults[.localModel] = models[0]
             }
-            if listedModels.isEmpty {
-                Defaults[.mode] = .local
-            }
             localFetchFailed = false
 
             // Reset the closedNoLocalModels flag when local models are successfully fetched.

--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -238,6 +238,8 @@ class AppState: NSObject {
                     useDeepSeek = true
                     usePerplexity = true
                 }
+                
+                Defaults[.showOnboarding] = false
             } catch {
                 print("Login by token failed with error: \(error)")
             }

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -9,7 +9,7 @@ import CoreGraphics
 import Defaults
 import Foundation
 
-enum OnboardingAuthState: String, Defaults.Serializable {
+enum AuthFlowStatus: String, Defaults.Serializable {
     case hideAuth
     case showSignUp
     case showSignIn
@@ -118,8 +118,8 @@ extension Defaults.Keys {
     static let openOnMouseMonitor = Key<Bool>("openOnMouseMonitor", default: false)
     
     // Onboarding
-    static let showOnboardingAccessibility = Key<Bool>("showOnboardingAccessibility", default: true)
-    static let onboardingAuthState = Key<OnboardingAuthState>("onboardingAuthState", default: .hideAuth)
+    static let showOnboarding = Key<Bool>("showOnboarding", default: true)
+    static let authFlowStatus = Key<AuthFlowStatus>("authFlowStatus", default: .hideAuth)
     
     // Alerts
     static let showTwoWeekProTrialEndedAlert = Key<Bool>("showTwoWeekProTrialEndedAlert", default: false)

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -34,13 +34,13 @@ extension Defaults.Keys {
     static let isPerplexityTokenValidated = Key<Bool>("perplexityTokenValidated", default: false)
     
     // Remote model usage
-    static let useOpenAI = Key<Bool>("useOpenAI", default: false)
-    static let useAnthropic = Key<Bool>("useAnthropic", default: false)
-    static let useXAI = Key<Bool>("useXAI", default: false)
-    static let useGoogleAI = Key<Bool>("useGoogleAI", default: false)
-    static let useDeepSeek = Key<Bool>("useDeepSeek", default: false)
-    static let usePerplexity = Key<Bool>("usePerplexity", default: false)
-    static let useLocal = Key<Bool>("useLocalModel", default: false)
+    static let useOpenAI = Key<Bool>("useOpenAI", default: true)
+    static let useAnthropic = Key<Bool>("useAnthropic", default: true)
+    static let useXAI = Key<Bool>("useXAI", default: true)
+    static let useGoogleAI = Key<Bool>("useGoogleAI", default: true)
+    static let useDeepSeek = Key<Bool>("useDeepSeek", default: true)
+    static let usePerplexity = Key<Bool>("usePerplexity", default: true)
+    static let useLocal = Key<Bool>("useLocalModel", default: true)
     
     static let streamResponse = Key<StreamResponseConfig>("streamResponse", default: StreamResponseConfig.default)
 

--- a/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager+Hint.swift
@@ -12,8 +12,7 @@ import SwiftUI
 extension PanelStateUntetheredManager {
     
     private var shouldShowOnboarding: Bool {
-        let accessibilityPermissionGranted = AccessibilityPermissionManager.shared.accessibilityPermissionStatus == .granted
-        return !accessibilityPermissionGranted && Defaults[.showOnboardingAccessibility]
+        return Defaults[.showOnboarding]
     }
     
     func debouncedShowTetherWindow(state: OnitPanelState, activeScreen: NSScreen) {

--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -50,8 +50,7 @@ struct AuthFlow: View {
                 emailAuthTokenForm
             } else {
                 form
-                if isSignUp { signUpRedirect }
-                else { redirectSection }
+                redirectSection
                 Spacer()
             }
         }

--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingAuth.swift
+//  AuthFlow.swift
 //  Onit
 //
 //  Created by Loyd Kim on 4/30/25.
@@ -11,10 +11,11 @@ import GoogleSignIn
 import GoogleSignInSwift
 import SwiftUI
 
-struct OnboardingAuth: View {
+struct AuthFlow: View {
     @Environment(\.appState) var appState
     
-    @Default(.onboardingAuthState) var onboardingAuthState
+    @Default(.authFlowStatus) var authFlowStatus
+    @Default(.showOnboarding) var showOnboarding
     
     @Default(.useOpenAI) var useOpenAI
     @Default(.useAnthropic) var useAnthropic
@@ -22,12 +23,6 @@ struct OnboardingAuth: View {
     @Default(.useGoogleAI) var useGoogleAI
     @Default(.useDeepSeek) var useDeepSeek
     @Default(.usePerplexity) var usePerplexity
-    
-    private let isSignUp: Bool
-    
-    init(isSignUp: Bool) {
-        self.isSignUp = isSignUp
-    }
 
     @State private var isHoveredContinueWithEmailButton: Bool = false
     @State private var isPressedContinueWithEmailButton: Bool = false
@@ -44,6 +39,10 @@ struct OnboardingAuth: View {
     
     @State private var errorMessageEmail: String = ""
     @State private var errorMessageAuth: String = ""
+    
+    private var isSignUp: Bool {
+        return authFlowStatus == .showSignUp
+    }
     
     var body: some View {
         VStack(alignment: .center, spacing: 42) {
@@ -63,7 +62,7 @@ struct OnboardingAuth: View {
 
 // MARK: - Child Components
 
-extension OnboardingAuth {
+extension AuthFlow {
     private var formAuthButtons: some View {
         VStack(spacing: 4) {
             OnboardingAuthButton(
@@ -139,9 +138,9 @@ extension OnboardingAuth {
             
             Button {
                 if isSignUp {
-                    onboardingAuthState = .showSignIn
+                    authFlowStatus = .showSignIn
                 } else {
-                    onboardingAuthState = .showSignUp
+                    authFlowStatus = .showSignUp
                 }
             } label: {
                 Text(isSignUp ? "Sign In" : "Sign up")
@@ -159,7 +158,8 @@ extension OnboardingAuth {
             redirectSection
             
             Button {
-                onboardingAuthState = .hideAuth
+                authFlowStatus = .hideAuth
+                showOnboarding = false
             } label: {
                 Text(generateSkipText())
                     .styleText(size: 13, weight: .regular, underline: isHoveredSkipButton)
@@ -241,7 +241,7 @@ extension OnboardingAuth {
 
 // MARK: - Private Functions (UI)
 
-extension OnboardingAuth {
+extension AuthFlow {
     private func generateAgreementText() -> AttributedString {
         var agreementText = AttributedString("By continuing with Google or email, you agree to our ")
         agreementText.foregroundColor = .gray300
@@ -295,13 +295,14 @@ extension OnboardingAuth {
             usePerplexity = true
         }
         
-        onboardingAuthState = .hideAuth
+        authFlowStatus = .hideAuth
+        showOnboarding = false
     }
 }
 
 // MARK: - Private Functions (email)
 
-extension OnboardingAuth {
+extension AuthFlow {
     private func validateEmail() -> Bool {
         let emailRegex = "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
@@ -334,7 +335,7 @@ extension OnboardingAuth {
 
 // MARK: - Private Functions (Google, Apple)
 
-extension OnboardingAuth {
+extension AuthFlow {
     private func handleGoogleSignInButton() {
         errorMessageAuth = ""
         

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -67,7 +67,7 @@ struct ContentView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .toolbar {
-            if !showOnboarding {
+            if !showOnboarding && appState.account != nil {
                 ToolbarItem(placement: .navigation) {
                     ToolbarAddButton()
                 }

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -12,12 +12,9 @@ struct ContentView: View {
     @Environment(\.appState) var appState
     @Environment(\.windowState) private var state
     
-    @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
-    
     @Default(.panelWidth) var panelWidth
     @Default(.mode) var mode
-    @Default(.showOnboardingAccessibility) var showOnboardingAccessibility
-    @Default(.onboardingAuthState) var onboardingAuthState
+    @Default(.showOnboarding) var showOnboarding
     @Default(.showTwoWeekProTrialEndedAlert) var showTwoWeekProTrialEndedAlert
     @Default(.hasClosedTrialEndedAlert) var hasClosedTrialEndedAlert
     
@@ -29,42 +26,14 @@ struct ContentView: View {
             set: { state.showFileImporter = $0 }
         )
     }
-    
-    private var shouldShowOnboardingAccessibility: Bool {
-        let accessibilityPermissionGranted = accessibilityPermissionManager.accessibilityPermissionStatus == .granted
-        return !accessibilityPermissionGranted && showOnboardingAccessibility
-    }
-    
-    private var shouldShowOnboardingAuth: Bool {
-        let loggedOut = appState.account == nil
-        let showOnboardingAuth = onboardingAuthState != .hideAuth
-        return loggedOut && showOnboardingAuth
-    }
 
     var body: some View {
         HStack(spacing: -TetheredButton.width / 2) {
             TetheredButton()
             
             ZStack(alignment: .top) {
-                if shouldShowOnboardingAccessibility {
-                    VStack(spacing: 0) {
-                        if state.showChatView {
-                            OnboardingAccessibility().transition(.opacity)
-                        } else {
-                            Spacer()
-                        }
-                    }
-                    .frame(width: panelWidth)
-                    .frame(maxHeight: .infinity)
-                    // .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.black)
-                    .onDisappear {
-                        if appState.account == nil {
-                            onboardingAuthState = .showSignUp
-                        }
-                    }
-                } else if shouldShowOnboardingAuth {
-                    OnboardingAuth(isSignUp: onboardingAuthState == .showSignUp)
+                if showOnboarding {
+                    Onboarding()
                 } else {
                     ZStack {
                         VStack(spacing: 0) {
@@ -96,7 +65,7 @@ struct ContentView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .toolbar {
-            if !shouldShowOnboardingAccessibility {
+            if !showOnboarding {
                 ToolbarItem(placement: .navigation) {
                     ToolbarAddButton()
                 }

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -34,6 +34,8 @@ struct ContentView: View {
             ZStack(alignment: .top) {
                 if showOnboarding {
                     Onboarding()
+                } else if appState.account == nil {
+                    AuthFlow()
                 } else {
                     ZStack {
                         VStack(spacing: 0) {

--- a/macos/Onit/UI/Onboarding/Onboarding.swift
+++ b/macos/Onit/UI/Onboarding/Onboarding.swift
@@ -1,0 +1,52 @@
+//
+//  Onboarding.swift
+//  Onit
+//
+//  Created by Loyd Kim on 5/16/25.
+//
+
+import Defaults
+import SwiftUI
+
+struct Onboarding: View {
+    @Environment(\.appState) var appState
+    @Environment(\.windowState) private var windowState
+    
+    @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
+    
+    @Default(.panelWidth) var panelWidth
+    @Default(.authFlowStatus) var authFlowStatus
+    
+    @State private var skippedAccessibility: Bool = false
+    
+    private var shouldShowOnboardingAccessibility: Bool {
+        let accessibilityNotGranted = accessibilityPermissionManager.accessibilityPermissionStatus != .granted
+        return accessibilityNotGranted && !skippedAccessibility
+    }
+    
+    var body: some View {
+        if shouldShowOnboardingAccessibility {
+            VStack(spacing: 0) {
+                if windowState.showChatView {
+                    OnboardingAccessibility(
+                        skippedAccessibility: $skippedAccessibility
+                    )
+                    .transition(.opacity)
+                } else {
+                    Spacer()
+                }
+            }
+            .frame(width: panelWidth)
+            .frame(maxHeight: .infinity)
+            // .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black)
+            .onDisappear {
+                if appState.account == nil {
+                    authFlowStatus = .showSignUp
+                }
+            }
+        } else  {
+            AuthFlow()
+        }
+    }
+}

--- a/macos/Onit/UI/Onboarding/Onboarding.swift
+++ b/macos/Onit/UI/Onboarding/Onboarding.swift
@@ -40,9 +40,11 @@ struct Onboarding: View {
             .frame(maxHeight: .infinity)
             // .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.black)
-            .onDisappear {
+            .onAppear {
                 if appState.account == nil {
                     authFlowStatus = .showSignUp
+                } else {
+                    authFlowStatus = .hideAuth
                 }
             }
         } else  {

--- a/macos/Onit/UI/Onboarding/OnboardingAccessibility.swift
+++ b/macos/Onit/UI/Onboarding/OnboardingAccessibility.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OnboardingAccessibility: View {
+    var skippedAccessibility: Binding<Bool>
+    
     @State private var isHoveringSkipButton: Bool = false
     @State private var showSkipConfirmation: Bool = false
     
@@ -31,7 +33,10 @@ struct OnboardingAccessibility: View {
             Spacer()
             
             if showSkipConfirmation {
-                OnboardingSkipAccessibility(showSkipConfirmation: $showSkipConfirmation)
+                OnboardingSkipAccessibility(
+                    skippedAccessibility: skippedAccessibility,
+                    showSkipConfirmation: $showSkipConfirmation
+                )
             } else {
                 skipAccessibilityButton
             }

--- a/macos/Onit/UI/Onboarding/OnboardingSkipAccessibility.swift
+++ b/macos/Onit/UI/Onboarding/OnboardingSkipAccessibility.swift
@@ -9,9 +9,14 @@ import Defaults
 import SwiftUI
 
 struct OnboardingSkipAccessibility: View {
+    private var skippedAccessibility: Binding<Bool>
     private var showSkipConfirmation: Binding<Bool>
     
-    init(showSkipConfirmation: Binding<Bool>) {
+    init(
+        skippedAccessibility: Binding<Bool>,
+        showSkipConfirmation: Binding<Bool>
+    ) {
+        self.skippedAccessibility = skippedAccessibility
         self.showSkipConfirmation = showSkipConfirmation
     }
     
@@ -28,7 +33,8 @@ struct OnboardingSkipAccessibility: View {
             HStack {
                 Spacer()
                 Button {
-                    Defaults[.showOnboardingAccessibility] = false
+                    Defaults[.authFlowStatus] = .showSignUp
+                    skippedAccessibility.wrappedValue = true
                 } label: {
                     Text("Yes, continue →")
                         .styleText(size: 13, underline: isHoveringContinueButton)
@@ -77,5 +83,8 @@ extension OnboardingSkipAccessibility {
 
 
 #Preview {
-    OnboardingSkipAccessibility(showSkipConfirmation: .constant(true))
+    OnboardingSkipAccessibility(
+        skippedAccessibility: .constant(false),
+        showSkipConfirmation: .constant(true)
+    )
 }

--- a/macos/Onit/UI/Settings/GeneralTabAccount.swift
+++ b/macos/Onit/UI/Settings/GeneralTabAccount.swift
@@ -84,8 +84,7 @@ extension GeneralTabAccount {
             text: "Create an account",
             action: {
                 authFlowStatus = .showSignUp
-                openWindow(id: windowOnboardingAuthId)
-                setOnboardingAuthWindowToFloat()
+                openPanel()
             },
             background: .blue
         )
@@ -96,8 +95,7 @@ extension GeneralTabAccount {
             text: "Sign in",
             action: {
                 authFlowStatus = .showSignIn
-                openWindow(id: windowOnboardingAuthId)
-                setOnboardingAuthWindowToFloat()
+                openPanel()
             }
         )
     }
@@ -133,5 +131,20 @@ extension GeneralTabAccount {
         TokenManager.token = nil
         appState.account = nil
         Defaults[.authFlowStatus] = .showSignIn
+    }
+    
+    private func openPanel() {
+        let coordinator = PanelStateCoordinator.shared
+        
+        // Open the pinned panel, if it isn't already open, so that the user can see the auth flow forms.
+        if coordinator.state.panel == nil {
+            if let currentScreen = NSScreen.main ?? NSScreen.mouse {
+                let manager = PanelStatePinnedManager.shared
+                
+                manager.hideTetherWindow()
+                coordinator.state.trackedScreen = currentScreen
+                coordinator.state.launchPanel()
+            }
+        }
     }
 }

--- a/macos/Onit/UI/Settings/GeneralTabAccount.swift
+++ b/macos/Onit/UI/Settings/GeneralTabAccount.swift
@@ -12,7 +12,7 @@ struct GeneralTabAccount: View {
     @Environment(\.appState) var appState
     @Environment(\.openWindow) private var openWindow
     
-    @Default(.onboardingAuthState) var onboardingAuthState
+    @Default(.authFlowStatus) var authFlowStatus
     
     @State private var showDeleteAccountAlert: Bool = false
     @State private var accountDeleteError: String = ""
@@ -83,7 +83,7 @@ extension GeneralTabAccount {
             iconText: "👤",
             text: "Create an account",
             action: {
-                onboardingAuthState = .showSignUp
+                authFlowStatus = .showSignUp
                 openWindow(id: windowOnboardingAuthId)
                 setOnboardingAuthWindowToFloat()
             },
@@ -95,7 +95,7 @@ extension GeneralTabAccount {
         SimpleButton(
             text: "Sign in",
             action: {
-                onboardingAuthState = .showSignIn
+                authFlowStatus = .showSignIn
                 openWindow(id: windowOnboardingAuthId)
                 setOnboardingAuthWindowToFloat()
             }
@@ -132,6 +132,6 @@ extension GeneralTabAccount {
     private func logout() {
         TokenManager.token = nil
         appState.account = nil
-        Defaults[.onboardingAuthState] = .showSignIn
+        Defaults[.authFlowStatus] = .showSignIn
     }
 }


### PR DESCRIPTION
* Make onboarding state handling cleaner.
* Rename `OnboardingAuth` to `AuthFlow`, as it isn't only used during onboarding (also used through settings).
* Remove `AuthFlow` from `ContentView` and replace with new `Onboarding` component that now handles both onboarding accessibility and auth flow views during onboarding.
* Auth form now only appears in a popup window when accessing through settings.
* Auth form now only appears in the main onit window when accessing through the onboarding flow.