### PR TITLE
Add Conventional display mode

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -77,6 +77,8 @@ extension Defaults.Keys {
 
     // Feature flags
     static let usePinnedMode = Key<Bool?>("use_screen_mode_with_accessibility", default: nil)
+    static let displayMode = Key<DisplayMode>("displayMode", default: .pinned)
+    static let conventionalPanelFrame = Key<NSRect?>("conventionalPanelFrame", default: nil)
     
     static let autoContextFromCurrentWindow = Key<Bool>("autoContextFromCurrentWindow", default: true)
     static let autoContextFromHighlights = Key<Bool>("autoContextFromHighlights", default: true)

--- a/macos/Onit/Data/Structures/DisplayMode.swift
+++ b/macos/Onit/Data/Structures/DisplayMode.swift
@@ -1,0 +1,7 @@
+import Defaults
+
+enum DisplayMode: String, CaseIterable, Codable, Defaults.Serializable {
+    case pinned
+    case tethered
+    case conventional
+}

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -36,7 +36,7 @@ struct KeyboardShortcutsManager {
             .filter { ![.launch, .launchWithAutoContext].contains($0) }
         
         // Remove ESC if needed for pinned mode
-        let isPinned = FeatureFlagManager.shared.usePinnedMode
+        let isPinned = FeatureFlagManager.shared.displayMode == .pinned
         let isForeground = NSApp.isActive
         let escDisabled = Defaults[.escapeShortcutDisabled]
         if isPinned {

--- a/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Delegates.swift
@@ -1,0 +1,26 @@
+//
+//  PanelStateConventionalManager+Delegates.swift
+//  Onit
+//
+//  Created by Codex on 2024-06-01.
+//
+
+import AppKit
+
+extension PanelStateConventionalManager: OnitPanelStateDelegate {
+    func panelBecomeKey(state: OnitPanelState) {
+        self.state = state
+        KeyboardShortcutsManager.enable(modelContainer: SwiftDataContainer.appContainer)
+    }
+    func panelResignKey(state: OnitPanelState) {
+        KeyboardShortcutsManager.disable(modelContainer: SwiftDataContainer.appContainer)
+    }
+    func panelStateDidChange(state: OnitPanelState) {
+        if !state.panelOpened {
+            activateMouseScreen(forced: true)
+        } else {
+            state.panel?.setLevel(.floating)
+        }
+    }
+    func userInputsDidChange(instruction: String, contexts: [Context], input: Input?) { }
+}

--- a/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Delegates.swift
@@ -19,7 +19,7 @@ extension PanelStateConventionalManager: OnitPanelStateDelegate {
         if !state.panelOpened {
             activateMouseScreen(forced: true)
         } else {
-            state.panel?.setLevel(.floating)
+            state.panel?.setLevel(.normal)
         }
     }
     func userInputsDidChange(instruction: String, contexts: [Context], input: Input?) { }

--- a/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Display.swift
@@ -1,0 +1,42 @@
+//
+//  PanelStateConventionalManager+Display.swift
+//  Onit
+//
+//  Created by Codex on 2024-06-01.
+//
+
+import AppKit
+import Defaults
+
+extension PanelStateConventionalManager {
+    func showPanel(for state: OnitPanelState) {
+        guard let panel = state.panel else { return }
+
+        panel.makeKeyAndOrderFront(nil)
+
+        var targetFrame: NSRect?
+        if let stored = Defaults[.conventionalPanelFrame], stored.findScreen() != nil {
+            targetFrame = stored
+        } else if let screen = NSScreen.mouse {
+            targetFrame = NSRect(
+                x: screen.visibleFrame.maxX - state.panelWidth,
+                y: screen.visibleFrame.minY,
+                width: state.panelWidth,
+                height: screen.visibleFrame.height
+            )
+        }
+
+        if let frame = targetFrame {
+            panel.setFrame(frame, display: true)
+        }
+    }
+
+    func hidePanel(for state: OnitPanelState) {
+        guard let panel = state.panel else { return }
+        panel.hide()
+        state.panel = nil
+        if let screen = NSScreen.mouse {
+            debouncedShowTetherWindow(activeScreen: screen)
+        }
+    }
+}

--- a/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager+Hint.swift
@@ -1,0 +1,114 @@
+//
+//  PanelStateConventionalManager+Hint.swift
+//  Onit
+//
+//  Created by Codex on 2024-06-01.
+//
+
+import SwiftUI
+
+extension PanelStateConventionalManager {
+    func debouncedShowTetherWindow(activeScreen: NSScreen) {
+        hideTetherWindow()
+
+        tetherHintDetails.showTetherDebounceTimer = Timer.scheduledTimer(
+            withTimeInterval: tetherHintDetails.showTetherDebounceDelay,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+                self.showTetherWindow(activeScreen: activeScreen)
+            }
+        }
+    }
+
+    private func showTetherWindow(activeScreen: NSScreen) {
+         let tetherView = ExternalTetheredButton(
+            onClick: { [weak self] in
+                self?.tetherHintClicked(screen: activeScreen)
+            },
+            onDrag: { [weak self] translation in
+                self?.tetheredWindowMoved(screen: activeScreen, y: translation)
+            }
+         ).environment(\.windowState, state)
+
+        let buttonView = NSHostingView(rootView: tetherView)
+        tetherHintDetails.tetherWindow.contentView = buttonView
+        tetherHintDetails.lastYComputed = nil
+        tetherButtonPanelState = state
+
+        updateTetherWindowPosition(for: activeScreen, lastYComputed: tetherHintDetails.lastYComputed)
+        tetherHintDetails.tetherWindow.orderFrontRegardless()
+    }
+
+    private func tetherHintClicked(screen: NSScreen) {
+        state.trackedScreen = screen
+        launchPanel(for: state)
+    }
+
+    private func updateTetherWindowPosition(for screen: NSScreen, lastYComputed: CGFloat? = nil) {
+        let activeScreenFrame = screen.visibleFrame
+        let positionX = activeScreenFrame.maxX - ExternalTetheredButton.containerWidth
+        var positionY: CGFloat
+
+        if lastYComputed == nil {
+            positionY = activeScreenFrame.minY + (activeScreenFrame.height / 2) - (ExternalTetheredButton.containerHeight / 2)
+        } else {
+            positionY = computeHintYPosition(for: activeScreenFrame, offset: lastYComputed)
+        }
+
+        let frame = NSRect(
+            x: positionX,
+            y: positionY,
+            width: ExternalTetheredButton.containerWidth,
+            height: ExternalTetheredButton.containerHeight
+        )
+        tetherHintDetails.tetherWindow.setFrame(frame, display: false)
+    }
+
+    private func computeHintYPosition(for screenVisibleFrame: CGRect, offset: CGFloat?) -> CGFloat {
+        let maxY = screenVisibleFrame.maxY - ExternalTetheredButton.containerHeight
+        let minY = screenVisibleFrame.minY
+
+        var lastYComputed = tetherHintDetails.lastYComputed ?? screenVisibleFrame.minY + (screenVisibleFrame.height / 2) - (ExternalTetheredButton.containerHeight / 2)
+
+        if let offset = offset {
+            lastYComputed -= offset
+        }
+
+        let finalOffset: CGFloat
+
+        if lastYComputed > maxY {
+            finalOffset = maxY
+        } else if lastYComputed < minY {
+            finalOffset = minY
+        } else {
+            finalOffset = lastYComputed
+        }
+
+        return finalOffset
+    }
+
+    private func tetheredWindowMoved(screen: NSScreen, y: CGFloat) {
+        let screenFrame = screen.visibleFrame
+        let lastYComputed = computeHintYPosition(for: screenFrame, offset: y)
+
+        tetherHintDetails.lastYComputed = lastYComputed
+
+        if let state = tetherButtonPanelState {
+            state.tetheredButtonYPosition = screenFrame.height -
+                (lastYComputed - screenFrame.minY) -
+                ExternalTetheredButton.containerHeight + (TetheredButton.height / 2)
+        }
+
+        let frame = NSRect(
+            x: tetherHintDetails.tetherWindow.frame.origin.x,
+            y: lastYComputed,
+            width: ExternalTetheredButton.containerWidth,
+            height: ExternalTetheredButton.containerHeight
+        )
+
+        tetherHintDetails.tetherWindow.setFrame(frame, display: true)
+    }
+}

--- a/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager.swift
+++ b/macos/Onit/PanelStateManager/Conventional/PanelStateConventionalManager.swift
@@ -1,0 +1,87 @@
+//
+//  PanelStateConventionalManager.swift
+//  Onit
+//
+//  Created by Codex on 2024-06-01.
+//
+
+import AppKit
+import Defaults
+import SwiftUI
+
+@MainActor
+class PanelStateConventionalManager: PanelStateBaseManager, ObservableObject {
+
+    static let shared = PanelStateConventionalManager()
+
+    private var globalMouseMonitor: Any?
+    private var localMouseMonitor: Any?
+    private var lastScreenFrame = CGRect.zero
+
+    private override init() {
+        super.init()
+        states = []
+    }
+
+    override func start() {
+        stop()
+
+        let state = OnitPanelState()
+        self.state = state
+        states = [state]
+
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            self?.activateMouseScreen()
+        }
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            self?.activateMouseScreen()
+            return event
+        }
+
+        state.addDelegate(self)
+        activateMouseScreen(forced: true)
+    }
+
+    override func stop() {
+        if let global = globalMouseMonitor { NSEvent.removeMonitor(global); globalMouseMonitor = nil }
+        if let local = localMouseMonitor { NSEvent.removeMonitor(local); localMouseMonitor = nil }
+        lastScreenFrame = .zero
+        state.removeDelegate(self)
+        super.stop()
+    }
+
+    override func launchPanel(for state: OnitPanelState) {
+        AnalyticsManager.Panel.opened(displayMode: "conventional")
+        buildPanelIfNeeded(for: state)
+        showPanel(for: state)
+    }
+
+    override func closePanel(for state: OnitPanelState) {
+        AnalyticsManager.Panel.closed(displayMode: "conventional")
+        if let frame = state.panel?.frame {
+            Defaults[.conventionalPanelFrame] = frame
+        }
+        hidePanel(for: state)
+        super.closePanel(for: state)
+    }
+
+    override func fetchWindowContext() { }
+
+    func activateMouseScreen(forced: Bool = false) {
+        if forced { lastScreenFrame = .zero }
+        if let mouseScreen = NSScreen.mouse {
+            if !mouseScreen.frame.equalTo(lastScreenFrame) {
+                handleActivation(of: mouseScreen)
+                lastScreenFrame = mouseScreen.frame
+            }
+        }
+    }
+
+    private func handleActivation(of screen: NSScreen) {
+        if state.panelOpened {
+            hideTetherWindow()
+        } else {
+            debouncedShowTetherWindow(activeScreen: screen)
+        }
+    }
+}

