### PR TITLE
Identify users in PostHog

### DIFF
--- a/macos/Onit/Analytics/AnalyticsManager+Account.swift
+++ b/macos/Onit/Analytics/AnalyticsManager+Account.swift
@@ -8,7 +8,7 @@
 import PostHog
 
 extension AnalyticsManager {
-    struct Account {
+    struct AccountEvents {
         static func createAccountPressed() {
             AnalyticsManager.sendCommonEvent(event: "account_create")
         }

--- a/macos/Onit/Analytics/AnalyticsManager+Identity.swift
+++ b/macos/Onit/Analytics/AnalyticsManager+Identity.swift
@@ -6,6 +6,7 @@
 //
 
 import PostHog
+import Foundation
 
 extension AnalyticsManager {
     struct Identity {
@@ -14,7 +15,7 @@ extension AnalyticsManager {
             if let email = account.email ?? account.appleEmail {
                 properties["email"] = email
             }
-            PostHogSDK.shared.identify(String(account.id), properties: properties)
+            PostHogSDK.shared.identify(String(account.id), userProperties: properties)
         }
     }
 }

--- a/macos/Onit/Analytics/AnalyticsManager+Identity.swift
+++ b/macos/Onit/Analytics/AnalyticsManager+Identity.swift
@@ -1,0 +1,21 @@
+//
+//  AnalyticsManager+Identity.swift
+//  Onit
+//
+//  Created by Codex AI on 2025-XX-XX.
+//
+
+import PostHog
+
+extension AnalyticsManager {
+    struct Identity {
+        static func identify(account: Account) {
+            var properties: [String: Any] = [:]
+            if let email = account.email ?? account.appleEmail {
+                properties["email"] = email
+            }
+            PostHogSDK.shared.identify(String(account.id), properties: properties)
+        }
+    }
+}
+

--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -170,7 +170,10 @@ struct App: SwiftUI.App {
         if TokenManager.token != nil && appState.account == nil {
             Task {
                 let client = FetchingClient()
-                appState.account = try? await client.getAccount()
+                if let fetched = try? await client.getAccount() {
+                    appState.account = fetched
+                    AnalyticsManager.Identity.identify(account: fetched)
+                }
             }
         }
     }

--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -168,7 +168,7 @@ struct App: SwiftUI.App {
 
     private func restoreSession() {
         if TokenManager.token != nil && appState.account == nil {
-            Task {
+            Task { @MainActor in 
                 let client = FetchingClient()
                 if let fetched = try? await client.getAccount() {
                     appState.account = fetched

--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -223,12 +223,13 @@ class AppState: NSObject {
         Task { @MainActor in
             do {
                 let loginResponse = try await FetchingClient().loginToken(loginToken: token)
-                
+
                 AnalyticsManager.Auth.success(provider: provider)
                 TokenManager.token = loginResponse.token
                 account = loginResponse.account
 
                 if loginResponse.isNewAccount {
+                    AnalyticsManager.Identity.identify(account: loginResponse.account)
                     useOpenAI = true
                     useAnthropic = true
                     useXAI = true

--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -286,8 +286,9 @@ extension AuthFlow {
     private func handleLogin(loginResponse: LoginResponse) {
         TokenManager.token = loginResponse.token
         appState.account = loginResponse.account
-        
+
         if loginResponse.isNewAccount {
+            AnalyticsManager.Identity.identify(account: loginResponse.account)
             useOpenAI = true
             useAnthropic = true
             useXAI = true

--- a/macos/Onit/UI/Settings/GeneralTabAccount.swift
+++ b/macos/Onit/UI/Settings/GeneralTabAccount.swift
@@ -82,7 +82,7 @@ extension GeneralTabAccount {
             iconText: "👤",
             text: "Create an account",
             action: {
-                AnalyticsManager.Account.createAccountPressed()
+                AnalyticsManager.AccountEvents.createAccountPressed()
                 authFlowStatus = .showSignUp
                 openPanel()
             },
@@ -94,7 +94,7 @@ extension GeneralTabAccount {
         SimpleButton(
             text: "Sign in",
             action: {
-                AnalyticsManager.Account.signInPressed()
+                AnalyticsManager.AccountEvents.signInPressed()
                 authFlowStatus = .showSignIn
                 openPanel()
             }
@@ -105,7 +105,7 @@ extension GeneralTabAccount {
         SimpleButton(
             text: "Log out",
             action: {
-                AnalyticsManager.Account.logoutPressed()
+                AnalyticsManager.AccountEvents.logoutPressed()
                 logout()
             }
         )
@@ -116,7 +116,7 @@ extension GeneralTabAccount {
             text: "Delete account",
             textColor: .red,
             action: {
-                AnalyticsManager.Account.deletePressed()
+                AnalyticsManager.AccountEvents.deletePressed()
                 showDeleteAccountAlert = true
             },
             background: .redBrick

--- a/macos/Onit/UI/Settings/GeneralTabAccountAlert.swift
+++ b/macos/Onit/UI/Settings/GeneralTabAccountAlert.swift
@@ -107,7 +107,7 @@ extension GeneralTabAccountAlert {
             isHovered: $isHoveredCancel,
             isPressed: $isPressedCancel
         ) {
-            AnalyticsManager.Account.deleteConfirmationCancelPressed()
+            AnalyticsManager.AccountEvents.deleteConfirmationCancelPressed()
             show.wrappedValue.toggle()
         }
     }
@@ -131,7 +131,7 @@ extension GeneralTabAccountAlert {
 extension GeneralTabAccountAlert {
     @MainActor
     private func deleteAccount() {
-        AnalyticsManager.Account.deleteConfirmationDeletePressed()
+        AnalyticsManager.AccountEvents.deleteConfirmationDeletePressed()
         
         accountDeleteError = ""
         let client = FetchingClient()


### PR DESCRIPTION
## Summary
- add `AnalyticsManager.Identity` for PostHog `.identify`
- identify new users on login
- identify existing users once when restoring session

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683a0feb3c88832fae7fd9072999a929