### PR TITLE
Prioritize Highlights when multiple context exists

### DIFF
--- a/macos/Onit/Data/Fetching/ChatEndpointMessagesBuilder.swift
+++ b/macos/Onit/Data/Fetching/ChatEndpointMessagesBuilder.swift
@@ -17,16 +17,10 @@ struct ChatEndpointMessagesBuilder {
         for (index, instruction) in instructions.enumerated() {
             var message = ""
             
-            if let input = inputs[index], !input.selectedText.isEmpty {
-                if let application = input.application {
-                    message += "\n\nSelected Text from \(application): \(input.selectedText)"
-                } else {
-                    message += "\n\nSelected Text: \(input.selectedText)"
-                }
-            }
-            
+     
             // TODO: add error handling for contexts too long & incorrect file types
             if !files[index].isEmpty {
+                message += "\n\nUse the following files as context:"
                 for file in files[index] {
                     if let fileContent = try? String(contentsOf: file, encoding: .utf8) {
                         message += "\n\nFile: \(file.lastPathComponent)\nContent:\n\(fileContent)"
@@ -35,6 +29,7 @@ struct ChatEndpointMessagesBuilder {
             }
             
             if !autoContexts[index].isEmpty {
+                message += "\n\nUse the following application content as context:"
                 for (appName, appContent) in autoContexts[index] {
                     message += "\n\nContent from application \(appName):\n\(appContent)"
                 }
@@ -42,6 +37,7 @@ struct ChatEndpointMessagesBuilder {
             
             // Add web contexts
             if index < webSearchContexts.count && !webSearchContexts[index].isEmpty {
+                message += "\n\nUse the following web search results as context:"
                 for webSearchContext in webSearchContexts[index] {
                     message += "\n\nWeb Search Result: \(webSearchContext.title)"
                     if !webSearchContext.source.isEmpty {
@@ -50,6 +46,16 @@ struct ChatEndpointMessagesBuilder {
                     message += "\n\(webSearchContext.content)"
                 }
             }
+
+           if let input = inputs[index], !input.selectedText.isEmpty { 
+                message += "\n\nUse the following selected text as context. When present, selected text should take priority over other context."
+                if let application = input.application {
+                    message += "\n\nSelected Text from \(application): \(input.selectedText)"
+                } else {
+                    message += "\n\nSelected Text: \(input.selectedText)"
+                }
+            }
+            
 
             // Intuitively, I (tim) think the message should be the last thing.
             // TODO: evaluate this

--- a/macos/Onit/UI/Prompt/GeneratedErrorView.swift
+++ b/macos/Onit/UI/Prompt/GeneratedErrorView.swift
@@ -17,6 +17,7 @@ struct GeneratedErrorView: View {
                 Text(errorDescription)
                     .appFont(.medium14)
                     .foregroundStyle(.warning)
+                    .textSelection(.enabled)
             }
             Spacer()
         }


### PR DESCRIPTION
This is a simple fix, inspired by a bug report from Elise. When multiple types of context exists - i.e. both a HighlightedText and an AutoContext - we should be giving priority to the Highlighted text. This PR accomplishes that with: 

- Move the Highlights to the end, so they're the last thing before the user prompt
- Call out explicitly that highlights should be given priority. 
- Add more explanations about the files/other context. 

I've tested it in a few situations myself and it seems to work!

<img width="1145" alt="Screenshot 2025-05-20 at 12 52 08 PM" src="https://github.com/user-attachments/assets/1f8610ae-b8b5-4b7c-8683-95af70689bd5" />

Note* This was a big problem in the prior iteration, where autocontext was automatically pulled constantly. It will be less of an issue now that users must add the autocontext explicitly. But, it's still good to fix!

