### PR TITLE
Open panel on fresh start

### DIFF
--- a/macos/Onit/AppDelegate.swift
+++ b/macos/Onit/AppDelegate.swift
@@ -16,6 +16,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let darkAppearance = NSAppearance(named: .darkAqua) {
             NSApp.appearance = darkAppearance
         }
+        // Launch the panel on fresh start so users immediately see Onit
+        DispatchQueue.main.async {
+            PanelStateCoordinator.shared.launchPanel()
+        }
         // This is helpful for debugging the new user experience, but should never be committed!
         //        if let appDomain = Bundle.main.bundleIdentifier {
         //            UserDefaults.standard.removePersistentDomain(forName: appDomain)


### PR DESCRIPTION
## Summary
- launch the panel automatically once the app has finished launching

## Testing
- `swift --version`
- `swift build -c release` *(fails: Could not find Package.swift)*
- `xcodebuild -list -workspace macos/Onit.xcodeproj` *(fails: command not found)*