### PR TITLE
Add version to menu bar

### DIFF
--- a/macos/Onit/General/Extensions/Bundle+AppVersion.swift
+++ b/macos/Onit/General/Extensions/Bundle+AppVersion.swift
@@ -1,0 +1,18 @@
+//
+//  Bundle+AppVersion.swift
+//  Onit
+//
+//  Created by Jay Swanson on 6/17/25.
+//
+
+import Foundation
+
+extension Bundle {
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "N/A"
+    }
+
+    var appBuild: String {
+        infoDictionary?["CFBundleVersion"] as? String ?? "N/A"
+    }
+}

--- a/macos/Onit/General/Extensions/Error+Sample.swift
+++ b/macos/Onit/General/Extensions/Error+Sample.swift
@@ -12,13 +12,3 @@ extension Error where Self == NSError {
         NSError(domain: message, code: 0)
     }
 }
-
-extension Bundle {
-    var appVersion: String {
-        infoDictionary?["CFBundleShortVersionString"] as? String ?? "N/A"
-    }
-
-    var appBuild: String {
-        infoDictionary?["CFBundleVersion"] as? String ?? "N/A"
-    }
-}

--- a/macos/Onit/General/Extensions/Error+Sample.swift
+++ b/macos/Onit/General/Extensions/Error+Sample.swift
@@ -12,3 +12,13 @@ extension Error where Self == NSError {
         NSError(domain: message, code: 0)
     }
 }
+
+extension Bundle {
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "N/A"
+    }
+
+    var appBuild: String {
+        infoDictionary?["CFBundleVersion"] as? String ?? "N/A"
+    }
+}

--- a/macos/Onit/Menu Bar/Content Rows/MenuVersion.swift
+++ b/macos/Onit/Menu Bar/Content Rows/MenuVersion.swift
@@ -1,0 +1,37 @@
+//
+//  MenuVersion.swift
+//  Onit
+//
+//  Created by Alex on 1/12/25.
+//
+
+import SwiftUI
+
+struct MenuVersion: View {
+    private var versionText: String {
+        let version = Bundle.main.appVersion
+        let build = Bundle.main.appBuild
+        
+        #if BETA
+        return "Onit v\(version) (\(build)) - BETA"
+        #else
+        return "Onit v\(version) (\(build))"
+        #endif
+    }
+    
+    var body: some View {
+        HStack {
+            Text(versionText)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.primary.opacity(0.5))
+            Spacer()
+        }
+        .frame(height: 18)
+        .padding(.horizontal, 8)
+        .padding(.top, 4)
+    }
+}
+
+#Preview {
+    MenuVersion()
+}

--- a/macos/Onit/Menu Bar/MenuBarContent.swift
+++ b/macos/Onit/Menu Bar/MenuBarContent.swift
@@ -11,6 +11,8 @@ import Defaults
 struct MenuBarContent: View {
     var body: some View {
         VStack(spacing: 5) {
+            MenuVersion()
+            MenuDivider()
             MenuCheckForPermissions()
             MenuOpenOnitButton()
             MenuDivider()


### PR DESCRIPTION
Simple quality of life request from Elise. We should include the version in the menubar, so you don't have to open settings every time. Here's what it looks like: 

<img width="391" alt="Screenshot 2025-06-13 at 2 46 54 PM" src="https://github.com/user-attachments/assets/6811b3c2-a215-49f8-85ce-3b2d06caaa82" />
