### PR TITLE
Add stop generation button

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -116,6 +116,9 @@ extension Defaults.Keys {
     // Alerts
     static let showTwoWeekProTrialEndedAlert = Key<Bool>("showTwoWeekProTrialEndedAlert", default: false)
     static let hasClosedTrialEndedAlert = Key<Bool>("hasClosedTrialEndedAlert", default: false)
+
+    // Stop generation behavior
+    static let stopMode = Key<StopMode>("stopMode", default: .removePartial)
 }
 
 extension NSRect: Defaults.Serializable {

--- a/macos/Onit/Data/Structures/StopMode.swift
+++ b/macos/Onit/Data/Structures/StopMode.swift
@@ -1,0 +1,13 @@
+//
+//  StopMode.swift
+//  Onit
+//
+//  Created by OpenAI on 2023-11-20.
+//
+
+import Defaults
+
+enum StopMode: String, CaseIterable, Codable, Defaults.Serializable {
+    case removePartial
+    case leavePartial
+}

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -44,28 +44,6 @@ struct ChatView: View {
                                 }
                         }
                     }
-                    
-                    if hasUserManuallyScrolled {
-                        HStack {
-                            Spacer()
-                            IconButton(
-                                icon: .arrowDown,
-                                buttonSize: 36,
-                                action: {
-                                    hasUserManuallyScrolled = false
-                                },
-                                activeColor: .white,
-                                inactiveColor: .white,
-                                tooltipPrompt: "Scroll to bottom",
-                                hoverBackgroundColor: .gray400
-                            )
-                            .background(.gray600)
-                            .addBorder(cornerRadius: 18, stroke: .gray400)
-                            .transition(.scale.combined(with: .opacity))
-                            .padding(.trailing, 20)
-                        }
-                        .padding(.bottom, 4)
-                    }
                 }
                 .onChange(of: state.currentChat) { old, new in
 					chatChangeTask?.cancel()
@@ -84,18 +62,42 @@ struct ChatView: View {
                 systemPrompt
             }
             
-            PromptCore()
+            // Floating action buttons area
+            if state.generatingPrompt != nil || hasUserManuallyScrolled {
+                HStack {
+                    Spacer()
+                    
+                    if state.generatingPrompt != nil {
+                        StopGenerationButton()
+                    }
+                    
+                    Spacer()
+                    
+                    if hasUserManuallyScrolled {
+                        IconButton(
+                            icon: .arrowDown,
+                            buttonSize: 36,
+                            action: {
+                                hasUserManuallyScrolled = false
+                            },
+                            activeColor: .white,
+                            inactiveColor: .white,
+                            tooltipPrompt: "Scroll to bottom",
+                            hoverBackgroundColor: .gray400
+                        )
+                        .background(.gray600)
+                        .addBorder(cornerRadius: 18, stroke: .gray400)
+                        .transition(.scale.combined(with: .opacity))
+                        .padding(.trailing, 20)
+                    }
+                }
+                .padding(.bottom, 4)
+            }
             
+            PromptCore()
             if currentPromptsCount <= 0 { Spacer() }
         }
         .drag()
-        .overlay(alignment: .bottomTrailing) {
-            if state.generatingPrompt != nil {
-                StopGenerationButton()
-                    .padding(.trailing, 12)
-                    .padding(.bottom, 60)
-            }
-        }
     }
 }
 

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -44,6 +44,44 @@ struct ChatView: View {
                                 }
                         }
                     }
+                    // Floating action buttons area
+                    if state.generatingPrompt != nil || hasUserManuallyScrolled {
+                        HStack {
+                            Spacer()
+                            
+                            if state.generatingPrompt != nil {
+                                StopGenerationButton()
+                                    .offset(x: 18, y: 0) // This centers it to account for the scroll button frame
+                            }
+                            
+                            Spacer()
+                            
+                            if hasUserManuallyScrolled {
+                                IconButton(
+                                    icon: .arrowDown,
+                                    buttonSize: 36,
+                                    action: {
+                                        hasUserManuallyScrolled = false
+                                    },
+                                    activeColor: .white,
+                                    inactiveColor: .white,
+                                    tooltipPrompt: "Scroll to bottom",
+                                    hoverBackgroundColor: .gray400
+                                )
+                                .background(.gray600)
+                                .addBorder(cornerRadius: 18, stroke: .gray400)
+                                .transition(.scale.combined(with: .opacity))
+                                .padding(.trailing, 20)
+                            } else {
+                                // Placeholders.
+                                Color.clear
+                                    .frame(width: 36, height: 36)
+                                    .padding(.trailing, 20)
+                            }
+                        }
+                        .background(.clear)
+                        .padding(.bottom, 4)
+                    }
                 }
                 .onChange(of: state.currentChat) { old, new in
 					chatChangeTask?.cancel()
@@ -60,38 +98,6 @@ struct ChatView: View {
                 }
             } else {
                 systemPrompt
-            }
-            
-            // Floating action buttons area
-            if state.generatingPrompt != nil || hasUserManuallyScrolled {
-                HStack {
-                    Spacer()
-                    
-                    if state.generatingPrompt != nil {
-                        StopGenerationButton()
-                    }
-                    
-                    Spacer()
-                    
-                    if hasUserManuallyScrolled {
-                        IconButton(
-                            icon: .arrowDown,
-                            buttonSize: 36,
-                            action: {
-                                hasUserManuallyScrolled = false
-                            },
-                            activeColor: .white,
-                            inactiveColor: .white,
-                            tooltipPrompt: "Scroll to bottom",
-                            hoverBackgroundColor: .gray400
-                        )
-                        .background(.gray600)
-                        .addBorder(cornerRadius: 18, stroke: .gray400)
-                        .transition(.scale.combined(with: .opacity))
-                        .padding(.trailing, 20)
-                    }
-                }
-                .padding(.bottom, 4)
             }
             
             PromptCore()

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -89,6 +89,13 @@ struct ChatView: View {
             if currentPromptsCount <= 0 { Spacer() }
         }
         .drag()
