### PR TITLE
Fix crash in SystemPrompt tab

### DIFF
--- a/macos/Onit/Data/Services/SystemPromptSuggestionService.swift
+++ b/macos/Onit/Data/Services/SystemPromptSuggestionService.swift
@@ -153,11 +153,10 @@ class SystemPromptSuggestionService {
     }
     
     private func updateSuggestions(text: String, apps: String) {
-        let context = ModelContext(state.container)
         let fetchDescriptor = FetchDescriptor<SystemPrompt>(
             sortBy: [SortDescriptor(\.lastUsed, order: .reverse)]
         )
-        let allPrompts = (try? context.fetch(fetchDescriptor)) ?? []
+        let allPrompts = (try? state.container.mainContext.fetch(fetchDescriptor)) ?? []
         lastPromptUsed = allPrompts.first ?? .outputOnly
         
         let scoredPrompts = allPrompts.map { prompt -> (SystemPrompt, Int) in

--- a/macos/Onit/Data/SwiftDataContainer.swift
+++ b/macos/Onit/Data/SwiftDataContainer.swift
@@ -21,13 +21,13 @@ actor SwiftDataContainer {
             let container = try ModelContainer(for: schema) // , migrationPlan: migrationPlan)
             maybeUpdatePromptPriorInstructions(container: container)
             
-            // Make sure the persistent store is empty. If it's not, return the non-empty container.
-            var itemFetchDescriptor = FetchDescriptor<SystemPrompt>()
-            itemFetchDescriptor.fetchLimit = 1
-            guard try container.mainContext.fetch(itemFetchDescriptor).count == 0 else { return container }
+            let itemFetchDescriptor = FetchDescriptor<SystemPrompt>()
+            let existingPrompts = try container.mainContext.fetch(itemFetchDescriptor)
             
-            container.mainContext.insert(SystemPrompt.outputOnly)
-            try container.mainContext.save()
+            if existingPrompts.isEmpty {
+                container.mainContext.insert(SystemPrompt.outputOnly)
+                try container.mainContext.save()
+            }
             
             return container
         } catch {

--- a/macos/Onit/UI/Content/ToolbarRight.swift
+++ b/macos/Onit/UI/Content/ToolbarRight.swift
@@ -90,8 +90,9 @@ struct ToolbarRight: View {
         .popover(
             isPresented: showHistoryBinding,
             arrowEdge: .bottom
-        )  {
+        ) {
             HistoryView()
+                .modelContainer(state.container)
         }
     }
 


### PR DESCRIPTION
* Avoid creating new ModelContext instead use existing one
* Surround with do/catch each modelContext.save()
* Show an alert to the user when an error occurs
* Remove unnecessary Task which can cause race.