### PR TITLE
Move database to new sandbox directory and migrate former db as needed

### DIFF
--- a/macos/Onit/Data/Services/DatabaseMigrationService.swift
+++ b/macos/Onit/Data/Services/DatabaseMigrationService.swift
@@ -1,0 +1,203 @@
+//
+//  DatabaseMigrationService.swift
+//  Onit
+//
+//  Created by Claude on $(date)
+//
+
+import Foundation
+import SwiftData
+import Defaults
+
+extension Defaults.Keys {
+    static let hasPerformedDatabaseMigration = Key<Bool>("hasPerformedDatabaseMigration", default: false)
+}
+
+@MainActor
+class DatabaseMigrationService {
+    
+    static let shared = DatabaseMigrationService()
+    
+    private init() {}
+    
+    /// Check if the legacy database exists and migration is needed
+    var migrationNeeded: Bool {
+        let legacyURL = getLegacyStorageURL()
+        let secureURL = getSecureStorageURL()
+        
+        return FileManager.default.fileExists(atPath: legacyURL.path) && 
+               !FileManager.default.fileExists(atPath: secureURL.path) &&
+               !Defaults[.hasPerformedDatabaseMigration]
+    }
+    
+    /// Get information about storage locations
+    var storageInfo: StorageInfo {
+        let legacyURL = getLegacyStorageURL()
+        let secureURL = getSecureStorageURL()
+        
+        return StorageInfo(
+            legacyLocation: legacyURL,
+            secureLocation: secureURL,
+            legacyExists: FileManager.default.fileExists(atPath: legacyURL.path),
+            secureExists: FileManager.default.fileExists(atPath: secureURL.path),
+            migrationCompleted: Defaults[.hasPerformedDatabaseMigration]
+        )
+    }
+    
+    /// Mark migration as completed
+    func markMigrationCompleted() {
+        Defaults[.hasPerformedDatabaseMigration] = true
+    }
+    
+    /// Perform migration by copying database files from legacy location to secure location
+    func performMigrationIfNeeded() {
+        guard migrationNeeded else {
+            return
+        }
+        
+        let storageInfo = self.storageInfo
+        print("DatabaseMigrationService - 🔄 Starting database migration by copying files...")
+        print("DatabaseMigrationService - 📋 Storage Information:")
+        print("DatabaseMigrationService - \(storageInfo.description)")
+        
+        do {
+            let legacyURL = storageInfo.legacyLocation
+            let newURL = storageInfo.secureLocation
+            let newDirectory = newURL.deletingLastPathComponent()
+            
+            // Ensure the new directory exists
+            try FileManager.default.createDirectory(at: newDirectory, 
+                                                   withIntermediateDirectories: true, 
+                                                   attributes: [.posixPermissions: 0o700])
+            
+            // Define the files to copy (SQLite database files)
+            let filesToCopy = [
+                ("default.store", "OnitData.sqlite"),           // Main database file
+                ("default.store-shm", "OnitData.sqlite-shm"),   // Shared memory file
+                ("default.store-wal", "OnitData.sqlite-wal")    // Write-ahead log file
+            ]
+            
+            var copiedFiles = 0
+            
+            for (legacyFileName, newFileName) in filesToCopy {
+                let legacyFileURL = legacyURL.deletingLastPathComponent().appendingPathComponent(legacyFileName)
+                let newFileURL = newDirectory.appendingPathComponent(newFileName)
+                
+                // Check if legacy file exists
+                if FileManager.default.fileExists(atPath: legacyFileURL.path) {
+                    // Remove existing file at destination if it exists
+                    if FileManager.default.fileExists(atPath: newFileURL.path) {
+                        try FileManager.default.removeItem(at: newFileURL)
+                        print("DatabaseMigrationService - 🗑️ Removed existing file: \(newFileURL.path)")
+                    }
+                    
+                    // Copy the file
+                    try FileManager.default.copyItem(at: legacyFileURL, to: newFileURL)
+                    print("DatabaseMigrationService - 📁 Copied \(legacyFileName) -> \(newFileName)")
+                    copiedFiles += 1
+                    
+                    // Set secure permissions on the copied file
+                    try FileManager.default.setAttributes([.posixPermissions: 0o600], 
+                                                         ofItemAtPath: newFileURL.path)
+                } else {
+                    print("DatabaseMigrationService - ⚠️ Legacy file not found: \(legacyFileURL.path)")
+                }
+            }
+            
+            if copiedFiles > 0 {
+                print("DatabaseMigrationService - ✅ Successfully copied \(copiedFiles) database files")
+                
+                // Create backup of original files before deletion
+                for (legacyFileName, _) in filesToCopy {
+                    let legacyFileURL = legacyURL.deletingLastPathComponent().appendingPathComponent(legacyFileName)
+                    let backupURL = legacyFileURL.appendingPathExtension("backup")
+                    
+                    if FileManager.default.fileExists(atPath: legacyFileURL.path) {
+                        // Remove existing backup if it exists
+                        if FileManager.default.fileExists(atPath: backupURL.path) {
+                            try? FileManager.default.removeItem(at: backupURL)
+                        }
+                        
+                        // Create backup
+                        try? FileManager.default.copyItem(at: legacyFileURL, to: backupURL)
+                        print("DatabaseMigrationService - 💾 Created backup: \(backupURL.lastPathComponent)")
+                        
+                        // Remove original file
+                        try? FileManager.default.removeItem(at: legacyFileURL)
+                        print("DatabaseMigrationService - 🗑️ Removed original: \(legacyFileName)")
+                    }
+                }
+                
+                // Mark migration as completed
+                markMigrationCompleted()
+                
+                print("DatabaseMigrationService - 🎉 Database migration completed successfully!")
+                print("DatabaseMigrationService - 📁 Data moved to secure location: \(newDirectory.path)")
+                print("DatabaseMigrationService - 🔒 Database is now stored in a secure, sandboxed location")
+                print("DatabaseMigrationService - 💾 Original files backed up with .backup extension")
+            } else {
+                print("DatabaseMigrationService - ⚠️ No files were copied - migration may not be needed")
+            }
+            
+        } catch {
+            print("DatabaseMigrationService - ❌ Failed to migrate database by copying: \(error)")
+            print("DatabaseMigrationService - 💡 The app will continue with the new secure storage location")
+            print("DatabaseMigrationService - 🔧 You may need to recreate your data if migration fails")
+            // Don't fatal error here - let the app continue with new storage location
+        }
+    }
+    
+    private func getLegacyStorageURL() -> URL {
+        // Get the actual user's home directory (not sandboxed)
+        let sandboxedHome = FileManager.default.homeDirectoryForCurrentUser
+        
+        // Parse the path to extract just /Users/username/
+        // sandboxedHome might be "/Users/timl/Library/Containers/inc.synth.Onit.dev/Data/"
+        let pathComponents = sandboxedHome.pathComponents
+        
+        // Find the user home directory by taking components up to and including the username
+        var userHomeComponents: [String] = []
+        for (index, component) in pathComponents.enumerated() {
+            // Stop after we find /Users/username pattern
+            if component == "Users" && index + 1 < pathComponents.count {
+                userHomeComponents.append(component)
+                userHomeComponents.append(pathComponents[index + 1]) // Add username
+                break
+            }
+        }
+        // TODO : TIM handle case where we don't find it.
+        
+        let actualHomeDirectory = URL(fileURLWithPath: "/"  + userHomeComponents.joined(separator: "/"))
+        let appSupportURL = actualHomeDirectory.appendingPathComponent("Library/Application Support")
+        return appSupportURL.appendingPathComponent("default.store")
+    }
+    
+    private func getSecureStorageURL() -> URL {
+        guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, 
+                                                           in: .userDomainMask).first else {
+            // TODO : TIM Do something other than 'fatal error'
+            fatalError("Could not find Application Support directory")
+        }
+        
+        let appName = Bundle.main.bundleIdentifier ?? "com.onit.app"
+        let secureAppDirectory = appSupportURL.appendingPathComponent(appName)
+        
+        return secureAppDirectory.appendingPathComponent("OnitData.sqlite")
+    }
+}
+
+struct StorageInfo {
+    let legacyLocation: URL
+    let secureLocation: URL
+    let legacyExists: Bool
+    let secureExists: Bool
+    let migrationCompleted: Bool
+    
+    var description: String {
+        var info = [String]()
+        info.append("Legacy Database: \(legacyLocation.path) (exists: \(legacyExists))")
+        info.append("Secure Database: \(secureLocation.path) (exists: \(secureExists))")
+        info.append("Migration Status: \(migrationCompleted ? "Completed" : "Pending")")
+        return info.joined(separator: "\n")
+    }
+} 

