### PR TITLE
Fix panel resizing in pinned mode

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -64,9 +64,6 @@ extension PanelStatePinnedManager {
                     let newWidth = windowFrame.width - overlapAmount
                     let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
                     _ = window.setFrame(newFrame)
-                } else if availableSpace > panelWidth, windowFrameChanged {
-                    // The user reduced the window, we should remove the initial frame
-                    targetInitialFrames.removeValue(forKey: window)
                 }
             } else {
                 // If we're already tracking it, then make it move.

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -227,4 +227,27 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
             targetInitialFrames.removeValue(forKey: window)
         }
     }
+
+    override func resetFramesOnAppChange() {
+        let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
+        targetInitialFrames.forEach { element, initialFrame in
+
+            // In Pinned mode, we should only reset the frame if it's still bordering the panel. 
+            // Instead of using the initial frame, we should add panelWidth back to the window, so it goes all the way to the edge of the screen.
+            if let currentFrame = element.getFrame() {
+                let screenFrame = NSScreen.main?.visibleFrame ?? .zero
+                let isNearPanel = abs((screenFrame.maxX - panelWidth) - currentFrame.maxX) <= 2
+
+                if !isNearPanel {
+                    return
+                }
+                let newWidth = currentFrame.width + panelWidth
+                let newFrame = NSRect(origin: currentFrame.origin,
+                                        size: NSSize(width: newWidth, height: currentFrame.height))
+                print("resizeWindow - resetting initialFrame \(initialFrame)")
+                _ = element.setFrame(newFrame)
+            }
+        }
+        targetInitialFrames.removeAll()
+    }
 }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -231,11 +231,10 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     override func resetFramesOnAppChange() {
         let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
         targetInitialFrames.forEach { element, initialFrame in
-
-            // In Pinned mode, we should only reset the frame if it's still bordering the panel. 
+            // In Pinned mode, we should only reset the frame if it's still bordering the panel.
             // Instead of using the initial frame, we should add panelWidth back to the window, so it goes all the way to the edge of the screen.
-            if let currentFrame = element.getFrame(convertedToGlobalCoordinateSpace: true) {
-                let screenFrame = NSScreen.main?.visibleFrame ?? .zero
+            if let currentFrame = element.getFrame() {
+                let screenFrame = attachedScreen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
                 let isNearPanel = abs((screenFrame.maxX - panelWidth) - currentFrame.maxX) <= 2
 
                 if !isNearPanel {
@@ -244,7 +243,6 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
                 let newWidth = currentFrame.width + panelWidth
                 let newFrame = NSRect(origin: currentFrame.origin,
                                         size: NSSize(width: newWidth, height: currentFrame.height))
-                print("resizeWindow - resetting initialFrame \(initialFrame)")
                 _ = element.setFrame(newFrame)
             }
         }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -234,7 +234,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
 
             // In Pinned mode, we should only reset the frame if it's still bordering the panel. 
             // Instead of using the initial frame, we should add panelWidth back to the window, so it goes all the way to the edge of the screen.
-            if let currentFrame = element.getFrame() {
+            if let currentFrame = element.getFrame(convertedToGlobalCoordinateSpace: true) {
                 let screenFrame = NSScreen.main?.visibleFrame ?? .zero
                 let isNearPanel = abs((screenFrame.maxX - panelWidth) - currentFrame.maxX) <= 2
 


### PR DESCRIPTION
I've noticed a bug where, when I open the panel in pinned mode and then close it, sometimes the main window doesn't resize. I figured this out today, while working on a different task. Here's what's going wrong: 

1. When the panel opens, we call resizeWindows(). For a full-screen window, there is no 'availableSpace', so we resize the window. 
2. Resizing the window creates a 'kAXWindowResizedNotification'. In handling this notification, we call 'resizeWindow()' again! 
3. The 2nd time, there _is_ available space because we just resized the window! Now the resizeWindow() function removes the targetInitialFrame (lines 67-69 of PanelStatePinnedManager+Resize.swift). We wrote this code to handle the case where the user drags the window away; however, we're encountering this case immediately because resizing the window triggers the resize notifications. 
4. When the user closes the panel, there is no 'targetInitialFrame', so the window frame is not reset. 

Instead, I've changing the code to do the following: 
- Never remove the target window in the resizeWindow() function. 
- Instead, add logic to 'resetFramesOnAppChange' to determine which window needs to be resized. 
- I am choosing only to resize windows that still share a border with the OnitPanel (i.e. their right edge is within 2 pixels of the OnitPanel). This handles the case where the window has been dragged away AND the case where new windows have been dragged over to overlap with the panel. 
