### PR TITLE
Prevent pinned windows from jumping back when moved

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Restore.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Restore.swift
@@ -1,0 +1,33 @@
+//
+//  PanelStatePinnedManager+Restore.swift
+//  Onit
+//
+//  Created by Codex on 2024-06-09.
+//
+
+import AppKit
+
+extension PanelStatePinnedManager {
+    override func resetFramesOnAppChange() {
+        guard let panel = state.panel else {
+            super.resetFramesOnAppChange()
+            return
+        }
+
+        let panelFrame = panel.frame
+        targetInitialFrames.forEach { element, initialFrame in
+            var shouldRestore = true
+            if let currentFrame = element.getFrame(convertedToGlobalCoordinateSpace: true) {
+                let touchesPanel = currentFrame.intersects(panelFrame) || abs(currentFrame.maxX - panelFrame.minX) <= 1
+                if !touchesPanel {
+                    shouldRestore = false
+                }
+            }
+
+            if shouldRestore {
+                _ = element.setFrame(initialFrame)
+            }
+        }
+        targetInitialFrames.removeAll()
+    }
+}


### PR DESCRIPTION
## Summary
- override `resetFramesOnAppChange` for pinned mode
- only restore frames if the window still touches the panel

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_68466cb55e04832f9076eea2ce9407cd