### PR TITLE
Add automatic autocontext loading in tethered mode

### DIFF
--- a/macos/Onit/App.swift
+++ b/macos/Onit/App.swift
@@ -27,6 +27,7 @@ struct App: SwiftUI.App {
     @Default(.launchOnStartupRequested) var launchOnStartupRequested
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
     @Default(.autoContextFromHighlights) var autoContextFromHighlights
+    @Default(.autoContextOnLaunchTethered) var autoContextOnLaunchTethered
     @Default(.authFlowStatus) var authFlowStatus
     
     private let appCoordinator: AppCoordinator
@@ -55,7 +56,8 @@ struct App: SwiftUI.App {
                 }
                 .onChange(of: [
                     autoContextFromCurrentWindow,
-                    autoContextFromHighlights
+                    autoContextFromHighlights,
+                    autoContextOnLaunchTethered
                 ], initial: true) { oldValue, newValue in
                     AnalyticsManager.Accessibility.flagsChanges()
                 }

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -80,6 +80,7 @@ extension Defaults.Keys {
     
     static let autoContextFromCurrentWindow = Key<Bool>("autoContextFromCurrentWindow", default: true)
     static let autoContextFromHighlights = Key<Bool>("autoContextFromHighlights", default: true)
+    static let autoContextOnLaunchTethered = Key<Bool>("autoContextOnLaunchTethered", default: true)
 
     // Web search
     static let webSearchEnabled = Key<Bool>("webSearchEnabled", default: false)

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
@@ -107,9 +107,12 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
     
     override func launchPanel(for state: OnitPanelState) {
         AnalyticsManager.Panel.opened(displayMode: "tethered", appName: appName(for: state))
-        
+
         buildPanelIfNeeded(for: state)
         showPanel(for: state)
+        if Defaults[.autoContextOnLaunchTethered] {
+            fetchWindowContext()
+        }
     }
     
     override func closePanel(for state: OnitPanelState) {

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -8,7 +8,6 @@ import AppKit
 struct AccessibilityTab: View {
     @Default(.autoContextFromHighlights) var autoContextFromHighlights
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
-    @Default(.autoContextOnLaunchTethered) var autoContextOnLaunchTethered
 
     @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
@@ -120,31 +119,6 @@ struct AccessibilityTab: View {
                         Text("Loads context from the active window. Note: this feature may not work in every application. ")
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
-                    }
-                }
-
-                if !featureFlagsManager.usePinnedMode {
-                    Section {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text("AutoContext on Launch")
-                                    .font(.system(size: 13))
-                                Spacer()
-                                Toggle("", isOn: $autoContextOnLaunchTethered)
-                                    .toggleStyle(.switch)
-                                    .controlSize(.small)
-                                SettingInfoButton(
-                                    title: "AutoContext on Launch",
-                                    description:
-                                        "When enabled, Onit automatically reads the tethered window and adds its text as context each time the panel opens.",
-                                    defaultValue: "on",
-                                    valueType: "Bool"
-                                )
-                            }
-                            Text("Adds context from the current window whenever Onit opens in Tethered mode.")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.gray200)
-                        }
                     }
                 }
             }

--- a/macos/Onit/UI/Settings/AccessibilityTab.swift
+++ b/macos/Onit/UI/Settings/AccessibilityTab.swift
@@ -8,6 +8,7 @@ import AppKit
 struct AccessibilityTab: View {
     @Default(.autoContextFromHighlights) var autoContextFromHighlights
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
+    @Default(.autoContextOnLaunchTethered) var autoContextOnLaunchTethered
 
     @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
     @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
@@ -119,6 +120,31 @@ struct AccessibilityTab: View {
                         Text("Loads context from the active window. Note: this feature may not work in every application. ")
                             .font(.system(size: 12))
                             .foregroundStyle(.gray200)
+                    }
+                }
+
+                if !featureFlagsManager.usePinnedMode {
+                    Section {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("AutoContext on Launch")
+                                    .font(.system(size: 13))
+                                Spacer()
+                                Toggle("", isOn: $autoContextOnLaunchTethered)
+                                    .toggleStyle(.switch)
+                                    .controlSize(.small)
+                                SettingInfoButton(
+                                    title: "AutoContext on Launch",
+                                    description:
+                                        "When enabled, Onit automatically reads the tethered window and adds its text as context each time the panel opens.",
+                                    defaultValue: "on",
+                                    valueType: "Bool"
+                                )
+                            }
+                            Text("Adds context from the current window whenever Onit opens in Tethered mode.")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.gray200)
+                        }
                     }
                 }
             }

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -13,11 +13,13 @@ struct GeneralTab: View {
     @Default(.createNewChatOnPanelOpen) var createNewChatOnPanelOpen
     @Default(.openOnMouseMonitor) var openOnMouseMonitor
     @Default(.usePinnedMode) var usePinnedMode
+    @Default(.autoContextOnLaunchTethered) var autoContextOnLaunchTethered
     
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
     @State var isAnalyticsEnabled: Bool = PostHogSDK.shared.isOptOut() == false
     
     @ObservedObject private var accessibilityPermissionManager = AccessibilityPermissionManager.shared
+    @ObservedObject private var featureFlagsManager = FeatureFlagManager.shared
     
     private var accessibilityGranted: Bool {
         accessibilityPermissionManager.accessibilityPermissionStatus == .granted
@@ -121,7 +123,6 @@ struct GeneralTab: View {
                     .buttonStyle(.plain)
                     .disabled(!accessibilityGranted)
                 }
-                
                 if !accessibilityGranted {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("To use Pinned or Tethered mode, enable Accessibility permission for Onit.")
@@ -153,6 +154,30 @@ struct GeneralTab: View {
                                 .foregroundStyle(.gray200)
                         } else {
                             Text("Onit will attach to your applications. There can be one Onit panel for each application window. If you move your app, Onit will move with it.")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.gray200)
+                        }
+                    }
+                }
+                if !featureFlagsManager.usePinnedMode {
+                    Section {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("AutoContext on Launch")
+                                    .font(.system(size: 13))
+                                Spacer()
+                                Toggle("", isOn: $autoContextOnLaunchTethered)
+                                    .toggleStyle(.switch)
+                                    .controlSize(.small)
+                                SettingInfoButton(
+                                    title: "AutoContext on Launch",
+                                    description:
+                                        "When enabled, Onit automatically reads the tethered window and adds its text as context whenever the panel opens.",
+                                    defaultValue: "on",
+                                    valueType: "Bool"
+                                )
+                            }
+                            Text("Adds context from the current window whenever Onit opens in Tethered mode.")
                                 .font(.system(size: 12))
                                 .foregroundStyle(.gray200)
                         }

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -163,14 +163,14 @@ struct GeneralTab: View {
                     Section {
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Text("AutoContext on Launch")
+                                Text("Add Current Window on Launch")
                                     .font(.system(size: 13))
                                 Spacer()
                                 Toggle("", isOn: $autoContextOnLaunchTethered)
                                     .toggleStyle(.switch)
                                     .controlSize(.small)
                                 SettingInfoButton(
-                                    title: "AutoContext on Launch",
+                                    title: "Add Current Window on Launch",
                                     description:
                                         "When enabled, Onit automatically reads the tethered window and adds its text as context whenever the panel opens.",
                                     defaultValue: "on",


### PR DESCRIPTION
## Summary
- add a `autoContextOnLaunchTethered` default
- include new toggle in settings when using tethered mode
- watch the new flag for analytics
- automatically fetch window context when opening the panel in tethered mode

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68432d0d9240832fa0ea00e1f7d93393