### PR TITLE
Fix - Pinned mode (space changes, window resizes and moves)

### DIFF
--- a/macos/Onit/Accessibility/ProcessIdentifier+Accessibility.swift
+++ b/macos/Onit/Accessibility/ProcessIdentifier+Accessibility.swift
@@ -22,7 +22,7 @@ extension pid_t {
         return getAXUIElement().children() ?? []
     }
     
-    private func findTargetWindows() -> [AXUIElement] {
+    func findTargetWindows() -> [AXUIElement] {
         let windows = self.getRootChildren()
         var targetWindows : [AXUIElement] = []
         

--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -15,6 +15,7 @@ class PanelStateBaseManager: PanelStateManagerLogic {
     // MARK: - Properties
     
     let defaultState = OnitPanelState()
+    let animationDuration: TimeInterval = 0.2
     
     @Published var state: OnitPanelState
     @Published var tetherButtonPanelState: OnitPanelState?

--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -60,7 +60,7 @@ class PanelStateBaseManager: PanelStateManagerLogic {
     // MARK: - Functions
     
     func start() {
-        
+        // Implemented by children
     }
     
     func stop() {
@@ -104,7 +104,7 @@ class PanelStateBaseManager: PanelStateManagerLogic {
     }
     
     func launchPanel(for state: OnitPanelState) {
-        buildPanelIfNeeded(for: state)
+        // Implemented by children
     }
     
     func closePanel(for state: OnitPanelState) {
@@ -113,12 +113,12 @@ class PanelStateBaseManager: PanelStateManagerLogic {
     }
 
     func fetchWindowContext() {
-        
+        // Implemented by children
     }
     
     // MARK: - Private functions
     
-    private func buildPanelIfNeeded(for state: OnitPanelState) {
+    func buildPanelIfNeeded(for state: OnitPanelState) {
         if let existingPanel = state.panel, existingPanel.isVisible {
             existingPanel.makeKeyAndOrderFront(nil)
             existingPanel.orderFrontRegardless()

--- a/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
+++ b/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
@@ -70,7 +70,8 @@ class PanelStateCoordinator {
         }
         
         // This workaround will make the pannel jump on another screen
-        if currentManager is PanelStatePinnedManager, let mouseScreen = NSScreen.mouse, panel.screen != mouseScreen {
+        if currentManager is PanelStatePinnedManager,
+            let mouseScreen = NSScreen.mouse, panel.screen != mouseScreen {
             currentManager.launchPanel(for: targetState)
             return
         }

--- a/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
+++ b/macos/Onit/PanelStateManager/PanelStateCoordinator.swift
@@ -68,6 +68,12 @@ class PanelStateCoordinator {
             currentManager.launchPanel(for: targetState)
             return
         }
+        
+        // This workaround will make the pannel jump on another screen
+        if currentManager is PanelStatePinnedManager, let mouseScreen = NSScreen.mouse, panel.screen != mouseScreen {
+            currentManager.launchPanel(for: targetState)
+            return
+        }
 
         // If we're using the shortcut as a Toggle, dismiss the panel.
         if Defaults[.launchShortcutToggleEnabled] {

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
@@ -25,7 +25,12 @@ extension PanelStatePinnedManager: AccessibilityNotificationsDelegate {
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didMoveWindow window: TrackedWindow) {
         guard state.panelOpened else { return }
 
-        checkIfDragStarted(window: window.element)
+        let isDragging = checkIfDragStarted(window: window.element)
+        
+        // Workaround to handle app which reposition automatically the window (Spectacle, Rectangle, ...)
+        if !isDragging, let panelScreen = state.panel?.screen {
+            resizeWindow(for: panelScreen, window: window.element)
+        }
     }
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didResizeWindow window: TrackedWindow) {
         guard state.panelOpened, let screen = state.panel?.screen else { return }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
@@ -1,0 +1,64 @@
+//
+//  PanelStatePinnedManager+Delegates.swift
+//  Onit
+//
+//  Created by Kévin Naudin on 19/05/2025.
+//
+
+import AppKit
+
+extension PanelStatePinnedManager: AccessibilityNotificationsDelegate {
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didActivateWindow window: TrackedWindow) {
+        guard state.panelOpened, let screen = state.panel?.screen else { return }
+        
+        /// Introduce a delay, as changing spaces causes simultaneous resizing, resulting in a visual glitch:
+        /// 1. The app is resized first by this function from Accessibility
+        /// 2. Then by the NSWorkspace.activeSpaceDidChangeNotification
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.resizeWindow(for: screen, window: window.element)
+        }
+    }
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didActivateIgnoredWindow window: TrackedWindow?) {}
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didMinimizeWindow window: TrackedWindow) {}
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDeminimizeWindow window: TrackedWindow) {}
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDestroyWindow window: TrackedWindow) {}
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didMoveWindow window: TrackedWindow) {
+        guard state.panelOpened else { return }
+
+        checkIfDragStarted(window: window.element)
+    }
+    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didResizeWindow window: TrackedWindow) {
+        guard state.panelOpened, let screen = state.panel?.screen else { return }
+        
+        // Prevent the auto-resizing (from Apple) when moving window from one screen to another one
+        guard draggingWindow == nil else { return }
+        
+        // This avoid simultaneous calls when closing the panel which restore the window's frame
+        guard state.panel?.isAnimating == false else { return }
+        
+        resizeWindow(for: screen, window: window.element, windowFrameChanged: true)
+    }
+}
+
+extension PanelStatePinnedManager: OnitPanelStateDelegate {
+    func panelBecomeKey(state: OnitPanelState) {
+        self.state = state
+        KeyboardShortcutsManager.enable(modelContainer: SwiftDataContainer.appContainer)
+    }
+    
+    func panelResignKey(state: OnitPanelState) {
+        KeyboardShortcutsManager.disable(modelContainer: SwiftDataContainer.appContainer)
+    }
+    
+    func panelStateDidChange(state: OnitPanelState) {
+        if !state.panelOpened {
+            state.trackedScreen = nil
+            
+            activateMouseScreen(forced: true)
+        } else {
+            state.panel?.setLevel(.floating)
+        }
+    }
+    
+    func userInputsDidChange(instruction: String, contexts: [Context], input: Input?) {}
+}

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
@@ -32,8 +32,7 @@ extension PanelStatePinnedManager {
         
         if panel.wasAnimated {
             panel.setFrame(newFrame, display: false)
-            /// TODO: KNA - Pinned mode fixes
-            /// Add some logic here to resize the windows when panel is opened on another screen
+            resizeWindows(for: screen)
         } else {
             panel.resizedApplication = false
             animateEnter(state: state,

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
@@ -44,10 +44,6 @@ extension PanelStatePinnedManager {
     
     func hidePanel(for state: OnitPanelState) {
         guard let panel = state.panel, !panel.isAnimating else { return }
-        
-        if state.currentAnimationTask != nil {
-            state.cancelCurrentAnimation()
-        }
 
         let toPanelX = panel.frame.maxX - 2
         let toPanel = NSRect(origin: NSPoint(x: toPanelX, y: panel.frame.minY), size: NSSize(width: 1, height: panel.frame.height))
@@ -63,8 +59,7 @@ extension PanelStatePinnedManager {
         state: OnitPanelState,
         panel: OnitPanel,
         fromPanel: CGRect,
-        toPanel: CGRect,
-        animationDuration: TimeInterval = 0.2
+        toPanel: CGRect
     ) {
         guard !panel.isAnimating else { return }
         
@@ -97,8 +92,7 @@ extension PanelStatePinnedManager {
     private func animateExit(
         state: OnitPanelState,
         panel: OnitPanel,
-        toPanel: CGRect,
-        animationDuration: TimeInterval = 0.2
+        toPanel: CGRect
     ) {
         guard !panel.isAnimating, panel.frame != toPanel else { return }
         

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -46,7 +46,6 @@ extension PanelStatePinnedManager {
     }
     
     private func tetherHintClicked(screen: NSScreen) {
-        
         state.trackedScreen = screen
         launchPanel(for: state)
     }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -13,7 +13,6 @@ extension PanelStatePinnedManager {
     func debouncedShowTetherWindow(activeScreen: NSScreen) {
         hideTetherWindow()
 
-        tetherHintDetails.showTetherDebounceTimer?.invalidate()
         tetherHintDetails.showTetherDebounceTimer = Timer.scheduledTimer(
             withTimeInterval: tetherHintDetails.showTetherDebounceDelay,
             repeats: false

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -1,0 +1,73 @@
+//
+//  PanelStatePinnedManager+Resize.swift
+//  Onit
+//
+//  Created by Kévin Naudin on 14/05/2025.
+//
+
+import AppKit
+
+extension PanelStatePinnedManager {
+    
+    func resizeWindows(for screen: NSScreen, isPanelResized: Bool = false) {
+        let onitName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+        let appPids = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .filter { $0.localizedName != onitName }
+            .map { $0.processIdentifier }
+         
+        for pid in appPids {
+            let windows = pid.getWindows()
+            
+            for window in windows {
+                resizeWindow(for: screen, window: window, isPanelResized: isPanelResized)
+            }
+        }
+    }
+    
+    func resizeWindow(
+        for screen: NSScreen,
+        window: AXUIElement,
+        windowFrameChanged: Bool = false,
+        isPanelResized: Bool = false
+    ) {
+        if !windowFrameChanged, !isPanelResized { guard !targetInitialFrames.keys.contains(window) else { return } }
+        
+        if let windowFrameConverted = window.getFrame(convertedToGlobalCoordinateSpace: true),
+           let windowScreen = windowFrameConverted.findScreen(),
+           windowScreen == screen,
+           let windowFrame = window.getFrame() {
+            
+            let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
+            let screenFrame = screen.visibleFrame
+            let availableSpace = screenFrame.maxX - windowFrame.maxX
+            
+            if !isPanelResized {
+                if availableSpace < panelWidth {
+                    if !windowFrameChanged {
+                        targetInitialFrames[window] = windowFrame
+                    }
+                    let overlapAmount = panelWidth - availableSpace
+                    let newWidth = windowFrame.width - overlapAmount
+                    let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                    _ = window.setFrame(newFrame)
+                }
+            } else {
+                // If we're already tracking it, then make it move.
+                if targetInitialFrames.keys.contains(window) {
+                    let newWidth = (screenFrame.maxX - windowFrame.origin.x) - panelWidth
+                    let newFrame = CGRect(x: windowFrame.origin.x, y:windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                    _ = window.setFrame(newFrame)
+                } else if availableSpace < panelWidth {
+                    // If we aren't already tracking it and it now needs to get resized, start tracking it.
+                    targetInitialFrames[window] = windowFrame
+                    let overlapAmount = panelWidth - availableSpace
+                    let newWidth = windowFrame.width - overlapAmount
+                    let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                    _ = window.setFrame(newFrame)
+                }
+                
+            }
+        }
+    }
+}

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -10,6 +10,10 @@ import AppKit
 extension PanelStatePinnedManager {
     
     func resizeWindows(for screen: NSScreen, isPanelResized: Bool = false) {
+        guard !isResizingWindows else { return }
+
+        isResizingWindows = true
+        
         let onitName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
         let appPids = NSWorkspace.shared.runningApplications
             .filter { $0.activationPolicy == .regular }
@@ -23,6 +27,8 @@ extension PanelStatePinnedManager {
                 resizeWindow(for: screen, window: window, isPanelResized: isPanelResized)
             }
         }
+        
+        isResizingWindows = false
     }
     
     func resizeWindow(

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -197,11 +197,13 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         }
     }
     
-    func checkIfDragStarted(window: AXUIElement) {
-        guard dragManager.isDragging else { return }
-        guard draggingWindow == nil else { return }
+    func checkIfDragStarted(window: AXUIElement) -> Bool {
+        guard dragManager.isDragging else { return false }
+        guard draggingWindow == nil else { return true }
         
         draggingWindow = window
+        
+        return true
     }
     
     private func onActiveWindowDragEnded() {

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -128,13 +128,12 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     override func launchPanel(for state: OnitPanelState) {
         PostHogSDK.shared.capture("launch_panel", properties: ["displayMode": "pinned"])
         
-        super.launchPanel(for: state)
-        
         hideTetherWindow()
         resetFramesOnAppChange()
         
         attachedScreen = NSScreen.mouse
         
+        buildPanelIfNeeded(for: state)
         showPanel(for: state)
     }
     

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -20,7 +20,8 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     
     // MARK: - Properties
     
-    private var isResizingWindows: Bool = false
+    var isResizingWindows: Bool = false
+    
     private var lastScreenFrame = CGRect.zero
     private var globalMouseMonitor: Any?
     private var localMouseMonitor: Any?

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Combine
 import Defaults
 import PostHog
 import SwiftUI
@@ -25,6 +26,11 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     private var localMouseMonitor: Any?
     
     var attachedScreen: NSScreen?
+    
+    /// Dragging
+    let dragManager = GlobalDragManager()
+    var dragManagerCancellable: AnyCancellable?
+    var draggingWindow: AXUIElement?
     
     // MARK: - Initializer
     
@@ -54,6 +60,13 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         
         AccessibilityNotificationsManager.shared.addDelegate(self)
         
+        dragManagerCancellable = dragManager.$isDragging
+            .sink { isDragging in
+                if !isDragging {
+                    self.onActiveWindowDragEnded()
+                }
+            }
+        
         NSWorkspace.shared.notificationCenter.addObserver(
             self,
             selector: #selector(appLaunchedReceived),
@@ -73,6 +86,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         
         state.addDelegate(self)
         
+        dragManager.startMonitoring()
         activateMouseScreen(forced: true)
     }
 
@@ -89,6 +103,9 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         AccessibilityNotificationsManager.shared.removeDelegate(self)
         NSWorkspace.shared.notificationCenter.removeObserver(self)
         NotificationCenter.default.removeObserver(self)
+        dragManager.stopMonitoring()
+        dragManagerCancellable?.cancel()
+        draggingWindow = nil
         
         state.removeDelegate(self)
         
@@ -160,7 +177,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         resetFramesOnAppChange()
     }
     
-    private func activateMouseScreen(forced: Bool = false) {
+    func activateMouseScreen(forced: Bool = false) {
         if forced {
             lastScreenFrame = .zero
         }
@@ -179,57 +196,27 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
             hideTetherWindow()
         }
     }
-}
-
-extension PanelStatePinnedManager: AccessibilityNotificationsDelegate {
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didActivateWindow window: TrackedWindow) {
-        guard state.panelOpened, let screen = state.panel?.screen else { return }
+    
+    func checkIfDragStarted(window: AXUIElement) {
+        guard dragManager.isDragging else { return }
+        guard draggingWindow == nil else { return }
         
-        /// Introduce a delay, as changing spaces causes simultaneous resizing, resulting in a visual glitch:
-        /// 1. The app is resized first by this function from Accessibility
-        /// 2. Then by the NSWorkspace.activeSpaceDidChangeNotification
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.resizeWindow(for: screen, window: window.element)
-        }
-    }
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didActivateIgnoredWindow window: TrackedWindow?) {}
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didMinimizeWindow window: TrackedWindow) {}
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDeminimizeWindow window: TrackedWindow) {}
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDestroyWindow window: TrackedWindow) {}
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didMoveWindow window: TrackedWindow) {
-        
-    }
-    func accessibilityManager(_ manager: AccessibilityNotificationsManager, didResizeWindow window: TrackedWindow) {
-        guard state.panelOpened, let screen = state.panel?.screen else { return }
-        
-        // This avoid simultaneous calls when closing the panel which restore the window's frame
-        guard state.panel?.isAnimating == false else { return }
-        
-        resizeWindow(for: screen, window: window.element, windowFrameChanged: true)
-    }
-}
-
-extension PanelStatePinnedManager: OnitPanelStateDelegate {
-    func panelBecomeKey(state: OnitPanelState) {
-        self.state = state
-        KeyboardShortcutsManager.enable(modelContainer: SwiftDataContainer.appContainer)
+        draggingWindow = window
     }
     
-    func panelResignKey(state: OnitPanelState) {
-        KeyboardShortcutsManager.disable(modelContainer: SwiftDataContainer.appContainer)
-    }
-    
-    func panelStateDidChange(state: OnitPanelState) {
-        if !state.panelOpened {
-            // resetFramesOnAppChange()
-            
-            state.trackedScreen = nil
-            
-            activateMouseScreen(forced: true)
+    private func onActiveWindowDragEnded() {
+        guard let window = draggingWindow else { return }
+        
+        draggingWindow = nil
+        
+        guard let mouseScreen = NSScreen.mouse,
+              let panelScreen = state.panel?.screen else { return }
+        
+        log.error("same screen: \(mouseScreen === panelScreen)")
+        if mouseScreen === panelScreen {
+            resizeWindow(for: panelScreen, window: window, windowFrameChanged: true)
         } else {
-            state.panel?.setLevel(.floating)
+            targetInitialFrames.removeValue(forKey: window)
         }
     }
-    
-    func userInputsDidChange(instruction: String, contexts: [Context], input: Input?) {}
 }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -61,9 +61,9 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         AccessibilityNotificationsManager.shared.addDelegate(self)
         
         dragManagerCancellable = dragManager.$isDragging
-            .sink { isDragging in
+            .sink { [weak self] isDragging in
                 if !isDragging {
-                    self.onActiveWindowDragEnded()
+                    self?.onActiveWindowDragEnded()
                 }
             }
         
@@ -212,7 +212,6 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         guard let mouseScreen = NSScreen.mouse,
               let panelScreen = state.panel?.screen else { return }
         
-        log.error("same screen: \(mouseScreen === panelScreen)")
         if mouseScreen === panelScreen {
             resizeWindow(for: panelScreen, window: window, windowFrameChanged: true)
         } else {

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Display.swift
@@ -372,8 +372,7 @@ extension PanelStateTetheredManager {
         toActive: CGRect?,
         panel: OnitPanel,
         toPanel: CGRect,
-        steps: Int = 10,
-        animationDuration: TimeInterval = 0.2
+        steps: Int = 10
     ) {
         guard !panel.isAnimating, panel.frame != toPanel else { return }
         
@@ -393,7 +392,7 @@ extension PanelStateTetheredManager {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration / 2) {
                     NSAnimationContext.runAnimationGroup { context in
-                        context.duration = animationDuration
+                        context.duration = self.animationDuration
                         context.timingFunction = CAMediaTimingFunction(name: .easeIn)
                         panel.animator().setFrame(toPanel, display: false)
                     } completionHandler: {

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
@@ -116,8 +116,7 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
         ]
         PostHogSDK.shared.capture("launch_panel", properties: properties)
         
-        super.launchPanel(for: state)
-        
+        buildPanelIfNeeded(for: state)
         showPanel(for: state)
     }
     

--- a/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager+Display.swift
@@ -58,8 +58,7 @@ extension PanelStateUntetheredManager {
         state: OnitPanelState,
         panel: OnitPanel,
         fromPanel: CGRect,
-        toPanel: CGRect,
-        animationDuration: TimeInterval = 0.2
+        toPanel: CGRect
     ) {
         guard !panel.isAnimating else { return }
         
@@ -87,8 +86,7 @@ extension PanelStateUntetheredManager {
         state: OnitPanelState,
         panel: OnitPanel,
         toPanel: CGRect,
-        steps: Int = 10,
-        animationDuration: TimeInterval = 0.2
+        steps: Int = 10
     ) {
         guard !panel.isAnimating, panel.frame != toPanel else { return }
         

--- a/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager.swift
@@ -116,8 +116,7 @@ class PanelStateUntetheredManager: PanelStateBaseManager, ObservableObject {
     override func launchPanel(for state: OnitPanelState) {
         PostHogSDK.shared.capture("launch_panel", properties: ["displayMode": "untethered"])
         
-        super.launchPanel(for: state)
-        
+        buildPanelIfNeeded(for: state)
         showPanel(for: state)
     }
     

--- a/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
@@ -61,7 +61,7 @@ extension OnitRegularPanel {
             // In pinned mode, we need to resize all windows that overlap with the panel
             if let screen = state.trackedScreen ?? NSScreen.mouse,
                let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {
-                pinnedManager.resizeWindows(for: screen, isResize: true)
+                pinnedManager.resizeWindows(for: screen, isPanelResized: true)
             }
         } else {
             // Normal mode - adjust a single active window


### PR DESCRIPTION
## Resizing window
Prevent the window from going underneath the panel.
### Edge cases 
If the user reduce the size of the window
* We remove the initial frame
* After this, if he tried to resize underneath the panel, we store the frame (containing the panel's space).

## Handling space changes
* Display the panel on the active space
* Restore the window's frame of previous space
* Resize the window of active space

## Moving window
We do nothing until the drag ends
* If it's on the panel's screen -> resize the window
* Else -> remove the initial frame