### PR TITLE
Update: Arrow Hotkeys Breaking User Experience

### DIFF
--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -192,7 +192,7 @@ class OnitPanelState: NSObject {
         isTypingDebounceTask?.cancel()
         
         isTypingDebounceTask = Task {
-            try? await Task.sleep(for: .milliseconds(1000))
+            try? await Task.sleep(for: .milliseconds(2500))
             
             if !Task.isCancelled {
                 await MainActor.run { self.isTyping = false }

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -32,7 +32,7 @@ class OnitPanelState: NSObject {
     /// States
     let systemPromptState: SystemPromptState = .init()
     var isTyping: Bool = false
-    var isTypingDebounceTask: Task<Void, Never>? = nil
+    private var isTypingDebounceTask: Task<Void, Never>? = nil
     
     /// ChatView visibility.
     /// When `showChatView` is true the ChatView is rendered;

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -31,6 +31,8 @@ class OnitPanelState: NSObject {
     
     /// States
     let systemPromptState: SystemPromptState = .init()
+    var isTyping: Bool = false
+    var isTypingDebounceTask: Task<Void, Never>? = nil
     
     /// ChatView visibility.
     /// When `showChatView` is true the ChatView is rendered;
@@ -179,6 +181,22 @@ class OnitPanelState: NSObject {
                 contexts: pendingContextList,
                 input: pendingInput
             )
+        }
+    }
+    
+    // MARK: - Functions
+    
+    func detectIsTyping() {
+        isTyping = true
+        
+        isTypingDebounceTask?.cancel()
+        
+        isTypingDebounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(1000))
+            
+            if !Task.isCancelled {
+                await MainActor.run { self.isTyping = false }
+            }
         }
     }
 }

--- a/macos/Onit/UI/Prompt/FinalContextView.swift
+++ b/macos/Onit/UI/Prompt/FinalContextView.swift
@@ -17,6 +17,7 @@ struct FinalContextView: View {
     @State private var isHoveringInstruction: Bool = false
     @FocusState private var isTextFieldFocused: Bool
     
+    @State private var cursorPosition: Int = 0
     @State private var textHeight: CGFloat = 20
     private let maxHeightLimit: CGFloat = 100
     @StateObject private var audioRecorder = AudioRecorder()
@@ -41,9 +42,12 @@ struct FinalContextView: View {
                 TextViewWrapper(
                     text: Binding(
                         get: { prompt.instruction },
-                        set: { prompt.instruction = $0 }
+                        set: {
+                            prompt.instruction = $0
+                            windowState.detectIsTyping()
+                        }
                     ),
-                    cursorPosition: .constant(prompt.instruction.count),
+                    cursorPosition: $cursorPosition,
                     dynamicHeight: $textHeight,
                     onSubmit: {
                         if isEditing {
@@ -68,6 +72,9 @@ struct FinalContextView: View {
                 .scrollContentBackground(.hidden)
                 .background(.gray800) // To match the TextField style
                 .padding(0) // To match the TextField padding
+                .onChange(of: cursorPosition) {
+                    windowState.detectIsTyping()
+                }
 
                 if isEditing {
                     HStack {

--- a/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
+++ b/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ToggleOutputsView: View {
+    @Environment(\.windowState) var windowState
+    
     var prompt: Prompt
 
     var body: some View {
@@ -21,7 +23,7 @@ struct ToggleOutputsView: View {
 
     var left: some View {
         Button {
-            prompt.updateGenerationIndex(prompt.generationIndex - 1)
+            decrementGenerationIndex()
         } label: {
             Color.clear
                 .frame(width: 20, height: 20)
@@ -29,9 +31,15 @@ struct ToggleOutputsView: View {
                     Image(.chevLeft)
                 }
         }
-        .keyboardShortcut(.leftArrow, modifiers: [])
         .foregroundStyle(prompt.canDecrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canDecrementGeneration)
+        .background {
+            if !windowState.isTyping {
+                Button { decrementGenerationIndex() }
+                label: { EmptyView() }
+                    .keyboardShortcut(.leftArrow, modifiers: [])
+            }
+        }
     }
 
     @ViewBuilder
@@ -45,7 +53,7 @@ struct ToggleOutputsView: View {
 
     var right: some View {
         Button {
-            prompt.updateGenerationIndex(prompt.generationIndex + 1)
+            incrementGenerationIndex()
         } label: {
             Color.clear
                 .frame(width: 20, height: 20)
@@ -53,9 +61,33 @@ struct ToggleOutputsView: View {
                     Image(.chevRight)
                 }
         }
-        .keyboardShortcut(.rightArrow, modifiers: [])
         .foregroundStyle(prompt.canIncrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canIncrementGeneration)
+        .background {
+            if !windowState.isTyping {
+                Button { incrementGenerationIndex() }
+                label: { EmptyView() }
+                    .keyboardShortcut(.rightArrow, modifiers: [])
+            }
+        }
+    }
+}
+
+// MARK: - Private Functions
+
+extension ToggleOutputsView {
+    private func decrementGenerationIndex() {
+        if prompt.generationIndex > 0 {
+            prompt.updateGenerationIndex(prompt.generationIndex - 1)
+        }
+    }
+    
+    private func incrementGenerationIndex() {
+        if let total = prompt.generationCount,
+           prompt.generationIndex + 1 < total
+        {
+            prompt.updateGenerationIndex(prompt.generationIndex + 1)
+        }
     }
 }
 

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -70,9 +70,20 @@ struct PromptCore: View {
         }
         .background {
             if !isEditing {
-                upListener
-                downListener
+                if !windowState.isTyping {
+                    upListener
+                    downListener
+                }
+                
                 newListener
+            }
+        }
+        .onChange(of: editingText?.wrappedValue ?? windowState.pendingInstruction) { _, _ in
+            windowState.detectIsTyping()
+        }
+        .onChange(of: windowState.pendingInstructionCursorPosition) {
+            if !isEditing {
+                windowState.detectIsTyping()
             }
         }
     }


### PR DESCRIPTION
This PR addresses the user-breaking-experience issue where the up, down, right, and left arrow hotkeys constantly interfere with prompt creation.

The arrow hotkeys are now disabled whenever the user is in the middle of typing or moving their cursor, debounced to 1000ms (subject to change).