### PR TITLE
add logging around GoogleSignIn failures

### DIFF
--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -347,8 +347,14 @@ extension AuthFlow {
                     return
                 } else if let error = error {
                     errorMessageAuth = error.localizedDescription
+                    PostHog.shared.capture("google_sign_in_error", properties: [
+                        "error": error.localizedDescription
+                    ])
                 } else {
                     errorMessageAuth = "Unknown Google sign in error"
+                    PostHog.shared.capture("google_sign_in_error", properties: [
+                        "error": "Unknown error"
+                    ])
                 }
                 return
             }


### PR DESCRIPTION
I spent all day trying to debug the 'keychain error' issue with GoogleSignIn. It seems to be working now, but I don't have a lot of confidence, since I couldn't understand the root issue. So, I'd like to add these analytics events so that we can track if/when users are running into this. If we see it in production, we will have to continue debugging or remove Google Sign-In until their team finds a consistent solution. 