### PR TITLE
Fix web search button active styling

### DIFF
--- a/macos/Onit/UI/Prompt/WebSearchButton.swift
+++ b/macos/Onit/UI/Prompt/WebSearchButton.swift
@@ -15,6 +15,8 @@ struct WebSearchButton: View {
             icon: .web,
             iconSize: 17,
             action: { toggleWebSearch() },
+            isActive: webSearchEnabled,
+            activeColor: .white,
             inactiveColor:
                 webSearchEnabled ? .blue400 :
                 !isTavilyAPITokenValidated ? .gray700 :


### PR DESCRIPTION
## Summary
- when toggling web search, highlight the button in the toolbar similar to the Local Mode button
- keep the icon white when active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a0f373138832f993f7b666f97bc28