+        .overlay(alignment: .bottomTrailing) {
+            if state.generatingPrompt != nil {
+                StopGenerationButton()
+                    .padding(.trailing, 12)
+                    .padding(.bottom, 60)
+            }
+        }
     }
 }
 

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -355,17 +355,17 @@ extension OnitPanelState {
     }
     
     func replacePartialResponse(prompt: Prompt, response: Response) {
-        // TODO could this cause isues where the generation index is beyond the lnegth of responses?
+        // TODO could this cause isues where the generation index is beyond the length of responses?
         if let partialResponseIndex = prompt.responses.firstIndex(where: { $0.isPartial }) {
             prompt.responses.remove(at: partialResponseIndex)
         }
         // We don't need to add the response if the generation was stopped we're removing the partial responses.
         if generationStopped == false || Defaults[.stopMode] != .removePartial {
             prompt.responses.append(response)
-        }
-        prompt.generationState = .done
-        do { try container.mainContext.save() } catch {
-            print("replacePartialResponse - Save failed!")
+            prompt.generationState = .done
+            do { try container.mainContext.save() } catch {
+                print("replacePartialResponse - Save failed!")
+            }
         }
     }
     

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -283,6 +283,12 @@ extension OnitPanelState {
                 currentPrompts?.remove(at: curIndex)
             }
             container.mainContext.delete(prompt)
