### PR TITLE
Fix IME phonetic input bug.

### DIFF
--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -80,19 +80,21 @@ struct TextViewWrapper: NSViewRepresentable {
         textView.audioRecorder = audioRecorder
         
         if textView.string != text {
-            let selectedRanges = textView.selectedRanges
-            textView.string = text
-            textView.selectedRanges = selectedRanges
-            
-            if !text.isEmpty {
-                let range = NSRange(location: 0, length: text.count)
-                textView.setTextColor(textColor, range: range)
-                textView.setFont(font, range: range)
+            if audioRecorder.isRecording || audioRecorder.isTranscribing || !textView.hasMarkedText() {
+                let selectedRanges = textView.selectedRanges
+                textView.string = text
+                textView.selectedRanges = selectedRanges
+                
+                if !text.isEmpty {
+                    let range = NSRange(location: 0, length: text.count)
+                    textView.setTextColor(textColor, range: range)
+                    textView.setFont(font, range: range)
+                }
+                
+                // Move cursor to the end of the text
+                let endRange = NSRange(location: text.count, length: 0)
+                textView.setSelectedRange(endRange)
             }
-            
-            // Move cursor to the end of the text
-            let endRange = NSRange(location: text.count, length: 0)
-            textView.setSelectedRange(endRange)
 
             context.coordinator.updateHeight()
         }

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -80,16 +80,16 @@ struct TextViewWrapper: NSViewRepresentable {
         textView.audioRecorder = audioRecorder
         
         if textView.string != text {
+            if !text.isEmpty {
+                let range = NSRange(location: 0, length: text.count)
+                textView.setTextColor(textColor, range: range)
+                textView.setFont(font, range: range)
+            }
+            
             if audioRecorder.isRecording || audioRecorder.isTranscribing || !textView.hasMarkedText() {
                 let selectedRanges = textView.selectedRanges
                 textView.string = text
                 textView.selectedRanges = selectedRanges
-                
-                if !text.isEmpty {
-                    let range = NSRange(location: 0, length: text.count)
-                    textView.setTextColor(textColor, range: range)
-                    textView.setFont(font, range: range)
-                }
                 
                 // Move cursor to the end of the text
                 let endRange = NSRange(location: text.count, length: 0)

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -80,12 +80,6 @@ struct TextViewWrapper: NSViewRepresentable {
         textView.audioRecorder = audioRecorder
         
         if textView.string != text {
-            if !text.isEmpty {
-                let range = NSRange(location: 0, length: text.count)
-                textView.setTextColor(textColor, range: range)
-                textView.setFont(font, range: range)
-            }
-            
             if audioRecorder.isRecording || audioRecorder.isTranscribing || !textView.hasMarkedText() {
                 let selectedRanges = textView.selectedRanges
                 textView.string = text
@@ -94,6 +88,12 @@ struct TextViewWrapper: NSViewRepresentable {
                 // Move cursor to the end of the text
                 let endRange = NSRange(location: text.count, length: 0)
                 textView.setSelectedRange(endRange)
+            }
+            
+            if !text.isEmpty {
+                let range = NSRange(location: 0, length: text.count)
+                textView.setTextColor(textColor, range: range)
+                textView.setFont(font, range: range)
             }
 
             context.coordinator.updateHeight()

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -85,15 +85,15 @@ struct TextViewWrapper: NSViewRepresentable {
                 textView.string = text
                 textView.selectedRanges = selectedRanges
                 
+                if !text.isEmpty {
+                    let range = NSRange(location: 0, length: text.count)
+                    textView.setTextColor(textColor, range: range)
+                    textView.setFont(font, range: range)
+                }
+                
                 // Move cursor to the end of the text
                 let endRange = NSRange(location: text.count, length: 0)
                 textView.setSelectedRange(endRange)
-            }
-            
-            if !text.isEmpty {
-                let range = NSRange(location: 0, length: text.count)
-                textView.setTextColor(textColor, range: range)
-                textView.setFont(font, range: range)
             }
 
             context.coordinator.updateHeight()

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -79,22 +79,20 @@ struct TextViewWrapper: NSViewRepresentable {
         // Update waveform and loading state
         textView.audioRecorder = audioRecorder
         
-        if textView.string != text {
-            if audioRecorder.isRecording || audioRecorder.isTranscribing || !textView.hasMarkedText() {
-                let selectedRanges = textView.selectedRanges
-                textView.string = text
-                textView.selectedRanges = selectedRanges
-                
-                if !text.isEmpty {
-                    let range = NSRange(location: 0, length: text.count)
-                    textView.setTextColor(textColor, range: range)
-                    textView.setFont(font, range: range)
-                }
-                
-                // Move cursor to the end of the text
-                let endRange = NSRange(location: text.count, length: 0)
-                textView.setSelectedRange(endRange)
+        if textView.string != text && !textView.hasMarkedText() {
+            let selectedRanges = textView.selectedRanges
+            textView.string = text
+            textView.selectedRanges = selectedRanges
+            
+            if !text.isEmpty {
+                let range = NSRange(location: 0, length: text.count)
+                textView.setTextColor(textColor, range: range)
+                textView.setFont(font, range: range)
             }
+            
+            // Move cursor to the end of the text
+            let endRange = NSRange(location: text.count, length: 0)
+            textView.setSelectedRange(endRange)
 
             context.coordinator.updateHeight()
         }

--- a/macos/Onit/UI/Prompt/PromptCoreFooter.swift
+++ b/macos/Onit/UI/Prompt/PromptCoreFooter.swift
@@ -31,7 +31,7 @@ struct PromptCoreFooter: View {
             Spacer()
             
             HStack(spacing: 4) {
-                MicrophoneButton(audioRecorder: audioRecorder)
+//                MicrophoneButton(audioRecorder: audioRecorder)
                 PromptCoreFooterButton(
                     text: "􀅇 Send",
                     disabled: windowState.pendingInstruction.isEmpty,

--- a/macos/Onit/UI/Prompt/PromptCoreFooter.swift
+++ b/macos/Onit/UI/Prompt/PromptCoreFooter.swift
@@ -31,7 +31,7 @@ struct PromptCoreFooter: View {
             Spacer()
             
             HStack(spacing: 4) {
-//                MicrophoneButton(audioRecorder: audioRecorder)
+                MicrophoneButton(audioRecorder: audioRecorder)
                 PromptCoreFooterButton(
                     text: "􀅇 Send",
                     disabled: windowState.pendingInstruction.isEmpty,


### PR DESCRIPTION
Fix for adding in IME text inputs. Texted with Japanese Romaji and Chinese Pinyin.

Notes: 

- From testing, I’ve noticed that the audio recorder functionality is broken in that the lack of a valid API key causes issues with how the audio recorder adds/removes spacing in the text input view to make room for the `AudioRecorder`. Therefore, I’ve removed (commented out) the audio recorder button (`MicrophoneButton` in `PromptCoreFooter`) for now until we resolve the issue on the server.
- I’ve also done a look-see on any other external features that rely on the code block that is now gated within the `audioRecorder.isRecording || audioRecorder.isTranscribing || !textView.hasMarkedText()` conditional in `updateNSView`, and I believe that the only feature that was relying on that logic was the audio transcription feature, so this update shouldn't break anything. Please double-check @timlenardo 