### PR TITLE
Add logging around DefaultValue access

### DIFF
--- a/macos/Onit/UI/Environment/Environment+Values.swift
+++ b/macos/Onit/UI/Environment/Environment+Values.swift
@@ -5,8 +5,10 @@
 //  Created by Kévin Naudin on 03/02/2025.
 //
 
+#if DEBUG
 #if canImport(Darwin)
 import Darwin
+#endif
 #endif
 
 import SwiftUI

--- a/macos/Onit/UI/Environment/Environment+Values.swift
+++ b/macos/Onit/UI/Environment/Environment+Values.swift
@@ -5,12 +5,41 @@
 //  Created by Kévin Naudin on 03/02/2025.
 //
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 import SwiftUI
 
 private struct OnitPanelStateKey: @preconcurrency EnvironmentKey {
     
     @MainActor
     static let defaultValue: OnitPanelState = {
+        #if DEBUG
+        // If this default value is fetched from a non-MainActor thread it means a view is
+        // trying to read `@Environment(\.windowState)` before we have injected it. This is
+        // exactly the scenario that causes the DisplayLink-thread crash.  Emit diagnostic
+        // information and raise a trap so we can break in the debugger *only* when it
+        // happens off the main thread (to avoid noise for normal, correct reads).
+
+        if !Thread.isMainThread {
+            // Attempt to get the current dispatch-queue label so we can filter for the
+            // SwiftUI DisplayLink queue.
+            let labelPtr = __dispatch_queue_get_label(nil)
+            let queueLabel = String(cString: labelPtr, encoding: .utf8) ?? "<unknown>"
+
+            // We are primarily interested in the SwiftUI.DisplayLink queue, but keeping the
+            // check broad (non-main thread) is still useful. If the label matches the
+            // DisplayLink queue we will raise SIGTRAP so a symbolic breakpoint will hit.
+            if queueLabel.contains("com.apple.SwiftUI.DisplayLink") {
+                let symbols = Thread.callStackSymbols.joined(separator: "\n")
+                print("⚠️  windowState defaultValue fetched on DisplayLink queue (\(queueLabel))\n\n\(symbols)\n")
+                // Raise SIGTRAP to pause execution; can be disabled by simply continuing.
+                raise(SIGTRAP)
+            }
+        }
+        #endif
+
         let state = OnitPanelState()
         state.defaultEnvironmentSource = "EnvironmentKey"
         return state


### PR DESCRIPTION
This is to help us debug the errors that are occuring where the windowState is not set. I am going to put a breakpoint in this code and leave it there, so I can inspect it further if Onit ever falls back to the default state on my computer. 