+            
+            do {
+                try container.mainContext.save()
+            } catch {
+                print("Failed to save after deleting prompt: \(error.localizedDescription)")
+            }
         }
 
         generatingPrompt = nil

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -210,7 +210,7 @@ extension OnitPanelState {
                     }
                     
                     if Defaults[.streamResponse].local {
-                        prompt.generationState = .streaming                        
+                        prompt.generationState = .streaming
                         let asyncText = try await streamingClient.localChat(
                             systemMessage: systemPrompt.prompt,
                             instructions: instructionsHistory,
@@ -307,12 +307,14 @@ extension OnitPanelState {
             do {
                 try container.mainContext.save()
                 // Reset the nextPrompt/priorPrompt links, to account for the removed prompt. We only want to do this if the save succeeded.
-                for existingPrompt in currentChat?.prompts ?? [] {
-                    if existingPrompt.nextPrompt?.id == prompt.id {
-                        existingPrompt.nextPrompt = prompt.nextPrompt
-                    }
-                    if existingPrompt.priorPrompt?.id == prompt.id {
-                        existingPrompt.priorPrompt = prompt.priorPrompt
+                if let chatPrompts = currentChat?.prompts {
+                    for existingPrompt in chatPrompts {
+                        if existingPrompt.nextPrompt?.id == prompt.id {
+                            existingPrompt.nextPrompt = prompt.nextPrompt
+                        }
+                        if existingPrompt.priorPrompt?.id == prompt.id {
+                            existingPrompt.priorPrompt = prompt.priorPrompt
+                        }
                     }
                 }
             } catch {
@@ -364,6 +366,7 @@ extension OnitPanelState {
             prompt.responses.append(response)
             prompt.generationState = .done
             do { try container.mainContext.save() } catch {
+                container.mainContext.rollback()
                 print("replacePartialResponse - Save failed!")
             }
         }

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -267,6 +267,26 @@ extension OnitPanelState {
             curPrompt.generationState = priorState
         }
     }
+
+    func stopGeneration() {
+        guard let prompt = generatingPrompt else { return }
+        cancelGenerate()
+
+        pendingInstruction = prompt.instruction
+        textFocusTrigger.toggle()
+
+        if Defaults[.stopMode] == .removePartial {
+            if let index = currentChat?.prompts.firstIndex(where: { $0.id == prompt.id }) {
+                currentChat?.prompts.remove(at: index)
+            }
+            if let curIndex = currentPrompts?.firstIndex(where: { $0.id == prompt.id }) {
+                currentPrompts?.remove(at: curIndex)
+            }
+            container.mainContext.delete(prompt)
+        }
+
+        generatingPrompt = nil
+    }
     
     func shouldUseStream(_ aiModel: AIModel) -> Bool {
         switch aiModel.provider {

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -287,7 +287,12 @@ extension OnitPanelState {
             do {
                 try container.mainContext.save()
             } catch {
-                print("Failed to save after deleting prompt: \(error.localizedDescription)")
+                // If save fails, let's restore the partial prompt to prevent weird states. 
+                container.mainContext.rollback()
+                if let chat = currentChat {
+                    chat.prompts.append(prompt)
+                    currentPrompts?.append(prompt)
+                }
             }
         }
 

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -127,6 +127,7 @@ class OnitPanelState: NSObject {
     var generateTask: Task<Void, Never>? = nil
     var generatingPrompt: Prompt?
     var generatingPromptPriorState: GenerationState?
+    var generationStopped: Bool = false
     
     /// Don't leave this text empty to ensure the first scroll works.
     var streamedResponse: String = " "

--- a/macos/Onit/UI/Prompt/StopGenerationButton.swift
+++ b/macos/Onit/UI/Prompt/StopGenerationButton.swift
@@ -1,0 +1,33 @@
+//
+//  StopGenerationButton.swift
+//  Onit
+//
+//  Created by OpenAI on 2023-11-20.
+//
+
+import SwiftUI
+import Defaults
+
+struct StopGenerationButton: View {
+    @Environment(\.windowState) private var state
+
+    private let shortcut = KeyboardShortcut(.delete, modifiers: [.command])
+
+    var body: some View {
+        TextButton(
+            gap: 4,
+            height: ToolbarButtonStyle.height,
+            fillContainer: false,
+            horizontalPadding: 8,
+            cornerRadius: ToolbarButtonStyle.cornerRadius,
+            background: .gray800,
+            hoverBackground: .gray600,
+            fontSize: 13,
+            fontColor: .gray200,
+            text: "Stop",
+            child: { KeyboardShortcutView(shortcut: shortcut) },
+            action: { state.stopGeneration() }
+        )
+        .keyboardShortcut(shortcut)
+    }
+}

--- a/macos/Onit/UI/Prompt/StopGenerationButton.swift
+++ b/macos/Onit/UI/Prompt/StopGenerationButton.swift
@@ -10,6 +10,7 @@ import Defaults
 
 struct StopGenerationButton: View {
     @Environment(\.windowState) private var state
+    @State private var isHovered: Bool = false
 
     private let shortcut = KeyboardShortcut(.delete, modifiers: [.command])
 
@@ -33,12 +34,15 @@ struct StopGenerationButton: View {
             .frame(height: 26)
         }
         .buttonStyle(PlainButtonStyle())
-        .background(.gray800)
+        .background(isHovered ? .gray400 : .gray800)
         .cornerRadius(6)
         .overlay(
             RoundedRectangle(cornerRadius: 6)
                 .stroke(.gray500, lineWidth: 1)
         )
         .keyboardShortcut(shortcut)
+        .onHover { hovering in
+            isHovered = hovering
+        }
     }
 }

--- a/macos/Onit/UI/Prompt/StopGenerationButton.swift
+++ b/macos/Onit/UI/Prompt/StopGenerationButton.swift
@@ -14,19 +14,30 @@ struct StopGenerationButton: View {
     private let shortcut = KeyboardShortcut(.delete, modifiers: [.command])
 
     var body: some View {
-        TextButton(
-            gap: 4,
-            height: ToolbarButtonStyle.height,
-            fillContainer: false,
-            horizontalPadding: 8,
-            cornerRadius: ToolbarButtonStyle.cornerRadius,
-            background: .gray800,
-            hoverBackground: .gray600,
-            fontSize: 13,
-            fontColor: .gray200,
-            text: "Stop",
-            child: { KeyboardShortcutView(shortcut: shortcut) },
-            action: { state.stopGeneration() }
+        Button(action: { state.stopGeneration() }) {
+            HStack(spacing: 4) {
+                Image(systemName: "command")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white)
+                
+                Image(systemName: "delete.left")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white)
+                
+                Text("Stop")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 0)
+            .frame(height: 26)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .background(.gray800)
+        .cornerRadius(6)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(.gray500, lineWidth: 1)
         )
         .keyboardShortcut(shortcut)
     }

--- a/macos/Onit/UI/Prompt/StopGenerationButton.swift
+++ b/macos/Onit/UI/Prompt/StopGenerationButton.swift
@@ -44,5 +44,6 @@ struct StopGenerationButton: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        .addAnimation(dependency: isHovered)
     }
 }


### PR DESCRIPTION
## Summary
- add `StopMode` configuration and default preference
- extend `OnitPanelState` with `stopGeneration()` logic
- show floating Stop button while generating
- allow stopping generation via `CMD+Delete`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68432f9f8720832f8466bc993783a9ed