### PR TITLE
Parse AX tree on demand

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -51,6 +51,8 @@ class AccessibilityNotificationsManager: ObservableObject {
     private var parseDebounceWorkItem: DispatchWorkItem?
 
     private var timedOutWindowHash: Set<UInt> = []  // Track window's hash that have timed out
+    
+    private var lastActiveWindowPid: pid_t?
 
     // MARK: - Private initializer
 
@@ -92,6 +94,16 @@ class AccessibilityNotificationsManager: ObservableObject {
         
         /// I (Kevin) don't think we should reset the timed out windows
         // timedOutWindowHash.removeAll()
+        
+        lastActiveWindowPid = nil
+    }
+    
+    func fetchAutoContext(pid: pid_t? = nil) {
+        if let pid = pid {
+            retrieveWindowContent(for: pid)
+        } else if let pid = lastActiveWindowPid {
+            retrieveWindowContent(for: pid)
+        }
     }
 
     // MARK: Handling app activated/deactived
@@ -110,12 +122,11 @@ class AccessibilityNotificationsManager: ObservableObject {
         }
 
         currentSource = appName
+        lastActiveWindowPid = processID
         
         if let focusedWindow = processID.getFocusedWindow() {
             handleWindowBounds(for: focusedWindow, elementPid: processID)
         }
-        
-        retrieveWindowContent(for: processID)
     }
     
     private func handleAppDeactivation(appName: String?, processID: pid_t) {
@@ -135,8 +146,6 @@ class AccessibilityNotificationsManager: ObservableObject {
         switch notification {
         case kAXFocusedWindowChangedNotification, kAXMainWindowChangedNotification:
             self.handleWindowBounds(for: element, elementPid: elementPid)
-        case kAXFocusedUIElementChangedNotification, kAXSelectedColumnsChangedNotification, kAXSelectedRowsChangedNotification:
-            self.handleFocusChange(elementPid: elementPid)
         case kAXSelectedTextChangedNotification:
             self.handleSelectionChange(for: element)
         case kAXValueChangedNotification:
@@ -210,12 +219,6 @@ class AccessibilityNotificationsManager: ObservableObject {
                 delegate.accessibilityManager(self, didDeminimizeWindow: firstTrackedWindow)
             }
         }
-    }
-
-    private func handleFocusChange(elementPid: pid_t) {
-        print("Focus change from pid: \(elementPid)")
-        
-        retrieveWindowContent(for: elementPid)
     }
 
     private func handleValueChanged(for element: AXUIElement) {
@@ -432,10 +435,7 @@ class AccessibilityNotificationsManager: ObservableObject {
         self.screenResult.errorMessage = nil
         self.showDebug()
         
-        // Automatically add AutoContext is only available in tethered mode.
-        if Defaults[.automaticallyAddAutoContext] && results != nil && !FeatureFlagManager.shared.usePinnedMode {
-            state.addAutoContext()
-        }
+        state.addAutoContext()
     }
 
     // MARK: Value Changed

--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversManager+Config.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversManager+Config.swift
@@ -14,15 +14,15 @@ extension AccessibilityObserversManager {
         static let notifications: [String] = [
             kAXFocusedWindowChangedNotification,
             kAXMainWindowChangedNotification,
-            kAXFocusedUIElementChangedNotification,
             kAXSelectedTextChangedNotification,
             kAXValueChangedNotification,
-            kAXSelectedColumnsChangedNotification,
-            kAXSelectedRowsChangedNotification,
             kAXWindowMovedNotification,
             kAXWindowResizedNotification,
             kAXWindowCreatedNotification,
             kAXUIElementDestroyedNotification
+            //            kAXFocusedUIElementChangedNotification,
+            //            kAXSelectedColumnsChangedNotification,
+            //            kAXSelectedRowsChangedNotification,
 
             //            kAXAnnouncementRequestedNotification,
             //            kAXApplicationActivatedNotification,

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -88,7 +88,6 @@ extension Defaults.Keys {
     
     static let autoContextFromCurrentWindow = Key<Bool>("autoContextFromCurrentWindow", default: true)
     static let autoContextFromHighlights = Key<Bool>("autoContextFromHighlights", default: true)
-    static let automaticallyAddAutoContext = Key<Bool>("automaticallyAddAutoContext", default: false)
 
     // Web search
     static let webSearchEnabled = Key<Bool>("webSearchEnabled", default: false)

--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -101,6 +101,10 @@ class PanelStateBaseManager: PanelStateManagerLogic {
         return chats
     }
     
+    func fetchWindowContext() {
+        
+    }
+    
     // MARK: - Private functions
     
     private func closePanels() {

--- a/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
+++ b/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
@@ -60,6 +60,10 @@ class PanelStateCoordinator {
         currentManager.filterPanelChats(allChats)
     }
     
+    func fetchWindowContext() {
+        currentManager.fetchWindowContext()
+    }
+    
     private func handleStateChange(accessibilityPermission: AccessibilityPermissionStatus, pinnedModeEnabled: Bool) {
         AccessibilityAnalytics.logPermission(local: accessibilityPermission)
         

--- a/macos/Onit/PanelStateManager/PanelStateManagerLogic.swift
+++ b/macos/Onit/PanelStateManager/PanelStateManagerLogic.swift
@@ -25,4 +25,6 @@ protocol PanelStateManagerLogic {
 
     func filterHistoryChats(_ chats: [Chat]) -> [Chat]
     func filterPanelChats(_ chats: [Chat]) -> [Chat]
+    
+    func fetchWindowContext()
 }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -98,6 +98,10 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         return super.filterPanelChats(chats)
     }
     
+    override func fetchWindowContext() {
+        AccessibilityNotificationsManager.shared.fetchAutoContext()
+    }
+    
     // MARK: - Functions
     
     @objc private func appLaunchedReceived(notification: Notification) {

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
@@ -104,6 +104,14 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
         }
     }
     
+    override func fetchWindowContext() {
+        guard let (trackedWindow, _) = statesByWindow.first(where: {
+            $0.1 === self.state
+        }) else { return }
+        
+        AccessibilityNotificationsManager.shared.fetchAutoContext(pid: trackedWindow.pid)
+    }
+    
     // MARK: - Functions
     
     @objc func appDidBecomeActive(_ notification: Notification) {

--- a/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
+++ b/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
@@ -69,6 +69,11 @@ struct PaperclipButton: View {
 
     private func handleAddContext() {
         if accessibilityAutoContextEnabled {
+            if let panel = state.panel {
+                if !panel.isKeyWindow {
+                    panel.makeKey()
+                }
+            }
             OverlayManager.shared.captureClickPosition()
             let view = ContextPickerView()
                 .environment(\.appState, appState)

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -8,7 +8,6 @@ import AppKit
 struct AccessibilityTab: View {
     @Default(.autoContextFromHighlights) var autoContextFromHighlights
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
-    @Default(.automaticallyAddAutoContext) var automaticallyAddAutoContext
 
     @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
@@ -120,42 +119,6 @@ struct AccessibilityTab: View {
                         Text("Loads context from the active window. Warning: If you notice the application freeze after enabling this, please disable it.")
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
-                    }
-                    if !featureFlagsManager.usePinnedMode {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text("Automatically Read Current Window")
-                                    .font(.system(size: 13))
-                                Spacer()
-                                Toggle(
-                                    "",
-                                    isOn: Binding(
-                                        get: { automaticallyAddAutoContext },
-                                        set: { automaticallyAddAutoContext = $0 }
-                                    )
-                                )
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                            }
-                            Text("When enabled, Onit will automatically capture context from the active window. Please use this feature cautiously, as sensitive information may be unintentionally uploaded.")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.gray200)
-                            if !automaticallyAddAutoContext {
-                                KeyboardShortcuts.Recorder(
-                                    "Shortcut", name: .launchWithAutoContext
-                                )
-                            }
-                        }
-                    } else {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Automatically Read Current Window")
-                                .font(.system(size: 13))
-                                .foregroundStyle(.gray300)
-                            Text("This feature is not available in Pinned mode.")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.gray200)
-                        }
-                        .padding(.vertical, 4)
                     }
                 }
             }

--- a/macos/Onit/UI/Windows/ContextPickerView.swift
+++ b/macos/Onit/UI/Windows/ContextPickerView.swift
@@ -24,7 +24,7 @@ struct ContextPickerView: View {
 
             Button(action: {
                 OverlayManager.shared.dismissOverlay()
-                state.addAutoContext()
+                PanelStateCoordinator.shared.fetchWindowContext()
             }) {
                 ContextPickerItemView(
                     imageRes: .stars, title: "AutoContext", subtitle: "Current window activity")


### PR DESCRIPTION
This is just a replay of @Niduank's PR #213 , which got caught up in a weird merge state. I've rebased it on the most recent main, confirmed that it works, and am just creating a clean PR so the merge goes successfully. 

* Stop listening notifications related to the automatic parsing
* Adding a window's context is handled by StateManagers
* Remove the automaticallyAddAutoContext feature