### PR TITLE
Fix - Audio Recorder UI getting clipped

### DIFF
--- a/macos/Onit/UI/Components/RecordingIndicator.swift
+++ b/macos/Onit/UI/Components/RecordingIndicator.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct RecordingIndicator: View {
     @ObservedObject var audioRecorder: AudioRecorder
+    
+    static let maxHeight: CGFloat = 18
 
     var body: some View {
         Group {
@@ -46,7 +48,7 @@ struct WaveformIndicator: View {
                 bar(for: index)
             }
         }
-        .frame(height: 22)
+        .frame(height: RecordingIndicator.maxHeight)
         .padding(.horizontal, 8)
         .background(
             RoundedRectangle(cornerRadius: 11)
@@ -89,7 +91,7 @@ struct LoadingIndicator: View {
         ZStack {
             RoundedRectangle(cornerRadius: 11)
                 .fill(Color.blue400.opacity(0.2))
-                .frame(width: 22, height: 22)
+                .frame(width: RecordingIndicator.maxHeight, height: RecordingIndicator.maxHeight)
             
             Color.blue400.mask {
                 Loader()

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -306,7 +306,13 @@ private class CustomTextView: NSTextView {
             if let recordingIndicator = recordingIndicator {
                 let glyphRange = layoutManager?.glyphRange(forCharacterRange: NSRange(location: parentCursorPosition, length: 0), actualCharacterRange: nil)
                 let glyphRect = layoutManager?.boundingRect(forGlyphRange: glyphRange!, in: textContainer!)
-                recordingIndicator.frame = NSRect(x: glyphRect!.maxX, y: glyphRect!.minY, width: 33, height: 20)
+                
+                recordingIndicator.frame = NSRect(
+                    x: glyphRect!.maxX,
+                    y: glyphRect!.minY,
+                    width: 33,
+                    height: RecordingIndicator.maxHeight
+                )
                 if recordingIndicator.superview == nil {
                     addSubview(recordingIndicator)
                 }
@@ -326,9 +332,24 @@ private class CustomTextView: NSTextView {
         layoutManager.ensureLayout(for: container)
         
         let usedRect = layoutManager.usedRect(for: container)
+        var height = ceil(usedRect.height + textContainerInset.height * 2)
+        
+        if audioRecorder.isRecording || audioRecorder.isTranscribing {
+            let glyphRange = layoutManager.glyphRange(
+                forCharacterRange: NSRange(location: parentCursorPosition, length: 0),
+                actualCharacterRange: nil
+            )
+            let glyphRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: container)
+            let recordingIndicatorBottom = glyphRect.minY + RecordingIndicator.maxHeight + textContainerInset.height
+            
+            if recordingIndicatorBottom > height {
+                height = ceil(recordingIndicatorBottom)
+            }
+        }
+        
         return NSSize(
             width: frame.width,
-            height: ceil(usedRect.height + textContainerInset.height * 2)
+            height: height
         )
     }
     


### PR DESCRIPTION
@timlenardo 
The real issue came from :
1.  `CustomTextView.intrinsicContentSize`, which didn’t take the `RecordingIndicator` view into account
2. RecordingIndicator height was 22px, we were using 20px for the host's frame.

The ideal height seems to be 18px. We can increase it (the view won’t be clipped) but it will increase the size of the prompt (see video with maxHeight = 22).

https://github.com/user-attachments/assets/885bf2db-10ee-47cd-803d-167c364466c5

