### PR TITLE
Display note about personal API token usage

### DIFF
--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -469,6 +469,45 @@ class AppState: NSObject {
         return models
     }
 
+    var hasUserAPITokens: Bool {
+        if let token = Defaults[.openAIToken],
+           !token.isEmpty,
+           isOpenAITokenValidated {
+            return true
+        }
+        if let token = Defaults[.anthropicToken],
+           !token.isEmpty,
+           isAnthropicTokenValidated {
+            return true
+        }
+        if let token = Defaults[.xAIToken],
+           !token.isEmpty,
+           isXAITokenValidated {
+            return true
+        }
+        if let token = Defaults[.googleAIToken],
+           !token.isEmpty,
+           isGoogleAITokenValidated {
+            return true
+        }
+        if let token = Defaults[.deepSeekToken],
+           !token.isEmpty,
+           isDeepSeekTokenValidated {
+            return true
+        }
+        if let token = Defaults[.perplexityToken],
+           !token.isEmpty,
+           isPerplexityTokenValidated {
+            return true
+        }
+        for provider in availableCustomProvider {
+            if !provider.token.isEmpty && provider.isTokenValidated {
+                return true
+            }
+        }
+        return false
+    }
+
 //    var remoteNeedsSetup: Bool {
 //        listedModels.isEmpty
 //    }

--- a/macos/Onit/UI/Settings/GeneralTabPlanAndBilling.swift
+++ b/macos/Onit/UI/Settings/GeneralTabPlanAndBilling.swift
@@ -245,7 +245,13 @@ extension GeneralTabPlanAndBilling {
                 }
                 
                 captionText("\(usage)/\(quota) generations used.")
-                
+
+                if appState.hasUserAPITokens {
+                    captionText(
+                        "Prompts sent using your own API tokens do not count against your free quota."
+                    )
+                }
+
                 captionText(handleRenewalDate(renewalDate))
             }
         }


### PR DESCRIPTION
## Summary
- show reminder that user-provided API tokens don't affect the free quota
- detect presence of validated tokens in `AppState`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_68432b0c151c832fb841a72c50db40a2