### PR TITLE
remove redundant logic for disabling escape

### DIFF
--- a/macos/Onit/UI/Panels/State/OnitPanelState+NSWindowDelegate.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+NSWindowDelegate.swift
@@ -13,6 +13,10 @@ extension OnitPanelState: NSWindowDelegate {
         notifyDelegates { $0.panelBecomeKey(state: self) }
     }
 
+    func windowDidResignKey(_ notification: Notification) {
+        notifyDelegates { $0.panelResignKey(state: self) }
+    }
+
     func windowWillMiniaturize(_ notification: Notification) {
         if !panelMiniaturized {
             panelMiniaturized = true


### PR DESCRIPTION
The logic for observing active applications and re-evaluating the escape shortcut is now redundant, since we're calling KeyboardShortcutManager's enable and disable functions when we receive on **panelBecomeKey** and **panelResignKey** notifications. So basically, whenever the panel's not active, we've _already_ disabled the shortcuts. The existing logic was actually causing bugs by re-enabling the escape shortcut in situations where it should not have been enabled. This change fixes it. 