### PR TITLE
disable the pinned vs tethered toggle for users who havent given acce…

### DIFF
--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -21,7 +21,11 @@ struct GeneralTab: View {
     
     @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
     
-    var isPinnedMode: Bool {
+    private var accessibilityGranted: Bool {
+        accessibilityPermissionManager.accessibilityPermissionStatus == .granted
+    }
+    
+    private var isPinnedMode: Bool {
         usePinnedMode ?? true
     }
     
@@ -68,14 +72,11 @@ struct GeneralTab: View {
     }
 
     var displayModeSection: some View {
-        let accessibilityGranted = accessibilityPermissionManager.accessibilityPermissionStatus == .granted
-        return Section {
+        Section {
             VStack(alignment: .leading, spacing: 16) {
                 HStack(spacing: 8) {
                     Button {
-                        if accessibilityGranted {
-                            FeatureFlagManager.shared.togglePinnedMode(true)
-                        }
+                        FeatureFlagManager.shared.togglePinnedMode(true)
                     } label: {
                         VStack(spacing: 4) {
                             Image(systemName: "pin.fill")
@@ -97,9 +98,7 @@ struct GeneralTab: View {
                     .disabled(!accessibilityGranted)
                     
                     Button {
-                        if accessibilityGranted {
-                            FeatureFlagManager.shared.togglePinnedMode(false)
-                        }
+                        FeatureFlagManager.shared.togglePinnedMode(false)
                     } label: {
                         VStack(spacing: 4) {
                             Image(systemName: "rectangle.split.2x1")
@@ -127,7 +126,7 @@ struct GeneralTab: View {
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
                         Button(action: {
-                            if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+                            if let url = URL(string: MenuCheckForPermissions.link) {
                                 NSWorkspace.shared.open(url)
                             }
                         }) {


### PR DESCRIPTION
…ssibility access

This is a small fix. I realized that we should be disabling the toggle between Pinned mode and Tethered mode if the user hasn't given Accessibility permissions: 

<img width="1341" alt="Screenshot 2025-05-16 at 3 53 13 PM" src="https://github.com/user-attachments/assets/3e5aba1b-2d6a-41cb-a1bf-c8d291747909" />

<img width="1308" alt="Screenshot 2025-05-16 at 3 53 23 PM" src="https://github.com/user-attachments/assets/238d690c-271f-4473-888d-b6c58164d42f" />