--- a/macos/Onit/Data/Services/DatabaseMigrationService.swift
+++ b/macos/Onit/Data/Services/DatabaseMigrationService.swift
@@ -20,26 +20,25 @@ class DatabaseMigrationService {
     
     private init() {}
     
-    /// Check if the legacy database exists and migration is needed
-    var migrationNeeded: Bool {
-        let legacyURL = getLegacyStorageURL()
-        let secureURL = getSecureStorageURL()
-        
-        return FileManager.default.fileExists(atPath: legacyURL.path) && 
-               !FileManager.default.fileExists(atPath: secureURL.path) &&
-               !Defaults[.hasPerformedDatabaseMigration]
-    }
-    
     /// Get information about storage locations
     var storageInfo: StorageInfo {
         let legacyURL = getLegacyStorageURL()
         let secureURL = getSecureStorageURL()
+
+        var legacyExists = false
+        if let legacyURL = legacyURL, FileManager.default.fileExists(atPath: legacyURL.path) {
+            legacyExists = true
+        }
+        var secureExists = false
+        if let secureURL = secureURL, FileManager.default.fileExists(atPath: secureURL.path) {
+            secureExists = true
+        }
         
         return StorageInfo(
             legacyLocation: legacyURL,
             secureLocation: secureURL,
-            legacyExists: FileManager.default.fileExists(atPath: legacyURL.path),
-            secureExists: FileManager.default.fileExists(atPath: secureURL.path),
+            legacyExists: legacyExists,
+            secureExists: secureExists,
             migrationCompleted: Defaults[.hasPerformedDatabaseMigration]
         )
     }
@@ -51,103 +50,82 @@ class DatabaseMigrationService {
     
     /// Perform migration by copying database files from legacy location to secure location
     func performMigrationIfNeeded() {
-        guard migrationNeeded else {
-            return
-        }
-        
         let storageInfo = self.storageInfo
-        print("DatabaseMigrationService - 🔄 Starting database migration by copying files...")
-        print("DatabaseMigrationService - 📋 Storage Information:")
-        print("DatabaseMigrationService - \(storageInfo.description)")
         
-        do {
-            let legacyURL = storageInfo.legacyLocation
-            let newURL = storageInfo.secureLocation
-            let newDirectory = newURL.deletingLastPathComponent()
+        if let legacyURL = storageInfo.legacyLocation,
+           let newURL = storageInfo.secureLocation,
+           storageInfo.legacyExists {
+           !storageInfo.secureExists,
+           !storageInfo.migrationCompleted {
             
-            // Ensure the new directory exists
-            try FileManager.default.createDirectory(at: newDirectory, 
-                                                   withIntermediateDirectories: true, 
-                                                   attributes: [.posixPermissions: 0o700])
+            print("DatabaseMigrationService - 🔄 Starting database migration by copying files...")
+            print("DatabaseMigrationService - 📋 Storage Information:")
+            print("DatabaseMigrationService - \(storageInfo.description)")
             
-            // Define the files to copy (SQLite database files)
-            let filesToCopy = [
-                ("default.store", "OnitData.sqlite"),           // Main database file
-                ("default.store-shm", "OnitData.sqlite-shm"),   // Shared memory file
-                ("default.store-wal", "OnitData.sqlite-wal")    // Write-ahead log file
-            ]
-            
-            var copiedFiles = 0
-            
-            for (legacyFileName, newFileName) in filesToCopy {
-                let legacyFileURL = legacyURL.deletingLastPathComponent().appendingPathComponent(legacyFileName)
-                let newFileURL = newDirectory.appendingPathComponent(newFileName)
+            do {
+                let newDirectory = newURL.deletingLastPathComponent()
                 
-                // Check if legacy file exists
-                if FileManager.default.fileExists(atPath: legacyFileURL.path) {
-                    // Remove existing file at destination if it exists
-                    if FileManager.default.fileExists(atPath: newFileURL.path) {
-                        try FileManager.default.removeItem(at: newFileURL)
-                        print("DatabaseMigrationService - 🗑️ Removed existing file: \(newFileURL.path)")
-                    }
-                    
-                    // Copy the file
-                    try FileManager.default.copyItem(at: legacyFileURL, to: newFileURL)
-                    print("DatabaseMigrationService - 📁 Copied \(legacyFileName) -> \(newFileName)")
-                    copiedFiles += 1
-                    
-                    // Set secure permissions on the copied file
-                    try FileManager.default.setAttributes([.posixPermissions: 0o600], 
-                                                         ofItemAtPath: newFileURL.path)
-                } else {
-                    print("DatabaseMigrationService - ⚠️ Legacy file not found: \(legacyFileURL.path)")
-                }
-            }
-            
-            if copiedFiles > 0 {
-                print("DatabaseMigrationService - ✅ Successfully copied \(copiedFiles) database files")
+                // Ensure the new directory exists
+                try FileManager.default.createDirectory(at: newDirectory, 
+                                                    withIntermediateDirectories: true, 
+                                                    attributes: [.posixPermissions: 0o700])
                 
-                // Create backup of original files before deletion
-                for (legacyFileName, _) in filesToCopy {
+                // Define the files to copy (SQLite database files)
+                let filesToCopy = [
+                    ("default.store", "OnitData.sqlite"),           // Main database file
+                    ("default.store-shm", "OnitData.sqlite-shm"),   // Shared memory file
+                    ("default.store-wal", "OnitData.sqlite-wal")    // Write-ahead log file
+                ]
+                
+                var copiedFiles = 0
+                
+                for (legacyFileName, newFileName) in filesToCopy {
                     let legacyFileURL = legacyURL.deletingLastPathComponent().appendingPathComponent(legacyFileName)
-                    let backupURL = legacyFileURL.appendingPathExtension("backup")
+                    let newFileURL = newDirectory.appendingPathComponent(newFileName)
                     
+                    // Check if legacy file exists
                     if FileManager.default.fileExists(atPath: legacyFileURL.path) {
-                        // Remove existing backup if it exists
-                        if FileManager.default.fileExists(atPath: backupURL.path) {
-                            try? FileManager.default.removeItem(at: backupURL)
+                        // Remove existing file at destination if it exists
+                        if FileManager.default.fileExists(atPath: newFileURL.path) {
+                            try FileManager.default.removeItem(at: newFileURL)
+                            print("DatabaseMigrationService - 🗑️ Removed existing file: \(newFileURL.path)")
                         }
                         
-                        // Create backup
-                        try? FileManager.default.copyItem(at: legacyFileURL, to: backupURL)
-                        print("DatabaseMigrationService - 💾 Created backup: \(backupURL.lastPathComponent)")
+                        // Copy the file
+                        try FileManager.default.copyItem(at: legacyFileURL, to: newFileURL)
+                        print("DatabaseMigrationService - 📁 Copied \(legacyFileName) -> \(newFileName)")
+                        copiedFiles += 1
                         
-                        // Remove original file
-                        try? FileManager.default.removeItem(at: legacyFileURL)
-                        print("DatabaseMigrationService - 🗑️ Removed original: \(legacyFileName)")
+                        // Set secure permissions on the copied file
+                        try FileManager.default.setAttributes([.posixPermissions: 0o600], 
+                                                            ofItemAtPath: newFileURL.path)
+                    } else {
+                        print("DatabaseMigrationService - ⚠️ Legacy file not found: \(legacyFileURL.path)")
                     }
                 }
                 
-                // Mark migration as completed
-                markMigrationCompleted()
+                if copiedFiles > 0 {
+                    print("DatabaseMigrationService - ✅ Successfully copied \(copiedFiles) database files")
+                    // Mark migration as completed
+                    markMigrationCompleted()
+                    
+                    print("DatabaseMigrationService - 🎉 Database migration completed successfully!")
+                    print("DatabaseMigrationService - 📁 Data moved to secure location: \(newDirectory.path)")
+                    print("DatabaseMigrationService - 🔒 Database is now stored in a secure, sandboxed location")
+                } else {
+                    print("DatabaseMigrationService - ⚠️ No files were copied - migration may not be needed")
+                }
                 
-                print("DatabaseMigrationService - 🎉 Database migration completed successfully!")
-                print("DatabaseMigrationService - 📁 Data moved to secure location: \(newDirectory.path)")
-                print("DatabaseMigrationService - 🔒 Database is now stored in a secure, sandboxed location")
-                print("DatabaseMigrationService - 💾 Original files backed up with .backup extension")
-            } else {
-                print("DatabaseMigrationService - ⚠️ No files were copied - migration may not be needed")
+            } catch {
+                print("DatabaseMigrationService - ❌ Failed to migrate database by copying: \(error)")
+                print("DatabaseMigrationService - 💡 The app will continue with the new secure storage location")
+                print("DatabaseMigrationService - 🔧 You may need to recreate your data if migration fails")
+                // Don't fatal error here - let the app continue with new storage location
             }
-            
-        } catch {
-            print("DatabaseMigrationService - ❌ Failed to migrate database by copying: \(error)")
-            print("DatabaseMigrationService - 💡 The app will continue with the new secure storage location")
-            print("DatabaseMigrationService - 🔧 You may need to recreate your data if migration fails")
-            // Don't fatal error here - let the app continue with new storage location
         }
     }
     
-    private func getLegacyStorageURL() -> URL {
+    private func getLegacyStorageURL() -> URL? {
         // Get the actual user's home directory (not sandboxed)
         let sandboxedHome = FileManager.default.homeDirectoryForCurrentUser
         
@@ -165,18 +143,18 @@ class DatabaseMigrationService {
                 break
             }
         }
-        // TODO : TIM handle case where we don't find it.
-        
+        if userHomeComponents.count != 2 {
+            return nil
+        }
         let actualHomeDirectory = URL(fileURLWithPath: "/"  + userHomeComponents.joined(separator: "/"))
         let appSupportURL = actualHomeDirectory.appendingPathComponent("Library/Application Support")
         return appSupportURL.appendingPathComponent("default.store")
     }
     
-    private func getSecureStorageURL() -> URL {
-        guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, 
+    public func getSecureStorageURL() -> URL? {
+        guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory,
                                                            in: .userDomainMask).first else {
-            // TODO : TIM Do something other than 'fatal error'
-            fatalError("Could not find Application Support directory")
+            return nil
         }
         
         let appName = Bundle.main.bundleIdentifier ?? "com.onit.app"
@@ -187,16 +165,16 @@ class DatabaseMigrationService {
 }
 
 struct StorageInfo {
-    let legacyLocation: URL
-    let secureLocation: URL
+    let legacyLocation: URL?
+    let secureLocation: URL?
     let legacyExists: Bool
     let secureExists: Bool
     let migrationCompleted: Bool
     
     var description: String {
         var info = [String]()
-        info.append("Legacy Database: \(legacyLocation.path) (exists: \(legacyExists))")
-        info.append("Secure Database: \(secureLocation.path) (exists: \(secureExists))")
+        info.append("Legacy Database: \(legacyLocation?.path ?? "none") (exists: \(legacyExists))")
+        info.append("Secure Database: \(secureLocation?.path ?? "none") (exists: \(secureExists))")
         info.append("Migration Status: \(migrationCompleted ? "Completed" : "Pending")")
         return info.joined(separator: "\n")
     }

--- a/macos/Onit/Data/Services/DatabaseMigrationService.swift
+++ b/macos/Onit/Data/Services/DatabaseMigrationService.swift
@@ -54,7 +54,7 @@ class DatabaseMigrationService {
         
         if let legacyURL = storageInfo.legacyLocation,
            let newURL = storageInfo.secureLocation,
-           storageInfo.legacyExists {
+           storageInfo.legacyExists,
            !storageInfo.secureExists,
            !storageInfo.migrationCompleted {
             

--- a/macos/Onit/Data/Structures/SettingsTab.swift
+++ b/macos/Onit/Data/Structures/SettingsTab.swift
@@ -9,6 +9,7 @@ enum SettingsTab: String {
     case webSearch
     case about
     #if DEBUG
+        case database
         case debug
         case account
     #endif

--- a/macos/Onit/Data/SwiftDataContainer.swift
+++ b/macos/Onit/Data/SwiftDataContainer.swift
@@ -25,8 +25,12 @@ actor SwiftDataContainer {
             DatabaseMigrationService.shared.performMigrationIfNeeded()
             
             // Create container with default secure storage (sandboxed location)
-            let container = try ModelContainer(for: schema)
-            
+            var configurations : [ModelConfiguration] = []
+            if let secureStorageURL = DatabaseMigrationService.shared.getSecureStorageURL() {
+                configurations.append(ModelConfiguration(url: secureStorageURL))
+            }
+            let container = try ModelContainer(for: schema, configurations: configurations)
+                
             maybeUpdatePromptPriorInstructions(container: container)
             
             // Make sure the persistent store is empty. If it's not, return the non-empty container.

--- a/macos/Onit/Data/SwiftDataContainer.swift
+++ b/macos/Onit/Data/SwiftDataContainer.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import Defaults
+import Foundation
 
 actor SwiftDataContainer {
     
@@ -17,8 +18,15 @@ actor SwiftDataContainer {
                 Chat.self,
                 SystemPrompt.self,
             ])
-                        
-            let container = try ModelContainer(for: schema) // , migrationPlan: migrationPlan)
+            
+            // This handles legacy clients before we added the sandbox entitlement. 
+            // Their data will be stored in the public ~/Library/Application Support/default.store, 
+            // which is accessible to other apps. This function copies that data to a new, private location.
+            DatabaseMigrationService.shared.performMigrationIfNeeded()
+            
+            // Create container with default secure storage (sandboxed location)
+            let container = try ModelContainer(for: schema)
+            
             maybeUpdatePromptPriorInstructions(container: container)
             
             // Make sure the persistent store is empty. If it's not, return the non-empty container.
@@ -77,7 +85,9 @@ actor SwiftDataContainer {
             // Mark migration as performed
             Defaults[.hasPerformedInstructionResponseMigration] = true
         } catch {
-            print("Error updating prior instructions: \(error)")
+            print("SwiftDataContainer - Error updating prior instructions: \(error)")
         }
     }
+    
+
 }

--- a/macos/Onit/Onit.entitlements
+++ b/macos/Onit/Onit.entitlements
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<!-- Temporary exception for migration - allows access to user's Library -->
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
+	<array>
+		<string>/Users/</string>
+	</array>
 	<key>com.apple.security.accessibility</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/macos/Onit/UI/Settings/DatabaseSettingsView.swift
+++ b/macos/Onit/UI/Settings/DatabaseSettingsView.swift
@@ -60,7 +60,7 @@ struct DatabaseSettingsView: View {
                     Spacer()
                 }
                 
-                Text(info.secureLocation.path)
+                Text(info.secureLocation?.path ?? "")
                     .font(.caption)
                     .textSelection(.enabled)
                     .padding(8)
@@ -113,7 +113,7 @@ struct DatabaseSettingsView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
             
-            Text(info.legacyLocation.appendingPathExtension("backup").path)
+            Text(info.legacyLocation?.appendingPathExtension("backup").path ?? "")
                 .font(.caption)
                 .textSelection(.enabled)
                 .padding(8)

--- a/macos/Onit/UI/Settings/DatabaseSettingsView.swift
+++ b/macos/Onit/UI/Settings/DatabaseSettingsView.swift
@@ -1,0 +1,156 @@
+//
+//  DatabaseSettingsView.swift
+//  Onit
+//
+//  Created by Claude on $(date)
+//
+
+import SwiftUI
+import SwiftData
+
+struct DatabaseSettingsView: View {
+    @State private var storageInfo: StorageInfo?
+    @State private var refreshTrigger = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Database Storage")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            if let storageInfo = storageInfo {
+                VStack(alignment: .leading, spacing: 12) {
+                    storageStatusCard(storageInfo)
+                    migrationStatusCard(storageInfo)
+                    
+                    if storageInfo.legacyExists {
+                        legacyWarningCard(storageInfo)
+                    }
+                }
+            } else {
+                ProgressView("Loading storage information...")
+                    .frame(height: 100)
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .onAppear {
+            loadStorageInfo()
+        }
+        .onChange(of: refreshTrigger) { _, _ in
+            loadStorageInfo()
+        }
+    }
+    
+    private func storageStatusCard(_ info: StorageInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "database")
+                    .foregroundColor(.blue)
+                Text("Storage Location")
+                    .font(.headline)
+            }
+            
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Current Database:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                
+                Text(info.secureLocation.path)
+                    .font(.caption)
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(4)
+                
+                HStack {
+                    Circle()
+                        .fill(info.secureExists ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text(info.secureExists ? "Database exists" : "Database not found")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.controlBackgroundColor))
+        .cornerRadius(8)
+    }
+    
+    private func migrationStatusCard(_ info: StorageInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: info.migrationCompleted ? "checkmark.shield" : "clock")
+                    .foregroundColor(info.migrationCompleted ? .green : .orange)
+                Text("Migration Status")
+                    .font(.headline)
+            }
+            
+            Text(migrationStatusText(info))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Color(.controlBackgroundColor))
+        .cornerRadius(8)
+    }
+    
+    private func legacyWarningCard(_ info: StorageInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundColor(.yellow)
+                Text("Legacy Database Found")
+                    .font(.headline)
+            }
+            
+            Text("A legacy database file was found at the old location. If migration was successful, you can safely delete the backup file.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            Text(info.legacyLocation.appendingPathExtension("backup").path)
+                .font(.caption)
+                .textSelection(.enabled)
+                .padding(8)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(4)
+            
+            Button("Refresh Status") {
+                refreshTrigger.toggle()
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+        }
+        .padding()
+        .background(Color.yellow.opacity(0.1))
+        .cornerRadius(8)
+    }
+    
+    private func migrationStatusText(_ info: StorageInfo) -> String {
+        if info.migrationCompleted {
+            return "✅ Migration completed successfully. Your data is now stored in a secure, sandboxed location."
+        } else if info.legacyExists && info.secureExists {
+            return "⚠️ Both legacy and secure databases exist. Migration may be in progress or failed."
+        } else if info.legacyExists && !info.secureExists {
+            return "📦 Legacy database found. Migration will occur on next app restart."
+        } else {
+            return "🆕 No legacy data found. Using secure storage from the start."
+        }
+    }
+    
+    private func loadStorageInfo() {
+        Task { @MainActor in
+            storageInfo = DatabaseMigrationService.shared.storageInfo
+        }
+    }
+}
+
+#Preview {
+    DatabaseSettingsView()
+        .frame(width: 500, height: 400)
+} 

--- a/macos/Onit/UI/Settings/SettingsView.swift
+++ b/macos/Onit/UI/Settings/SettingsView.swift
@@ -57,6 +57,14 @@ struct SettingsView: View {
                 .tag(SettingsTab.webSearch)
 
             #if DEBUG
+            DatabaseSettingsView()
+                .tabItem {
+                    Label("Database", systemImage: "externaldrive")
+                }
+                .tag(SettingsTab.database)
+            #endif
+
+            #if DEBUG
                 DebugModeTab()
                     .tabItem {
                         Label("Debug", systemImage: "wrench.and.screwdriver")


### PR DESCRIPTION
Some users have reported a bug where their history and system prompts get reset periodically. On thinking about this, I realized that:
1. The app is currently not using a sandboxed mode, as we are not distributing it through the App Store. 
2. This means that all our data is stored in a 'default.store' file located in a public directory (in this case, ~Library/Application Support/). 
3. Theoretically, any other app that makes the same mistake will also write its data to the default.store file at that same location. 

These realizations lead me to the theory: perhaps when our users lose their history, it's because another app has overwritten the file. To resolve the issue, we should migrate our data to a sandboxed URL. We accomplish this by adding the sandbox entitlement. With the sandbox entitlement in place, the URLs will automatically default to a private, app-access-only location. 

Then, there's some complication for existing users, who have existing data in the shared default.store. To solve this, I copy any existing file from the public URL to the sandboxed URL on first start. This PR also added a debug-only settings view, which allows us to track this (though this is probably not very helpful, and something we can delete in the future).