### PR TITLE
Save Tether hint position

### DIFF
--- a/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
+++ b/macos/Onit/PanelStateManager/PanelStateBaseManager.swift
@@ -85,7 +85,6 @@ class PanelStateBaseManager: PanelStateManagerLogic {
 
         tetherHintDetails.tetherWindow.orderOut(nil)
         tetherHintDetails.tetherWindow.contentView = nil
-        tetherHintDetails.lastYComputed = nil
     }
     
     func resetFramesOnAppChange() {

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -37,7 +37,6 @@ extension PanelStatePinnedManager {
 
         let buttonView = NSHostingView(rootView: tetherView)
         tetherHintDetails.tetherWindow.contentView = buttonView
-        tetherHintDetails.lastYComputed = nil
         tetherButtonPanelState = state
 
         updateTetherWindowPosition(for: activeScreen, lastYComputed: tetherHintDetails.lastYComputed)
@@ -54,7 +53,10 @@ extension PanelStatePinnedManager {
         let positionX = activeScreenFrame.maxX - ExternalTetheredButton.containerWidth
         var positionY: CGFloat
         
-        if lastYComputed == nil {
+        if let relativePosition = hintYRelativePosition {
+            positionY = activeScreenFrame.minY + (relativePosition * activeScreenFrame.height) - (ExternalTetheredButton.containerHeight / 2)
+            positionY = max(activeScreenFrame.minY, min(positionY, activeScreenFrame.maxY - ExternalTetheredButton.containerHeight))
+        } else if lastYComputed == nil {
             positionY = activeScreenFrame.minY + (activeScreenFrame.height / 2) - (ExternalTetheredButton.containerHeight / 2)
         } else {
             positionY = computeHintYPosition(for: activeScreenFrame, offset: lastYComputed)
@@ -98,10 +100,11 @@ extension PanelStatePinnedManager {
         
         tetherHintDetails.lastYComputed = lastYComputed
         
+        let relativeY = (lastYComputed + (ExternalTetheredButton.containerHeight / 2) - screenFrame.minY) / screenFrame.height
+        hintYRelativePosition = max(0.0, min(1.0, relativeY))
+        
         if let state = tetherButtonPanelState {
-            state.tetheredButtonYPosition = screenFrame.height -
-                (lastYComputed - screenFrame.minY) -
-                ExternalTetheredButton.containerHeight + (TetheredButton.height / 2)
+            state.tetheredButtonYRelativePosition = hintYRelativePosition
         }
 
         let frame = NSRect(

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -21,6 +21,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     // MARK: - Properties
     
     var isResizingWindows: Bool = false
+    var hintYRelativePosition: CGFloat?
     
     private var lastScreenFrame = CGRect.zero
     private var globalMouseMonitor: Any?
@@ -114,6 +115,8 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
         draggingWindow = nil
         
         state.removeDelegate(self)
+        
+        hintYRelativePosition = nil
         
         super.stop()
     }

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Hint.swift
@@ -41,7 +41,6 @@ extension PanelStateTetheredManager {
         
         let buttonView = NSHostingView(rootView: tetherView)
         tetherHintDetails.tetherWindow.contentView = buttonView
-        tetherHintDetails.lastYComputed = nil
         tetherButtonPanelState = state
 
         updateTetherWindowPosition(for: activeWindow, action: action, lastYComputed: tetherHintDetails.lastYComputed)
@@ -81,10 +80,13 @@ extension PanelStateTetheredManager {
         let windowFrame = optionalWindowFrame ?? activeWindowFrame
         
         var positionY: CGFloat
-        if lastYComputed == nil {
-            positionY = windowFrame.minY + (windowFrame.height / 2) - (ExternalTetheredButton.containerHeight / 2)
+        
+        if let appKey = appKey(for: activeWindow),
+           let relativePosition = relativeHintPositionsByApp[appKey] {
+            positionY = windowFrame.minY + (relativePosition * windowFrame.height) - (ExternalTetheredButton.containerHeight / 2)
+            positionY = max(windowFrame.minY, min(positionY, windowFrame.maxY - ExternalTetheredButton.containerHeight))
         } else {
-            positionY = computeTetheredWindowY(windowFrame: windowFrame, offset: lastYComputed)
+            positionY = windowFrame.minY + (windowFrame.height / 2) - (ExternalTetheredButton.containerHeight / 2)
         }
         
         let activeScreen = action == .move ? NSScreen.mouse : windowFrame.findScreen()
@@ -101,10 +103,10 @@ extension PanelStateTetheredManager {
             }
         }
 
-        if let state = tetherButtonPanelState {
-            state.tetheredButtonYPosition = windowFrame.height -
-                (positionY - windowFrame.minY) -
-                ExternalTetheredButton.containerHeight + (TetheredButton.height / 2)
+        if let state = tetherButtonPanelState,
+           let appKey = appKey(for: activeWindow),
+           let relativePosition = relativeHintPositionsByApp[appKey] {
+            state.tetheredButtonYRelativePosition = relativePosition
         }
 
         let frame = NSRect(
@@ -130,10 +132,15 @@ extension PanelStateTetheredManager {
         let lastYComputed = computeTetheredWindowY(windowFrame: windowFrame, offset: y)
         tetherHintDetails.lastYComputed = lastYComputed
         
-        if let state = tetherButtonPanelState {
-            state.tetheredButtonYPosition = windowFrame.height -
-                (lastYComputed - windowFrame.minY) -
-                ExternalTetheredButton.containerHeight + (TetheredButton.height / 2)
+        if let appKey = appKey(for: trackedWindow.element) {
+            let relativeY = (lastYComputed + (ExternalTetheredButton.containerHeight / 2) - windowFrame.minY) / windowFrame.height
+            relativeHintPositionsByApp[appKey] = max(0.0, min(1.0, relativeY))
+        }
+        
+        if let state = tetherButtonPanelState,
+           let appKey = appKey(for: trackedWindow.element),
+           let relativePosition = relativeHintPositionsByApp[appKey] {
+            state.tetheredButtonYRelativePosition = relativePosition
         }
 
         let frame = NSRect(
@@ -167,5 +174,11 @@ extension PanelStateTetheredManager {
         }
 
         return finalOffset
+    }
+    
+    private func appKey(for window: AXUIElement) -> String? {
+        guard let pid = window.pid() else { return nil }
+        
+        return "\(pid)-\(CFHash(window))"
     }
 }

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
@@ -26,6 +26,8 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
         }
     }
     
+    var relativeHintPositionsByApp: [String: CGFloat] = [:]
+    
     /// Dragging
     private let dragManager = GlobalDragManager()
     private var dragManagerCancellable: AnyCancellable?
@@ -77,6 +79,7 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
         super.stop()
         
         statesByWindow = [:]
+        relativeHintPositionsByApp = [:]
     }
     
     override func getState(for windowHash: UInt) -> OnitPanelState? {
@@ -165,11 +168,7 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
                     tempShowPanel(state: state)
                 }
                 
-                // TODO: KNA - We need to store the frame used to calculate the tetheredButtonYPosition and apply a diff
-                // Quick fix - when resizing, center the TetheredButton
-                if action == .resize {
-                    state.tetheredButtonYPosition = nil
-                } else if action == .move {
+                if action == .move {
                     action = checkIfDragStarted(state: state)
                 }
                 

--- a/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Untethered/PanelStateUntetheredManager.swift
@@ -20,6 +20,7 @@ class PanelStateUntetheredManager: PanelStateBaseManager, ObservableObject {
     // MARK: - Properties
     
     var lastScreenFrame = CGRect.zero
+    var hintYRelativePositionsByScreen: [String: CGFloat] = [:]
     
     private var globalMouseMonitor: Any?
     private var localMouseMonitor: Any?
@@ -98,6 +99,7 @@ class PanelStateUntetheredManager: PanelStateBaseManager, ObservableObject {
         super.stop()
         
         lastScreenFrame = CGRect.zero
+        hintYRelativePositionsByScreen = [:]
         statesByScreen = [:]
     }
     

--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -21,7 +21,19 @@ struct TetheredButton: View {
     }
     
     private var spacerHeight: CGFloat? {
-        state.tetheredButtonYPosition
+        guard let relativePosition = state.tetheredButtonYRelativePosition else { return nil }
+        
+        let windowHeight: CGFloat
+        if let trackedWindow = state.trackedWindow,
+           let frame = trackedWindow.element.getFrame(convertedToGlobalCoordinateSpace: true) {
+            windowHeight = frame.height
+        } else if let trackedScreen = state.trackedScreen {
+            windowHeight = trackedScreen.visibleFrame.height
+        } else {
+            return nil
+        }
+        
+        return windowHeight * (1.0 - relativePosition) - (Self.height / 2)
     }
 
     private var arrowRotation: Angle {

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -89,7 +89,7 @@ class OnitPanelState: NSObject {
         }
     }
     
-    var tetheredButtonYPosition: CGFloat?
+    var tetheredButtonYRelativePosition: CGFloat?
     
     var panelWidth: CGFloat 
     


### PR DESCRIPTION
* Work with all managers: Tethered, Pinned, Untethered.
* Untethered's tutorial follows the hint when dragged.
* Use relative positioning so panel's button follows the hint even when resizing app.