### PR TITLE
Fix issue with custom model providers

### DIFF
--- a/macos/Onit/Data/Model/CustomProvider.swift
+++ b/macos/Onit/Data/Model/CustomProvider.swift
@@ -10,6 +10,7 @@ class CustomProvider: Codable, Identifiable, Defaults.Serializable {
     var token: String
     var models: [AIModel]
     var isEnabled: Bool
+    var isTokenValidated: Bool
 
     init(name: String, baseURL: String, token: String, models: [AIModel]) {
         self.name = name
@@ -17,12 +18,14 @@ class CustomProvider: Codable, Identifiable, Defaults.Serializable {
         self.token = token
         self.models = models
         self.isEnabled = true
+        self.isTokenValidated = false
     }
 
     static func == (lhs: CustomProvider, rhs: CustomProvider) -> Bool {
         return lhs.name == rhs.name && lhs.baseURL == rhs.baseURL
             && lhs.token == rhs.token && lhs.models == rhs.models
             && lhs.isEnabled == rhs.isEnabled
+            && lhs.isTokenValidated == rhs.isTokenValidated
     }
 
     @MainActor

--- a/macos/Onit/TokenValidation/TokenValidationManager.swift
+++ b/macos/Onit/TokenValidation/TokenValidationManager.swift
@@ -33,46 +33,34 @@ class TokenValidationManager {
                 let endpoint = OpenAIValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .anthropic:
                 let endpoint = AnthropicValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .xAI:
                 let endpoint = XAIValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .googleAI:
                 let endpoint = GoogleAIValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .deepSeek:
                 let endpoint = DeepSeekValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .perplexity:
                 let endpoint = PerplexityValidationEndpoint(apiKey: token)
                 _ = try await FetchingClient().execute(endpoint)
                 state.setValid(provider: provider)
-
+                
             case .custom:
-                // For custom providers, we'll validate by trying to fetch the models list
-                if let customProviderName = Defaults[.remoteModel]?.customProviderName,
-                   let customProvider = Defaults[.availableCustomProviders].first(where: {
-                       $0.name == customProviderName
-                   }),
-                   let url = URL(string: customProvider.baseURL)
-                {
-                    let endpoint = CustomModelsEndpoint(baseURL: url, token: token)
-                    _ = try await FetchingClient().execute(endpoint)
-                    state.setValid(provider: provider)
-                } else {
-                    throw FetchingError.invalidURL
-                }
+                throw FetchingError.invalidRequest(message: "Custom provider token validation is not supported")   
             }
             Self.setTokenIsValid(true)
         } catch let error as FetchingError {

--- a/macos/Onit/TokenValidation/TokenValidationManager.swift
+++ b/macos/Onit/TokenValidation/TokenValidationManager.swift
@@ -108,12 +108,8 @@ class TokenValidationManager {
             Defaults[.isPerplexityTokenValidated] = isValid
         case .custom:
             if let customProviderName = Defaults[.remoteModel]?.customProviderName,
-               let customProvider = Defaults[.availableCustomProviders].first(where: { $0.name == customProviderName }) {
-                var updatedProvider = customProvider
-                updatedProvider.isTokenValidated = isValid
-                if let index = Defaults[.availableCustomProviders].firstIndex(where: { $0.name == customProviderName }) {
-                    Defaults[.availableCustomProviders][index] = updatedProvider
-                }
+               let index = Defaults[.availableCustomProviders].firstIndex(where: { $0.name == customProviderName }) {
+                Defaults[.availableCustomProviders][index].isTokenValidated = isValid
             }
         }
     }

--- a/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderFormView.swift
+++ b/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderFormView.swift
@@ -84,6 +84,7 @@ struct CustomProviderFormView: View {
                 try await provider.fetchModels()
 
                 // If the above doesn't crash, we're good!
+                provider.isTokenValidated = true
                 availableCustomProviders.append(provider)
                 availableRemoteModels.append(contentsOf: provider.models)
                 DispatchQueue.main.async {

--- a/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
+++ b/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
@@ -17,7 +17,6 @@ struct CustomProviderRow: View {
 
     @State private var searchText: String = ""
     @State private var loading = false
-    @State private var validated = false
     @State private var errorMessage: String?
     @State private var showAlert = false
     @State private var showAdvanced: Bool = false
@@ -114,15 +113,20 @@ struct CustomProviderRow: View {
                 Task {
                     loading = true
                     do {
-                        try await provider.fetchModels()
-                        validated = true
+                        await TokenValidationManager.shared.validateToken(provider: .custom, token: provider.token)
+                        if provider.isTokenValidated {
+                            errorMessage = nil
+                        } else {
+                            errorMessage = "Failed to validate token"
+                        }
                     } catch {
-                        errorMessage = "Failed to fetch models: \(error.localizedDescription)"
+                        errorMessage = "Failed to validate token: \(error.localizedDescription)"
+                        provider.isTokenValidated = false
                     }
                     loading = false
                 }
             } label: {
-                if validated {
+                if provider.isTokenValidated {
                     Text("Verified")
                 } else {
                     if loading {

--- a/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
+++ b/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
@@ -110,20 +110,19 @@ struct CustomProviderRow: View {
                 .foregroundColor(.primary)  // Ensure placeholder text is not dimmed
 
             Button {
+                loading = true
+                
                 Task {
-                    loading = true
-                    do {
-                        await TokenValidationManager.shared.validateToken(provider: .custom, token: provider.token)
+                    await TokenValidationManager.shared.validateToken(provider: .custom, token: provider.token)
+                    
+                    DispatchQueue.main.async {
                         if provider.isTokenValidated {
                             errorMessage = nil
                         } else {
                             errorMessage = "Failed to validate token"
                         }
-                    } catch {
-                        errorMessage = "Failed to validate token: \(error.localizedDescription)"
-                        provider.isTokenValidated = false
+                        loading = false
                     }
-                    loading = false
                 }
             } label: {
                 if provider.isTokenValidated {


### PR DESCRIPTION
Custom model providers stopped working (Issue #237) because of how we route requests. We send requests either to OnitChatEndpoint or directly to provider endpoints based on token validation status.

The bug occurred because:

1. Custom providers weren’t storing their token validation status
2. TokenValidationManager didn’t support the .custom enum
3. This caused all custom provider requests to route to OnitChatEndpoints
4. These requests failed since custom models aren’t on our server’s approved list

The fix: Mark custom providers as validated when they’re added, ensuring requests route directly to the provider endpoints instead of our servers.