### PR TITLE
(do not merge) Add 'all' resize mode in pinned panel

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -88,6 +88,7 @@ extension Defaults.Keys {
 
     // Window state
     static let panelWidth = Key<Double>("panelWidth", default: 400)
+    static let pinnedResizeMode = Key<PinnedResizeMode>("pinnedResizeMode", default: .overlap)
 
     // General settings
     static let launchOnStartupRequested = Key<Bool>("launchOnStartupRequested", default: false)

--- a/macos/Onit/Data/Structures/PinnedResizeMode.swift
+++ b/macos/Onit/Data/Structures/PinnedResizeMode.swift
@@ -1,0 +1,7 @@
+import Defaults
+
+enum PinnedResizeMode: String, CaseIterable, Defaults.Serializable {
+    case overlap
+    case all
+}
+

--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -72,6 +72,7 @@ class PanelStateBaseManager: PanelStateManagerLogic {
         
         state = defaultState
         tetherButtonPanelState = nil
+        print("resizeWindow - resetting target frame")
         targetInitialFrames = [:]
     }
     
@@ -85,7 +86,9 @@ class PanelStateBaseManager: PanelStateManagerLogic {
     }
     
     func resetFramesOnAppChange() {
+        print("resizeWindow - resetFramesOnAppChange called frames to reset: \(targetInitialFrames.count)")
         targetInitialFrames.forEach { element, initialFrame in
+            print("resizeWindow - resetting initialFrame \(initialFrame)")
             _ = element.setFrame(initialFrame)
         }
         targetInitialFrames.removeAll()

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -53,23 +53,35 @@ extension PanelStatePinnedManager {
 
             if resizeMode == .all {
                 if targetInitialFrames[window] == nil {
+                    // This is situation where new window enters our screen but hadn't previously been moved handle later.
                     if windowFrameChanged {
-                        let newWidth = windowFrame.width + panelWidth
-                        let newFrame = NSRect(origin: windowFrame.origin,
-                                              size: NSSize(width: newWidth, height: windowFrame.height))
-                        targetInitialFrames[window] = newFrame
+                        
+//                        let newWidth = windowFrame.width + panelWidth
+//                        let newFrame = NSRect(origin: windowFrame.origin,
+//                                              size: NSSize(width: newWidth, height: windowFrame.height))
+//                        targetInitialFrames[window] = newFrame
                     } else {
                         targetInitialFrames[window] = windowFrame
                     }
-                }
 
-                let newWidth = (screenFrame.maxX - windowFrame.origin.x) - panelWidth
-                let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
-                _ = window.setFrame(newFrame)
+                    let newWidth = windowFrame.width - panelWidth
+                    let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                    print("resizeWindow - App \(window.title() ?? ""), og width: \(windowFrame.width), new width: \(newWidth)")
+                    _ = window.setFrame(newFrame)
+                }
+                
+                // This is the situation where we're already tracking it and it's move. What's the behavior here?
+                // If we drag it under the panel, we probably want to resize it.
+            
+                // Check if window is Xcode and print frame
+//                if let appname = window.appName(), appname.lowercased().contains("xcode") == true {
+//                    print("Xcode window new frame: \(newFrame)")
+//                }
 
             } else if !isPanelResized {
                 if availableSpace < panelWidth {
                     if !windowFrameChanged {
+                        print("resizeWindow - Saving initial frame!! \(windowFrame)")
                         targetInitialFrames[window] = windowFrame
                     } else if targetInitialFrames[window] == nil {
                         // The user resize the window, we should store the initial frame containing the panel space.
@@ -82,10 +94,12 @@ extension PanelStatePinnedManager {
                     let overlapAmount = panelWidth - availableSpace
                     let newWidth = windowFrame.width - overlapAmount
                     let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                    print("resizeWindow - setting new frame!! \(newFrame)")
                     _ = window.setFrame(newFrame)
-                } else if availableSpace > panelWidth, windowFrameChanged {
-                    // The user reduced the window, we should remove the initial frame
-                    targetInitialFrames.removeValue(forKey: window)
+//                } else if availableSpace > panelWidth, windowFrameChanged {
+//                    // The user reduced the window, we should remove the initial frame
+//                    print("resizeWindow - removing target frame")
+//                    targetInitialFrames.removeValue(forKey: window)
                 }
             } else {
                 // If we're already tracking it, then make it move.

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -8,6 +8,7 @@ struct GeneralTab: View {
     @Default(.fontSize) var fontSize
     @Default(.lineHeight) var lineHeight
     @Default(.panelWidth) var panelWidth
+    @Default(.pinnedResizeMode) var pinnedResizeMode
     
     @Default(.launchShortcutToggleEnabled) var launchShortcutToggleEnabled
     @Default(.createNewChatOnPanelOpen) var createNewChatOnPanelOpen
@@ -151,6 +152,17 @@ struct GeneralTab: View {
                             Text("Onit will always appear on the right side of your screen. You will only have one Onit panel at any given time. Other applications will be resized to make room for Onit.")
                                 .font(.system(size: 12))
                                 .foregroundStyle(.gray200)
+
+                            HStack {
+                                Text("Resize windows")
+                                    .font(.system(size: 13))
+                                Picker("", selection: $pinnedResizeMode) {
+                                    Text("Overlap").tag(PinnedResizeMode.overlap)
+                                    Text("All").tag(PinnedResizeMode.all)
+                                }
+                                .pickerStyle(.segmented)
+                                .frame(width: 150)
+                            }
                         } else {
                             Text("Onit will attach to your applications. There can be one Onit panel for each application window. If you move your app, Onit will move with it.")
                                 .font(.system(size: 12))

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -149,20 +149,32 @@ struct GeneralTab: View {
                 } else {
                     VStack(alignment: .leading, spacing: 4) {
                         if isPinnedMode {
-                            Text("Onit will always appear on the right side of your screen. You will only have one Onit panel at any given time. Other applications will be resized to make room for Onit.")
+                            Text("Onit will always appear on the right side of your screen. You will only have one Onit panel at any given time. Other applications will be resized to make room for Onit. In 'All' mode, all applications will be resized by the size of the Onit panel, regardless of where they are on the screen.")
                                 .font(.system(size: 12))
                                 .foregroundStyle(.gray200)
 
-                            HStack {
-                                Text("Resize windows")
-                                    .font(.system(size: 13))
-                                Picker("", selection: $pinnedResizeMode) {
-                                    Text("Overlap").tag(PinnedResizeMode.overlap)
-                                    Text("All").tag(PinnedResizeMode.all)
+                            Section {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack {
+                                        Text("Window Resizing")
+                                            .font(.system(size: 13))
+                                        Picker("", selection: $pinnedResizeMode) {
+                                            Text("Overlap").tag(PinnedResizeMode.overlap)
+                                            Text("All").tag(PinnedResizeMode.all)
+                                        }
+                                        .padding(.top, 4)
+                                        .pickerStyle(.segmented)
+                                        .frame(width: 150)
+                                    }
+                                    Text(pinnedResizeMode == .overlap ? 
+                                            "In 'Overlap' mode, when the Onit panel is opened, any applications that occupy space that the Onit panel will occupy are resized. When the panel is closed, applications will be restored to their original size, but only if they still shared a border with the Onit panel. 'Overlap' mode is good for most users. " : 
+                                            "In 'All' mode, when the Onit panel is opened, all applications are reduced by the size of the Onit panel. When the panel is closed, all applications are expanded by the width of the Onit panel. 'All' mode is good for users who wish to preserve the relative layout of other application windows.")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.gray200)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
-                                .pickerStyle(.segmented)
-                                .frame(width: 150)
                             }
+                            .padding(.top, 12)
                         } else {
                             Text("Onit will attach to your applications. There can be one Onit panel for each application window. If you move your app, Onit will move with it.")
                                 .font(.system(size: 12))


### PR DESCRIPTION
## Summary
- add `PinnedResizeMode` enum and default
- expose resize mode setting when pinned mode is active
- support resizing all windows in pinned mode via new enum

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_68432577fce0832f8433b991fa8acb84