### PR TITLE
Remove Onit server toggle

### DIFF
--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -423,25 +423,6 @@ class AppState: NSObject {
             models = models.filter { $0.provider != .perplexity }
         }
 
-//        if !useOpenAI || (!subscriptionActive && !isOpenAITokenValidated) {
-//            models = models.filter { $0.provider != .openAI }
-//        }
-//        if !useAnthropic || (!subscriptionActive && !isAnthropicTokenValidated) {
-//            models = models.filter { $0.provider != .anthropic }
-//        }
-//        if !useXAI || (!subscriptionActive && !isXAITokenValidated) {
-//            models = models.filter { $0.provider != .xAI }
-//        }
-//        if !useGoogleAI || (!subscriptionActive && !isGoogleAITokenValidated) {
-//            models = models.filter { $0.provider != .googleAI }
-//        }
-//        if !useDeepSeek || (!subscriptionActive && !isDeepSeekTokenValidated) {
-//            models = models.filter { $0.provider != .deepSeek }
-//        }
-//        if !usePerplexity || (!subscriptionActive && !isPerplexityTokenValidated) {
-//            models = models.filter { $0.provider != .perplexity }
-//        }
-
         // Filter out models from disabled custom providers
         for customProvider in availableCustomProvider {
             models = models.filter { model in

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -12,6 +12,7 @@ import Foundation
 struct ChatStreamingEndpointBuilder {
 
     static func build(
+        useOnitServer: Bool,
         model: AIModel,
         images: [[URL]],
         responses: [String],
@@ -19,7 +20,7 @@ struct ChatStreamingEndpointBuilder {
         systemMessage: String,
         userMessages: [String]
     ) throws -> any StreamingEndpoint {
-        if Defaults[.useOnitChat] {
+        if useOnitServer {
             return ChatStreamingEndpointBuilder.onit(
                 model: model,
                 images: images,

--- a/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
+++ b/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
@@ -19,6 +19,7 @@ actor StreamingClient {
               autoContexts: [[String: String]],
               webSearchContexts: [[(title: String, content: String, source: String, url: URL?)]],
               responses: [String],
+              useOnitServer: Bool,
               model: AIModel,
               apiToken: String?) async throws -> AsyncThrowingStream<String, Error> {
         let userMessages = ChatEndpointMessagesBuilder.user(
@@ -28,6 +29,7 @@ actor StreamingClient {
             autoContexts: autoContexts,
             webSearchContexts: webSearchContexts)
         let endpoint = try ChatStreamingEndpointBuilder.build(
+            useOnitServer: useOnitServer,
             model: model,
             images: images,
             responses: responses,
@@ -36,7 +38,7 @@ actor StreamingClient {
             userMessages: userMessages)
         var eventParser: EventParser?
         
-        if !Defaults[.useOnitChat] && model.provider == .perplexity {
+        if !useOnitServer && model.provider == .perplexity {
             eventParser = PerplexityEventParser(mode: .dataOnly)
         }
 

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -65,7 +65,6 @@ extension Defaults.Keys {
     static let remoteModel = Key<AIModel?>("remoteModel", default: nil)
     static let localModel = Key<String?>("localModel", default: nil)
     static let mode = Key<InferenceMode>("mode", default: .remote)
-    static let useOnitChat = Key<Bool>("useOnitChat", default: false)
     static let availableLocalModels = Key<[String]>("availableLocalModels", default: [])
     static let availableRemoteModels = Key<[AIModel]>("availableRemoteModels", default: [])
     static let availableCustomProviders = Key<[CustomProvider]>(

--- a/macos/Onit/TokenValidation/TokenValidationManager.swift
+++ b/macos/Onit/TokenValidation/TokenValidationManager.swift
@@ -115,17 +115,17 @@ class TokenValidationManager {
         if let provider = model?.provider {
             switch provider {
             case .openAI:
-                return Defaults[.openAIToken]
+                return Defaults[.isOpenAITokenValidated] ? Defaults[.openAIToken] : nil
             case .anthropic:
-                return Defaults[.anthropicToken]
+                return Defaults[.isAnthropicTokenValidated] ? Defaults[.anthropicToken] : nil
             case .xAI:
-                return Defaults[.xAIToken]
+                return Defaults[.isXAITokenValidated] ? Defaults[.xAIToken] : nil
             case .googleAI:
-                return Defaults[.googleAIToken]
+                return Defaults[.isGoogleAITokenValidated] ? Defaults[.googleAIToken] : nil
             case .deepSeek:
-                return Defaults[.deepSeekToken]
+                return Defaults[.isDeepSeekTokenValidated] ? Defaults[.deepSeekToken] : nil
             case .perplexity:
-                return Defaults[.perplexityToken]
+                return Defaults[.isPerplexityTokenValidated] ? Defaults[.perplexityToken] : nil
             case .custom:
                 return nil
             }

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -167,8 +167,9 @@ extension OnitPanelState {
                         throw FetchingError.invalidRequest(message: "Model is required")
                     }
                     let apiToken = TokenValidationManager.getTokenForModel(model)
+                    let useOnitChat = apiToken == nil || apiToken == ""
                     
-                    if Defaults[.useOnitChat] || shouldUseStream(model) {
+                    if useOnitChat || shouldUseStream(model) {
                         prompt.generationState = .streaming
                         let asyncText = try await streamingClient.chat(
                             systemMessage: systemPrompt.prompt,
@@ -179,6 +180,7 @@ extension OnitPanelState {
                             autoContexts: autoContextsHistory,
                             webSearchContexts: webSearchContextsHistory,
                             responses: responsesHistory,
+                            useOnitServer: useOnitChat,
                             model: model,
                             apiToken: apiToken)
                         for try await response in asyncText {

--- a/macos/Onit/UI/Settings/AccountTab.swift
+++ b/macos/Onit/UI/Settings/AccountTab.swift
@@ -20,7 +20,6 @@ struct AccountTab: View {
     @State private var token: String = ""
     @State private var loginPassword: String = ""
 
-    @Default(.useOnitChat) var useOnitChat
     @State private var freeTrialAvailable: Bool?
     @State private var features: [SubscriptionFeature]?
     @State private var setPassword: String = ""
@@ -40,7 +39,6 @@ struct AccountTab: View {
                 google
                 apple
             } else {
-                useOnitChatSection
                 subscriptionSection
                 subscriptionFreeTrialAvailableSection
                 subscriptionFeaturesSection
@@ -207,17 +205,6 @@ struct AccountTab: View {
     func handleLogin(loginResponse: LoginResponse) {
         TokenManager.token = loginResponse.token
         appState.account = loginResponse.account
-    }
-    
-    var useOnitChatSection: some View {
-        HStack {
-            Text("Use Onit Chat")
-                .font(.system(size: 13))
-            Spacer()
-            Toggle("", isOn: $useOnitChat)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-        }
     }
 
     var subscriptionSection: some View {


### PR DESCRIPTION
- In my first pass on the auth business logic, I imagined using Onit server chat completion would be user toggleable.
- On further reflection, we decided that we should just default to using any valid token the user inputs and fallback on the Onit server in its absence.
- This state logic does not represent the logged out state. From now on, users must create an account to use the interface.