### PR TITLE
Audit and reduce setup dialogs

### DIFF
--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -17,14 +17,9 @@ struct SetUpDialogs: View {
     @State private var fetchingLocal = false
     @State private var debounceTask: DispatchWorkItem?
 
+    @Default(.mode) var mode
     @Default(.closedRemote) var closedRemote
     @Default(.closedLocal) var closedLocal
-    @Default(.closedOpenAI) var closedOpenAI
-    @Default(.closedAnthropic) var closedAnthropic
-    @Default(.closedXAI) var closedXAI
-    @Default(.closedGoogleAI) var closedGoogleAI
-    @Default(.closedDeepSeek) var closedDeepSeek
-    @Default(.closedPerplexity) var closedPerplexity
     @Default(.closedNoLocalModels) var closedNoLocalModels
     @Default(.closedNoRemoteModels) var closedNoRemoteModels
     @Default(.seenLocal) var seenLocal
@@ -109,8 +104,6 @@ struct SetUpDialogs: View {
 //                noRemote
 //                local
 //                restartLocal
-//                expired(.openAI)
-//                expired(.anthropic)
 //            #endif
             
             if availableRemoteModels.isEmpty && appState.remoteFetchFailed && !closedNoRemoteModels {
@@ -132,29 +125,11 @@ struct SetUpDialogs: View {
                 }
                 newRemote(models: newModels)
             }
-            if !closedLocal && availableLocalModels.isEmpty && !seenLocal {
+            if mode == .local && !closedLocal && availableLocalModels.isEmpty && !seenLocal {
                 local
             }
-            if !closedNoLocalModels && availableLocalModels.isEmpty && seenLocal {
+            if mode == .local && !closedNoLocalModels && availableLocalModels.isEmpty && seenLocal {
                 restartLocal
-            }
-            if false && !closedOpenAI {
-                expired(.openAI)
-            }
-            if false && !closedAnthropic {
-                expired(.anthropic)
-            }
-            if false && !closedXAI {
-                expired(.xAI)
-            }
-            if false && !closedGoogleAI {
-                expired(.googleAI)
-            }
-            if false && !closedDeepSeek {
-                expired(.deepSeek)
-            }
-            if false && !closedPerplexity {
-                expired(.perplexity)
             }
         }
     }
@@ -278,38 +253,8 @@ struct SetUpDialogs: View {
         }
     }
 
-    func expired(_ provider: AIModel.ModelProvider) -> some View {
-        SetUpDialog(title: "Couldn't connect to \(provider.title)", buttonText: "Go to Settings") {
-            Text("Onit couldn't connect to remote API providers - your tokens may have expired.")
-        } action: {
-            settings()
-        } closeAction: {
-            switch provider {
-            case .openAI:
-                closedOpenAI = true
-            case .anthropic:
-                closedAnthropic = true
-            case .xAI:
-                closedXAI = true
-            case .googleAI:
-                closedGoogleAI = true
-            case .deepSeek:
-                closedDeepSeek = true
-            case .perplexity:
-                closedPerplexity = true
-            case .custom:
-                break  // TODO: KNA -
-            }
-        }
-    }
-
     func resetAppStorageFlags() {
         closedRemote = false
         closedLocal = false
-        closedOpenAI = false
-        closedAnthropic = false
-        closedXAI = false
-        closedGoogleAI = false
-        closedDeepSeek = false
     }
 }


### PR DESCRIPTION
It seems like the team all agrees that these setup dialogs are mostly annoying, and not that useful:

<img width="402" alt="Screenshot 2025-05-20 at 1 39 10 PM" src="https://github.com/user-attachments/assets/e7e12b4b-4664-4c97-b9c7-972917261576" />

From watching a handful of users onboard, I've been surprised by how many people entirely ignore these ! Now that setup isn't required (i.e. they don't have to input a token), we should remove as many of them as possible. 

This PR: removes some and also makes it so that the local-mode related setup dialogs only show up if/when you try to put the app into local mode. Demo here: 

https://github.com/user-attachments/assets/86361904-e5b9-404a-a612-d69416bd6b74



