### PR TITLE
Make it so that dragging anywhere on the left edge resizes the panel

### DIFF
--- a/macos/Onit/UI/Components/ResizeHandle.swift
+++ b/macos/Onit/UI/Components/ResizeHandle.swift
@@ -29,16 +29,11 @@ struct ResizeHandle: View {
     
     var body: some View {
         ZStack {
-            Image(.cornerResize)
-                .foregroundColor(.gray300)
-                .padding(8)
             // Overlay the non-draggable NSView
             NonDraggableNSView()
-                .frame(width: ResizeHandle.size, height: ResizeHandle.size)
                 .allowsHitTesting(true)
                 .background(Color.clear)
         }
-        .frame(width: ResizeHandle.size, height: ResizeHandle.size)
         .highPriorityGesture(
             DragGesture(minimumDistance: 1, coordinateSpace: .local)
                 .onChanged { value in

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -28,43 +28,39 @@ struct ContentView: View {
     }
 
     var body: some View {
-        HStack(spacing: -TetheredButton.width / 2) {
-            TetheredButton()
-            
-            ZStack(alignment: .top) {
-                if showOnboarding {
-                    Onboarding()
-                } else if appState.account == nil {
-                    AuthFlow()
-                } else {
-                    ZStack {
-                        VStack(spacing: 0) {
-                            Spacer().frame(height: 38)
-                            
-                            PromptDivider()
-                            
-                            if state.showChatView { ChatView().transition(.opacity) }
-                            else { Spacer() }
-                        }
+        ZStack(alignment: .top) {
+            if showOnboarding {
+                Onboarding()
+            } else if appState.account == nil {
+                AuthFlow()
+            } else {
+                ZStack {
+                    VStack(spacing: 0) {
+                        Spacer().frame(height: 38)
                         
-                        if showTwoWeekProTrialEndedAlert {
-                            TwoWeekProTrialEndedAlert()
-                        } else if appState.showFreeLimitAlert {
-                            FreeLimitAlert()
-                        } else if appState.showProLimitAlert {
-                            ProLimitAlert()
-                        }
+                        PromptDivider()
+                        
+                        if state.showChatView { ChatView().transition(.opacity) }
+                        else { Spacer() }
+                    }
+                    
+                    if showTwoWeekProTrialEndedAlert {
+                        TwoWeekProTrialEndedAlert()
+                    } else if appState.showFreeLimitAlert {
+                        FreeLimitAlert()
+                    } else if appState.showProLimitAlert {
+                        ProLimitAlert()
                     }
                 }
             }
-            .background(Color.black)
-            .addBorder(
-                cornerRadius: 14,
-                lineWidth: 2,
-                stroke: .gray600
-            )
-            .edgesIgnoringSafeArea(.top)
         }
+        .background(Color.black)
+        .addBorder(
+            cornerRadius: 14,
+            lineWidth: 2,
+            stroke: .gray600
+        )
+        .edgesIgnoringSafeArea(.top)
         .buttonStyle(PlainButtonStyle())
         .toolbar {
             if !showOnboarding && appState.account != nil {


### PR DESCRIPTION
This update makes it so that clicking on dragging anywhere on the left edge of the Panel will resize it. From observing users, this is what people seem to expect, which makes sense since it's how every other app on Mac works. 

To get this working, I had to move some things around. Specifically, I had to move the TetheredButton out of the ContentView and put it in a new hostingView. This was the only way I could make it so the TetheredButton is on top of the ResizeOverlay, which is on top of the ContentView. 

Here's a demo (with the draggable area in orange so it's clearer): 

https://github.com/user-attachments/assets/dbbf6a97-843e-4604-b516-7cb4fde71db6

