### PR TITLE
Fix web search shimmer position

### DIFF
--- a/macos/Onit/UI/Components/ContextTag.swift
+++ b/macos/Onit/UI/Components/ContextTag.swift
@@ -83,7 +83,7 @@ struct ContextTag: View {
                     AnyView(iconView)
                 }
                 
-                if isLoading { textView.shimmering() }
+                if isLoading { textView.fixedShimmer() }
                 else { textView }
                 
                 if let caption = caption {

--- a/macos/Onit/UI/Components/FixedShimmer.swift
+++ b/macos/Onit/UI/Components/FixedShimmer.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct FixedShimmer: ViewModifier {
+    @State private var phase: CGFloat = -1
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                GeometryReader { geo in
+                    let gradient = LinearGradient(
+                        colors: [.clear, Color.white.opacity(0.3), .clear],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    Rectangle()
+                        .fill(gradient)
+                        .rotationEffect(.degrees(30))
+                        .offset(x: phase * geo.size.width * 2)
+                        .frame(width: geo.size.width * 3, height: geo.size.height)
+                        .onAppear {
+                            phase = 1
+                        }
+                        .animation(
+                            .linear(duration: 1.2).repeatForever(autoreverses: false),
+                            value: phase
+                        )
+                }
+                .mask(content)
+            }
+    }
+}
+
+extension View {
+    func fixedShimmer() -> some View {
+        modifier(FixedShimmer())
+    }
+}

--- a/macos/Onit/UI/Components/Shimmer.swift
+++ b/macos/Onit/UI/Components/Shimmer.swift
@@ -29,6 +29,6 @@ struct Shimmer: View {
                 height: height
             )
             .cornerRadius(cornerRadius)
-            .shimmering()
+            .fixedShimmer()
     }
 }

--- a/macos/Onit/UI/Prompt/FinalContextView.swift
+++ b/macos/Onit/UI/Prompt/FinalContextView.swift
@@ -145,7 +145,7 @@ struct FinalContextView: View {
                         .foregroundColor(.gray200)
                     Spacer()
                 }
-                .shimmering()
+                .fixedShimmer()
             } else if usingContextOrInput {
                 Button {
                     isExpanded.toggle()

--- a/macos/Onit/UI/Prompt/GeneratingView.swift
+++ b/macos/Onit/UI/Prompt/GeneratingView.swift
@@ -38,7 +38,7 @@ struct GeneratingView: View {
 
     var icon: some View {
         Image(.word)
-            .shimmering()
+            .fixedShimmer()
     }
 
     var text: some View {


### PR DESCRIPTION
## Summary
- prevent the searching indicator from jumping around
- add a new `FixedShimmer` modifier and use it instead of `.shimmering()`

## Testing
- `swift --version`