### PR TITLE
Use drive file permission with Google picker

### DIFF
--- a/macos/Onit/Data/Fetching/Endpoints/Onit/Auth/GetGooglePickerAPIKey.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Onit/Auth/GetGooglePickerAPIKey.swift
@@ -1,0 +1,43 @@
+//
+//  GetGooglePickerAPIKey.swift
+//  Onit
+//
+//  Created by Jay Swanson on 6/23/25.
+//
+
+import Foundation
+
+extension FetchingClient {
+    func getGooglePickerAPIKey() async throws -> String {
+        let endpoint = GetGooglePickerAPIKeyEndpoint()
+        let response = try await execute(endpoint)
+        return response.key
+    }
+}
+
+struct GetGooglePickerAPIKeyEndpoint: Endpoint {
+    typealias Request = EmptyRequest
+
+    typealias Response = GooglePickerAPIKeyResponse
+
+    var baseURL: URL { OnitServer.baseURL }
+
+    var path: String { "/v1/auth/google-picker-api-key" }
+
+    var getParams: [String: String]? { nil }
+
+    var method: HTTPMethod { .get }
+
+    var token: String? { TokenManager.token }
+
+    var requestBody: Request? { nil }
+
+    var additionalHeaders: [String: String]? { nil }
+
+    var timeout: TimeInterval? { nil }
+
+}
+
+struct GooglePickerAPIKeyResponse: Codable {
+    let key: String
+}


### PR DESCRIPTION
- The Google Drive `readonly` scope requires a security review
- Use the `file` scope in the meantime
- The `file` scope requires that we let the user select files via their Picker API
- Support that Picker API in a web view