### PR TITLE
disable esc shortcut in pinned mode when our app isn't in the foreground

### DIFF
--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -5,6 +5,7 @@
 //  Created by Kévin Naudin on 11/02/2025.
 //
 
+@preconcurrency import AppKit
 import Defaults
 import KeyboardShortcuts
 import PostHog
@@ -13,10 +14,12 @@ import SwiftData
 @MainActor
 struct KeyboardShortcutsManager {
     
+    private static var didObserveAppActiveNotifications = false
+    
     static func configure() {
         registerSettingsShortcuts()
-        
         registerSystemPromptsShortcuts()
+        observeAppActiveNotificationsIfNeeded()
     }
     
     static func register(systemPrompt: SystemPrompt) {
@@ -33,21 +36,30 @@ struct KeyboardShortcutsManager {
         var names = KeyboardShortcuts.Name.allCases
             .filter { ![.launch, .launchWithAutoContext].contains($0) }
         
-        if Defaults[.escapeShortcutDisabled] {
-            names.removeAll { $0 == .escape }
+        // Remove ESC if needed for pinned mode
+        let isPinned = FeatureFlagManager.shared.usePinnedMode
+        let isForeground = NSApp.isActive
+        let escDisabled = Defaults[.escapeShortcutDisabled]
+        if isPinned {
+            if !isForeground || escDisabled {
+                names.removeAll { $0 == .escape }
+            }
+        } else {
+            if escDisabled {
+                names.removeAll { $0 == .escape }
+            }
         }
         
         do {
             let storedPrompts = try modelContainer.mainContext.fetch(FetchDescriptor<SystemPrompt>())
-            
             for systemPrompt in storedPrompts {
                 names.append(KeyboardShortcuts.Name(systemPrompt.id))
             }
         } catch {
             print("Enabling keyboard shortcuts - Can't fetch local system prompts: \(error)")
         }
-        
         KeyboardShortcuts.enable(names)
+        reevaluateEscShortcut()
     }
 
     static func disable(modelContainer: ModelContainer) {
@@ -130,6 +142,49 @@ struct KeyboardShortcutsManager {
         
         KeyboardShortcuts.onKeyUp(for: name) {
             PanelStateCoordinator.shared.state.systemPromptId = systemPrompt.id
+        }
+    }
+    
+    private static func observeAppActiveNotificationsIfNeeded() {
+        guard !didObserveAppActiveNotifications else { return }
+        didObserveAppActiveNotifications = true
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { notification in
+            DispatchQueue.main.async {
+                reevaluateEscShortcut()
+            }
+        }
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { notification in
+            DispatchQueue.main.async {
+                reevaluateEscShortcut()
+            }
+        }
+    }
+    
+    private static func reevaluateEscShortcut() {
+        let isPinned = FeatureFlagManager.shared.usePinnedMode
+        let isForeground = NSApp.isActive
+        let escDisabled = Defaults[.escapeShortcutDisabled]
+        if isPinned {
+            if isForeground && !escDisabled {
+                KeyboardShortcuts.enable(.escape)
+            } else {
+                KeyboardShortcuts.disable(.escape)
+            }
+        } else {
+            // In non-pinned mode, follow the normal toggle
+            if !escDisabled {
+                KeyboardShortcuts.enable(.escape)
+            } else {
+                KeyboardShortcuts.disable(.escape)
+            }
         }
     }
 }


### PR DESCRIPTION
The 'ESC' shortcut has been annoying me in Pinned mode... basically, in Pinned mode, my intuition is to just leave the panel open at all times. But then we're listening for the ESC notification always, so it breaks "ESC" in all the other apps I'm using. I keep hitting ESC to exit a textfield in xcode or something, and the onit panel closes even though I wanted to leave it open. 

My solution is to only listen for the ESC notification when our process is in the foreground. I implemented this by listening for App activation notifications in the keyboard shortcut manager, but I'm not sure if this is the best way to do this. I'm open to other ideas if you have them @Niduank . What do you think? 