--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -134,7 +134,10 @@ class PanelStateBaseManager: PanelStateManagerLogic {
             state.newChat(clearContext: false)
         }
 
-        state.panel = OnitRegularPanel(state: state)
+        state.panel = OnitRegularPanel(
+            state: state,
+            displayMode: FeatureFlagManager.shared.displayMode
+        )
     }
     
     private func closePanels() {

--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -25,7 +25,7 @@ struct TetheredButton: View {
     }
 
     private var arrowRotation: Angle {
-        if FeatureFlagManager.shared.usePinnedMode {
+        if FeatureFlagManager.shared.displayMode != .tethered {
             return .degrees(0)
         }
 

--- a/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
@@ -56,9 +56,9 @@ extension OnitRegularPanel {
         AnalyticsManager.Panel.resized(oldWidth: originalPanelWidth, newWidth: width)
 
         // Check if pinned mode is enabled
-        let usePinnedMode = FeatureFlagManager.shared.usePinnedMode
-        
-        if state.isScreenMode && usePinnedMode {
+        let isPinned = FeatureFlagManager.shared.displayMode == .pinned
+
+        if state.isScreenMode && isPinned {
             // In pinned mode, we need to resize all windows that overlap with the panel
             if let screen = state.trackedScreen ?? NSScreen.mouse,
                let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {

--- a/macos/Onit/UI/Panels/OnitRegularPanel.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel.swift
@@ -72,10 +72,13 @@ class OnitRegularPanel: NSPanel {
         standardWindowButton(.miniaturizeButton)?.isHidden = hideButtons
         standardWindowButton(.zoomButton)?.isHidden = hideButtons
         
-        let contentView = ContentView()
+        var contentView = ContentView()
             .modelContainer(state.container)
             .environment(\.windowState, state)
-            .padding(.leading, TetheredButton.width / 2)
+
+        if displayMode != .conventional {
+            contentView = contentView.padding(.leading, TetheredButton.width / 2)
+        }
         
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.wantsLayer = true
@@ -122,16 +125,18 @@ class OnitRegularPanel: NSPanel {
             resizeOverlay.autoresizingMask = [.maxXMargin, .height]
         }
 
-        // Create a separate hosting view for the TetheredButton
-        let tetheredButtonView = NSHostingView(rootView: 
-            TetheredButton()
-                .modelContainer(state.container)
-                .environment(\.windowState, state)
-        )
-        tetheredButtonView.wantsLayer = true
-        tetheredButtonView.frame = NSRect(x: 0, y: 0, width: TetheredButton.width, height: frame.height)
-        hostingView.addSubview(tetheredButtonView)
-        tetheredButtonView.autoresizingMask = [.maxXMargin, .height]
+        if displayMode != .conventional {
+            // Create a separate hosting view for the TetheredButton
+            let tetheredButtonView = NSHostingView(rootView:
+                TetheredButton()
+                    .modelContainer(state.container)
+                    .environment(\.windowState, state)
+            )
+            tetheredButtonView.wantsLayer = true
+            tetheredButtonView.frame = NSRect(x: 0, y: 0, width: TetheredButton.width, height: frame.height)
+            hostingView.addSubview(tetheredButtonView)
+            tetheredButtonView.autoresizingMask = [.maxXMargin, .height]
+        }
 
         if PanelStateCoordinator.shared.isPanelMovable {
             NotificationCenter.default.addObserver(

--- a/macos/Onit/UI/Panels/OnitRegularPanel.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel.swift
@@ -19,7 +19,7 @@ class OnitRegularPanel: NSPanel {
     }
     
     override var canBecomeKey: Bool {
-        return _level == .floating
+        return displayMode == .conventional || _level == .floating
     }
     
     let state: OnitPanelState
@@ -34,10 +34,12 @@ class OnitRegularPanel: NSPanel {
     var resizedApplication: Bool = false
     var isResizing: Bool = false
     var originalFrame : NSRect = .zero
-    
+    let displayMode: DisplayMode
+
     init(state: OnitPanelState, displayMode: DisplayMode = FeatureFlagManager.shared.displayMode) {
         self.state = state
         self.width = state.panelWidth
+        self.displayMode = displayMode
 
         var style: NSWindow.StyleMask = [.titled, .fullSizeContentView]
         if displayMode != .conventional {
@@ -162,7 +164,9 @@ class OnitRegularPanel: NSPanel {
             }
         }
         
-        show()
+        if displayMode != .conventional {
+            show()
+        }
     }
     
     @objc private func windowWillMove(_ notification: Notification) {
@@ -236,7 +240,9 @@ extension OnitRegularPanel: OnitPanel {
     
     func show() {
         makeKeyAndOrderFront(nil)
-        setupFrame()
+        if displayMode != .conventional {
+            setupFrame()
+        }
     }
     
     func hide() {


### PR DESCRIPTION
## Summary
- introduce `DisplayMode` enum with a new `conventional` option
- persist last window location for conventional mode
- implement `PanelStateConventionalManager` with hint logic
- refactor feature flags to store `displayMode`
- update settings UI and other managers to use the new mode

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840ce5b24cc832f9692ee83c7b526c6