### PR TITLE
Solution for Environments+Values crash

### DIFF
--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
@@ -17,6 +17,8 @@ extension KeyboardShortcuts.Name {
     static let newChat = Self("newChat", default: .init(.nine, modifiers: [.command]))
     static let toggleLocalMode = Self(
         "toggleLocalMode", default: .init(.seven, modifiers: [.shift, .command]))
+    static let addForegroundWindowToContext = Self(
+        "addForegroundWindowToContext", default: .init(.nine, modifiers: [.command]))
 }
 
 extension KeyboardShortcuts.Name: @retroactive CaseIterable {
@@ -25,6 +27,7 @@ extension KeyboardShortcuts.Name: @retroactive CaseIterable {
         .launchWithAutoContext,
         .escape,
         .newChat,
-        .toggleLocalMode
+        .toggleLocalMode,
+        .addForegroundWindowToContext
     ]
 }

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -110,6 +110,10 @@ struct KeyboardShortcutsManager {
                     state.newChat()
                 case .toggleLocalMode:
                     Defaults[.mode] = Defaults[.mode] == .local ? .remote : .local
+                case .addForegroundWindowToContext:
+                    if let foregroundWindow = state.foregroundWindow {
+                        state.addWindowToContext(window: foregroundWindow.element)
+                    }
                 default:
                     print("KeyboardShortcut not handled: \(name)")
                 }

--- a/macos/Onit/UI/Chat/ChatSystemPromptView.swift
+++ b/macos/Onit/UI/Chat/ChatSystemPromptView.swift
@@ -91,7 +91,7 @@ struct ChatSystemPromptView: View {
                                     .foregroundStyle(.blue300)
                                     .underline()
                                     .onTapGesture {
-                                        state.newChat(shouldSystemPrompt: true)
+                                        state?.newChat(shouldSystemPrompt: true)
                                     }
                             }
                         }

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -11,15 +11,15 @@ struct ChatView: View {
     @State private var chatChangeTask: Task<Void, Never>?
     
     private var chatsID: Int? {
-        state.currentChat?.hashValue
+        state?.currentChat?.hashValue
     }
     
     private var shouldShowSystemPrompt: Bool {
-        state.currentChat?.systemPrompt == nil && state.systemPromptState.shouldShowSystemPrompt
+        state?.currentChat?.systemPrompt == nil && state?.systemPromptState.shouldShowSystemPrompt == true
     }
     
     private var currentPromptsCount: Int {
-        if let currentPrompts = state.currentPrompts {
+        if let currentPrompts = state?.currentPrompts {
             return currentPrompts.count
         } else {
             return 0
@@ -35,8 +35,8 @@ struct ChatView: View {
                 ZStack(alignment: .bottom) {
                     ChatScrollViewRepresentable(
                         hasUserManuallyScrolled: $hasUserManuallyScrolled,
-                        streamedResponse: state.streamedResponse,
-                        currentChat: state.currentChat
+                        streamedResponse: state?.streamedResponse ?? "",
+                        currentChat: state?.currentChat
                     ) {
                         VStack(alignment: .leading, spacing: 0) {
                             systemPrompt
@@ -48,11 +48,11 @@ struct ChatView: View {
                         }
                     }
                     // Floating action buttons area
-                    if state.generatingPrompt != nil || hasUserManuallyScrolled {
+                    if state?.generatingPrompt != nil || hasUserManuallyScrolled {
                         HStack {
                             Spacer()
                             
-                            if state.generatingPrompt != nil {
+                            if state?.generatingPrompt != nil {
                                 StopGenerationButton()
                                     .offset(x: 18, y: 0) // This centers it to account for the scroll button frame
                             }
@@ -85,7 +85,7 @@ struct ChatView: View {
                         .padding(.bottom, 4)
                     }
                 }
-                .onChange(of: state.currentChat) { old, new in
+                .onChange(of: state?.currentChat) { old, new in
 					chatChangeTask?.cancel()
                     hasUserManuallyScrolled = true
                     chatChangeTask = Task {
@@ -121,7 +121,7 @@ struct ChatView: View {
 extension ChatView {
     var systemPrompt: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let systemPrompt = state.currentChat?.systemPrompt {
+            if let systemPrompt = state?.currentChat?.systemPrompt {
                 ChatSystemPromptView(systemPrompt: systemPrompt)
             }
             if shouldShowSystemPrompt { SystemPromptView() }

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -34,13 +34,13 @@ struct ContentView: View {
     
     private var showFileImporterBinding: Binding<Bool> {
         Binding(
-            get: { state.showFileImporter },
-            set: { state.showFileImporter = $0 }
+            get: { state?.showFileImporter ?? false },
+            set: { state?.showFileImporter = $0 }
         )
     }
     
     private var errorContext: Context? {
-        state.pendingContextList.first { context in
+        state?.pendingContextList.first { context in
             if case .auto(let autoContext) = context {
                 return autoContext.appContent["error"] != nil
             }
@@ -67,7 +67,7 @@ struct ContentView: View {
         ZStack(alignment: .top) {
             if shouldShowOnboardingAccessibility {
                 VStack(spacing: 0) {
-                    if state.showChatView {
+                    if state?.showChatView == true {
                         OnboardingAccessibility().transition(.opacity)
                     } else {
                         Spacer()
@@ -92,12 +92,12 @@ struct ContentView: View {
                         }
                         
                         VStack(spacing: 0) {
-                            if state.showChatView { ChatView().transition(.opacity) }
+                            if state?.showChatView == true { ChatView().transition(.opacity) }
                             else { Spacer() }
                         }
                     }
                     
-                    if state.showChatView {
+                    if state?.showChatView == true {
                         ZStack {
                             alertView(
                                 isPresented: showTwoWeekProTrialEndedAlert,
@@ -143,7 +143,7 @@ struct ContentView: View {
         ) { result in
             handleFileImport(result)
         }
-        .addAnimation(dependency: state.showChatView)
+        .addAnimation(dependency: state?.showChatView)
         .onAppear {
             if !hasClosedTrialEndedAlert {
                 if let subscriptionStatus = appState.subscription?.status {
@@ -165,15 +165,17 @@ struct ContentView: View {
     }
     
     private func handleViewClicked() {
-        state.textFocusTrigger.toggle()
+        state?.textFocusTrigger.toggle()
         
-        state.notifyDelegates { $0.panelBecomeKey(state: state) }
+        if let state = state {
+            state.notifyDelegates { $0.panelBecomeKey(state: state) }
+        }
     }
 
     private func handleFileImport(_ result: Result<[URL], any Error>) {
         switch result {
         case .success(let urls):
-            state.addContext(urls: urls)
+            state?.addContext(urls: urls)
         case .failure(let error):
             print(error.localizedDescription)
         }

--- a/macos/Onit/UI/Content/ExternalTetheredButton.swift
+++ b/macos/Onit/UI/Content/ExternalTetheredButton.swift
@@ -33,7 +33,7 @@ struct ExternalTetheredButton: View {
     }
     
     private var containsInput: Bool {
-        return windowState.pendingInput != nil
+        return windowState?.pendingInput != nil
     }
     
     private var containsInputBinding: Binding<Bool> {

--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -21,13 +21,14 @@ struct TetheredButton: View {
     }
     
     private var spacerHeight: CGFloat? {
-        guard let relativePosition = state?.tetheredButtonYRelativePosition else { return nil }
+        guard let state = state else { return nil }
+        guard let relativePosition = state.tetheredButtonYRelativePosition else { return nil }
         
         let windowHeight: CGFloat
-        if let trackedWindow = state?.trackedWindow,
+        if let trackedWindow = state.trackedWindow,
            let frame = trackedWindow.element.getFrame(convertedToGlobalCoordinateSpace: true) {
             windowHeight = frame.height
-        } else if let trackedScreen = state?.trackedScreen {
+        } else if let trackedScreen = state.trackedScreen {
             windowHeight = trackedScreen.visibleFrame.height
         } else {
             return nil
@@ -72,11 +73,6 @@ struct TetheredButton: View {
             }
             .tooltip(prompt: fitActiveWindowPrompt)
             Spacer()
-        }
-        .onAppear {
-            if let defaultEnvironmentSource = state?.defaultEnvironmentSource {
-                AnalyticsManager.Technical.defaultWindowState(source: defaultEnvironmentSource)
-            }
         }
         .edgesIgnoringSafeArea(.top)
         .frame(maxHeight: .infinity, alignment: .top)

--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -21,13 +21,13 @@ struct TetheredButton: View {
     }
     
     private var spacerHeight: CGFloat? {
-        guard let relativePosition = state.tetheredButtonYRelativePosition else { return nil }
+        guard let relativePosition = state?.tetheredButtonYRelativePosition else { return nil }
         
         let windowHeight: CGFloat
-        if let trackedWindow = state.trackedWindow,
+        if let trackedWindow = state?.trackedWindow,
            let frame = trackedWindow.element.getFrame(convertedToGlobalCoordinateSpace: true) {
             windowHeight = frame.height
-        } else if let trackedScreen = state.trackedScreen {
+        } else if let trackedScreen = state?.trackedScreen {
             windowHeight = trackedScreen.visibleFrame.height
         } else {
             return nil
@@ -41,7 +41,7 @@ struct TetheredButton: View {
             return .degrees(0)
         }
 
-        if state.trackedScreen != nil || state.panel == nil || state.panel?.resizedApplication == true {
+        if state?.trackedScreen != nil || state?.panel == nil || state?.panel?.resizedApplication == true {
             return .degrees(0)
         } else {
             return .degrees(180)
@@ -74,7 +74,7 @@ struct TetheredButton: View {
             Spacer()
         }
         .onAppear {
-            if let defaultEnvironmentSource = state.defaultEnvironmentSource {
+            if let defaultEnvironmentSource = state?.defaultEnvironmentSource {
                 AnalyticsManager.Technical.defaultWindowState(source: defaultEnvironmentSource)
             }
         }

--- a/macos/Onit/UI/Content/ToolbarLeft.swift
+++ b/macos/Onit/UI/Content/ToolbarLeft.swift
@@ -45,7 +45,7 @@ struct ToolbarLeft: View {
             tooltipShortcut: .keyboardShortcuts(.newChat)
         ) {
             AnalyticsManager.Toolbar.newChatPressed()
-            state.newChat()
+            state?.newChat()
         }
     }
     
@@ -55,13 +55,13 @@ struct ToolbarLeft: View {
             tooltipPrompt: "Start new Chat with system prompt"
         ) {
             AnalyticsManager.Toolbar.systemPromptPressed()
-            state.newChat()
-            state.systemPromptState.shouldShowSelection = true
-            state.systemPromptState.shouldShowSystemPrompt = true
+            state?.newChat()
+            state?.systemPromptState.shouldShowSelection = true
+            state?.systemPromptState.shouldShowSystemPrompt = true
         }
         .onHover(perform: { isHovered in
-            if isHovered && state.currentChat?.systemPrompt == nil && !state.systemPromptState.shouldShowSystemPrompt {
-                state.systemPromptState.shouldShowSystemPrompt = true
+            if isHovered && state?.currentChat?.systemPrompt == nil && state?.systemPromptState.shouldShowSystemPrompt != true {
+                state?.systemPromptState.shouldShowSystemPrompt = true
             }
         })
     }

--- a/macos/Onit/UI/Content/ToolbarRight.swift
+++ b/macos/Onit/UI/Content/ToolbarRight.swift
@@ -74,26 +74,28 @@ struct ToolbarRight: View {
 
     var showHistoryBinding: Binding<Bool> {
         Binding(
-            get: { self.state.showHistory },
-            set: { self.state.showHistory = $0 }
+            get: { self.state?.showHistory ?? false },
+            set: { self.state?.showHistory = $0 }
         )
     }
     var history: some View {
         IconButton(
             icon: .history,
             iconSize: 22,
-            isActive: state.showHistory,
+            isActive: state?.showHistory ?? false,
             tooltipPrompt: "History"
         ) {
-            AnalyticsManager.Toolbar.historyPressed(displayed: state.showHistory)
-            state.showHistory.toggle()
+            AnalyticsManager.Toolbar.historyPressed(displayed: state?.showHistory ?? false)
+            state?.showHistory.toggle()
         }
         .popover(
             isPresented: showHistoryBinding,
             arrowEdge: .bottom
         ) {
-            HistoryView()
-                .modelContainer(state.container)
+            if let state = state {
+                HistoryView()
+                    .modelContainer(state.container)
+            }
         }
     }
 

--- a/macos/Onit/UI/Content/ToolbarRight.swift
+++ b/macos/Onit/UI/Content/ToolbarRight.swift
@@ -71,13 +71,16 @@ struct ToolbarRight: View {
             MenuJoinDiscord.openDiscord(appState)
         }
     }
-
+   
+    var showHistory: Bool { state?.showHistory ?? false }
+    
     var showHistoryBinding: Binding<Bool> {
         Binding(
-            get: { self.state?.showHistory ?? false },
+            get: { self.showHistory },
             set: { self.state?.showHistory = $0 }
         )
     }
+    
     var history: some View {
         IconButton(
             icon: .history,

--- a/macos/Onit/UI/Environment/Environment+Values.swift
+++ b/macos/Onit/UI/Environment/Environment+Values.swift
@@ -32,14 +32,7 @@ extension EnvironmentValues {
     }
     
     var windowState: OnitPanelState? {
-        get { 
-            if Thread.isMainThread {
-                return self[OnitPanelStateKey.self]
-            } else {
-                print("Environment+ValuesDebug - returning nil for background get")
-                return nil
-            }
-        }
+        get { self[OnitPanelStateKey.self] }
         set { self[OnitPanelStateKey.self] = newValue }
     }
 }

--- a/macos/Onit/UI/Environment/Environment+Values.swift
+++ b/macos/Onit/UI/Environment/Environment+Values.swift
@@ -16,36 +16,7 @@ import SwiftUI
 private struct OnitPanelStateKey: @preconcurrency EnvironmentKey {
     
     @MainActor
-    static let defaultValue: OnitPanelState = {
-        #if DEBUG
-        // If this default value is fetched from a non-MainActor thread it means a view is
-        // trying to read `@Environment(\.windowState)` before we have injected it. This is
-        // exactly the scenario that causes the DisplayLink-thread crash.  Emit diagnostic
-        // information and raise a trap so we can break in the debugger *only* when it
-        // happens off the main thread (to avoid noise for normal, correct reads).
-
-        if !Thread.isMainThread {
-            // Attempt to get the current dispatch-queue label so we can filter for the
-            // SwiftUI DisplayLink queue.
-            let labelPtr = __dispatch_queue_get_label(nil)
-            let queueLabel = String(cString: labelPtr, encoding: .utf8) ?? "<unknown>"
-
-            // We are primarily interested in the SwiftUI.DisplayLink queue, but keeping the
-            // check broad (non-main thread) is still useful. If the label matches the
-            // DisplayLink queue we will raise SIGTRAP so a symbolic breakpoint will hit.
-            if queueLabel.contains("com.apple.SwiftUI.DisplayLink") {
-                let symbols = Thread.callStackSymbols.joined(separator: "\n")
-                print("⚠️  windowState defaultValue fetched on DisplayLink queue (\(queueLabel))\n\n\(symbols)\n")
-                // Raise SIGTRAP to pause execution; can be disabled by simply continuing.
-                raise(SIGTRAP)
-            }
-        }
-        #endif
-
-        let state = OnitPanelState()
-        state.defaultEnvironmentSource = "EnvironmentKey"
-        return state
-    }()
+    static let defaultValue: OnitPanelState? = nil
 }
 
 private struct OnitAppStateKey: @preconcurrency EnvironmentKey {
@@ -60,8 +31,15 @@ extension EnvironmentValues {
         set { self[OnitAppStateKey.self] = newValue }
     }
     
-    var windowState: OnitPanelState {
-        get { self[OnitPanelStateKey.self] }
+    var windowState: OnitPanelState? {
+        get { 
+            if Thread.isMainThread {
+                return self[OnitPanelStateKey.self]
+            } else {
+                print("Environment+ValuesDebug - returning nil for background get")
+                return nil
+            }
+        }
         set { self[OnitPanelStateKey.self] = newValue }
     }
 }

--- a/macos/Onit/UI/History/HistoryRowView.swift
+++ b/macos/Onit/UI/History/HistoryRowView.swift
@@ -2,66 +2,65 @@
 //  HistoryRowView.swift
 //  Onit
 //
-//  Created by Benjamin Sage on 11/4/24.
+//  Created by Benjamin Sage on 11/3/24.
 //
 
 import SwiftUI
 
 struct HistoryRowView: View {
     @Environment(\.windowState) private var windowState
+    let chat: Chat
+    let index: Int
     
-    @State private var showDelete: Bool = false
-
-    var chat: Chat
-    var index: Int
+    @State private var isHovered: Bool = false
+    @State private var isPressed: Bool = false
 
     var body: some View {
-        TextButton(
-            text: getPromptText()
-        ) {
-            Group {
-                if showDelete { deleteButton }
-                else { chatResponseCount }
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(chat.prompts.first?.instruction ?? "Empty chat")
+                    .appFont(.medium14)
+                    .foregroundStyle(.white)
+                    .truncateText()
+                
+                Text("\(chat.prompts.count) messages")
+                    .appFont(.medium12)
+                    .foregroundStyle(.white.opacity(0.6))
             }
-        } action: {
-            windowState.setChat(chat: chat, index: index)
-        }
-        .onHover { hovering in showDelete = hovering }
-    }
-    
-    var chatResponseCount: some View {
-        Text("\(chat.responseCount)")
-            .appFont(.medium13)
-            .monospacedDigit()
-            .foregroundStyle(.gray200)
-    }
-    
-    var deleteButton: some View {
-        HStack(alignment: .center) {
-            Text(windowState.deleteChatFailed ? "Delete failed" : "")
-                .foregroundColor(Color.red)
-            
-            Image(systemName: "trash")
-                .frame(width: 14, height: 14)
-        }
-        .frame(height: 34)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            // We want the padding around the button to also be a tap target
-            if !windowState.deleteChatFailed {
-                windowState.deleteChat(chat: chat)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onTapGesture {
+                windowState?.setChat(chat: chat, index: index)
+            }
+
+            HStack(spacing: 4) {
+                IconButton(
+                    icon: .remove,
+                    iconSize: 12,
+                    action: {
+                        // Only proceed if windowState is available and deletion hasn't failed
+                        guard let windowState = windowState else { return }
+                        
+                        if !windowState.deleteChatFailed {
+                            windowState.deleteChat(chat: chat)
+                        }
+                    },
+                    tooltipPrompt: "Delete"
+                )
             }
         }
-    }
-    
-    private func getPromptText() -> String {
-        guard let firstPrompt = chat.prompts.first,
-              !firstPrompt.responses.isEmpty,
-              firstPrompt.generationIndex < firstPrompt.responses.count else {
-            return "Empty"
-        }
-        
-        return firstPrompt.responses[firstPrompt.generationIndex].instruction ?? ""
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .addButtonEffects(
+            background: .gray700,
+            hoverBackground: .gray600,
+            cornerRadius: 6,
+            isHovered: $isHovered,
+            isPressed: $isPressed,
+            action: {
+                windowState?.setChat(chat: chat, index: index)
+            }
+        )
     }
 }
 

--- a/macos/Onit/UI/History/HistoryRowView.swift
+++ b/macos/Onit/UI/History/HistoryRowView.swift
@@ -2,65 +2,67 @@
 //  HistoryRowView.swift
 //  Onit
 //
-//  Created by Benjamin Sage on 11/3/24.
+//  Created by Benjamin Sage on 11/4/24.
 //
 
 import SwiftUI
 
 struct HistoryRowView: View {
     @Environment(\.windowState) private var windowState
-    let chat: Chat
-    let index: Int
     
-    @State private var isHovered: Bool = false
-    @State private var isPressed: Bool = false
+    @State private var showDelete: Bool = false
+
+    var chat: Chat
+    var index: Int
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(chat.prompts.first?.instruction ?? "Empty chat")
-                    .appFont(.medium14)
-                    .foregroundStyle(.white)
-                    .truncateText()
-                
-                Text("\(chat.prompts.count) messages")
-                    .appFont(.medium12)
-                    .foregroundStyle(.white.opacity(0.6))
+        TextButton(
+            text: getPromptText()
+        ) {
+            Group {
+                if showDelete { deleteButton }
+                else { chatResponseCount }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .onTapGesture {
-                windowState?.setChat(chat: chat, index: index)
-            }
-
-            HStack(spacing: 4) {
-                IconButton(
-                    icon: .remove,
-                    iconSize: 12,
-                    action: {
-                        // Only proceed if windowState is available and deletion hasn't failed
-                        guard let windowState = windowState else { return }
-                        
-                        if !windowState.deleteChatFailed {
-                            windowState.deleteChat(chat: chat)
-                        }
-                    },
-                    tooltipPrompt: "Delete"
-                )
+        } action: {
+            windowState?.setChat(chat: chat, index: index)
+        }
+        .onHover { hovering in showDelete = hovering }
+    }
+    
+    var chatResponseCount: some View {
+        Text("\(chat.responseCount)")
+            .appFont(.medium13)
+            .monospacedDigit()
+            .foregroundStyle(.gray200)
+    }
+    
+    var deleteButton: some View {
+        HStack(alignment: .center) {
+            Text(windowState?.deleteChatFailed == true ? "Delete failed" : "")
+                .foregroundColor(Color.red)
+            
+            Image(systemName: "trash")
+                .frame(width: 14, height: 14)
+        }
+        .frame(height: 34)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // We want the padding around the button to also be a tap target
+            guard let windowState = windowState else { return }
+            if !windowState.deleteChatFailed {
+                windowState.deleteChat(chat: chat)
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .addButtonEffects(
-            background: .gray700,
-            hoverBackground: .gray600,
-            cornerRadius: 6,
-            isHovered: $isHovered,
-            isPressed: $isPressed,
-            action: {
-                windowState?.setChat(chat: chat, index: index)
-            }
-        )
+    }
+    
+    private func getPromptText() -> String {
+        guard let firstPrompt = chat.prompts.first,
+              !firstPrompt.responses.isEmpty,
+              firstPrompt.generationIndex < firstPrompt.responses.count else {
+            return "Empty"
+        }
+        
+        return firstPrompt.responses[firstPrompt.generationIndex].instruction ?? ""
     }
 }
 

--- a/macos/Onit/UI/History/HistoryTitle.swift
+++ b/macos/Onit/UI/History/HistoryTitle.swift
@@ -11,23 +11,30 @@ struct HistoryTitle: View {
     @Environment(\.windowState) private var state
 
     var body: some View {
-        HStack {
-            Text("History")
-                .appFont(.medium14)
-                .foregroundStyle(.FG)
-            Spacer()
-            Button {
-                state.showHistory = false
-            } label: {
-                Image(.smallCross)
-                    .renderingMode(.template)
-                    .foregroundStyle(.gray200)
-                    .frame(width: 20, height: 20)
+        // Only show content if windowState is available
+        if let state = state {
+            HStack {
+                Text("History")
+                    .appFont(.medium14)
+                    .foregroundStyle(.FG)
+                Spacer()
+                Button {
+                    state.showHistory = false
+                } label: {
+                    Image(.smallCross)
+                        .renderingMode(.template)
+                        .foregroundStyle(.gray200)
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(BorderlessButtonStyle())
             }
-            .buttonStyle(BorderlessButtonStyle())
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        } else {
+            Text("History")
+                .appFont(.medium16)
+                .foregroundStyle(.white)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 }
 

--- a/macos/Onit/UI/History/HistoryTitle.swift
+++ b/macos/Onit/UI/History/HistoryTitle.swift
@@ -11,30 +11,23 @@ struct HistoryTitle: View {
     @Environment(\.windowState) private var state
 
     var body: some View {
-        // Only show content if windowState is available
-        if let state = state {
-            HStack {
-                Text("History")
-                    .appFont(.medium14)
-                    .foregroundStyle(.FG)
-                Spacer()
-                Button {
-                    state.showHistory = false
-                } label: {
-                    Image(.smallCross)
-                        .renderingMode(.template)
-                        .foregroundStyle(.gray200)
-                        .frame(width: 20, height: 20)
-                }
-                .buttonStyle(BorderlessButtonStyle())
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-        } else {
+        HStack {
             Text("History")
-                .appFont(.medium16)
-                .foregroundStyle(.white)
+                .appFont(.medium14)
+                .foregroundStyle(.FG)
+            Spacer()
+            Button {
+                state?.showHistory = false
+            } label: {
+                Image(.smallCross)
+                    .renderingMode(.template)
+                    .foregroundStyle(.gray200)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(BorderlessButtonStyle())
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 }
 

--- a/macos/Onit/UI/History/HistoryView.swift
+++ b/macos/Onit/UI/History/HistoryView.swift
@@ -59,7 +59,7 @@ struct HistoryView: View {
                     icon: .cross,
                     iconSize: 10
                 ) {
-                    windowState.showHistory = false
+                    windowState?.showHistory = false
                 }
             },
             search: MenuList.Search(query: $searchQuery)

--- a/macos/Onit/UI/Modifiers/DragModifier.swift
+++ b/macos/Onit/UI/Modifiers/DragModifier.swift
@@ -28,12 +28,12 @@ struct DragModifier: ViewModifier {
                         guard let item = items.first else { return false }
                         if let data = item.data {
                             if let image = NSImage(data: data) {
-                                state.addContext(images: [image])
+                                state?.addContext(images: [image])
                                 return true
                             }
                             return false
                         } else if let url = item.url {
-                            state.addContext(urls: [url])
+                            state?.addContext(urls: [url])
                             return true
                         }
                         return false

--- a/macos/Onit/UI/Modifiers/ImageProgressModifier.swift
+++ b/macos/Onit/UI/Modifiers/ImageProgressModifier.swift
@@ -13,7 +13,7 @@ struct ImageProgressModifier: ViewModifier {
     var url: URL
 
     var progress: Int? {
-        if let progress = state.imageUploads[url] {
+        if let progress = state?.imageUploads[url] {
             switch progress {
             case .completed:
                 return 100
@@ -26,7 +26,7 @@ struct ImageProgressModifier: ViewModifier {
     }
 
     var done: Bool {
-        if let progress = state.imageUploads[url] {
+        if let progress = state?.imageUploads[url] {
             switch progress {
             case .completed:
                 return true

--- a/macos/Onit/UI/Prompt/ChatsView.swift
+++ b/macos/Onit/UI/Prompt/ChatsView.swift
@@ -12,13 +12,18 @@ struct ChatsView: View {
     @Environment(\.windowState) private var state
     
     var body: some View {
-        VStack(spacing: 0) {
-            ForEach(state.currentPrompts ?? []) { prompt in
-                Rectangle() // This is very odd. Without this, we get about 20px of vertical padding that I can't explain.
-                    .frame(maxWidth: .infinity, minHeight: 0, maxHeight: 0)
-                    .padding(0)
-                PromptView(prompt: prompt)
+        // Only show content if windowState is available
+        if let state = state {
+            VStack(spacing: 0) {
+                ForEach(state.currentPrompts ?? []) { prompt in
+                    Rectangle() // This is very odd. Without this, we get about 20px of vertical padding that I can't explain.
+                        .frame(maxWidth: .infinity, minHeight: 0, maxHeight: 0)
+                        .padding(0)
+                    PromptView(prompt: prompt)
+                }
             }
+        } else {
+            EmptyView()
         }
     }
 }

--- a/macos/Onit/UI/Prompt/ChatsView.swift
+++ b/macos/Onit/UI/Prompt/ChatsView.swift
@@ -12,18 +12,13 @@ struct ChatsView: View {
     @Environment(\.windowState) private var state
     
     var body: some View {
-        // Only show content if windowState is available
-        if let state = state {
-            VStack(spacing: 0) {
-                ForEach(state.currentPrompts ?? []) { prompt in
-                    Rectangle() // This is very odd. Without this, we get about 20px of vertical padding that I can't explain.
-                        .frame(maxWidth: .infinity, minHeight: 0, maxHeight: 0)
-                        .padding(0)
-                    PromptView(prompt: prompt)
-                }
+        VStack(spacing: 0) {
+            ForEach(state?.currentPrompts ?? []) { prompt in
+                Rectangle() // This is very odd. Without this, we get about 20px of vertical padding that I can't explain.
+                    .frame(maxWidth: .infinity, minHeight: 0, maxHeight: 0)
+                    .padding(0)
+                PromptView(prompt: prompt)
             }
-        } else {
-            EmptyView()
         }
     }
 }

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -85,12 +85,14 @@ struct SetUpDialogs: View {
         debounceTask?.cancel()
         
         let task = DispatchWorkItem {
-            guard state?.panel?.isVisible == true else {
-                state?.setUpHeight = 0
-                return
+            DispatchQueue.main.async {
+                guard state?.panel?.isVisible == true else {
+                    state?.setUpHeight = 0
+                    return
+                }
+                
+                state?.setUpHeight = newHeight
             }
-            
-            state?.setUpHeight = newHeight
         }
         debounceTask = task
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: task)

--- a/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
+++ b/macos/Onit/UI/Prompt/Dialogs/SetUpDialogs.swift
@@ -46,47 +46,51 @@ struct SetUpDialogs: View {
     let scrollMaxHeight: CGFloat = 230
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack {
-                content
-            }
-            .onHeightChanged(callback: updateHeight)
-            .onChange(of: availableLocalModels.count) { _, new in
-                if new != 0 {
-                    seenLocal = true
+        if let state = state {
+            ScrollView(showsIndicators: false) {
+                VStack {
+                    content
                 }
+                .onHeightChanged(callback: updateHeight)
+                .onChange(of: availableLocalModels.count) { _, new in
+                    if new != 0 {
+                        seenLocal = true
+                    }
+                }
+                .padding(.bottom, 4) 
             }
-            .padding(.bottom, 4) 
+            .frame(maxHeight: min(state.setUpHeight, scrollMaxHeight))
+            .overlay(
+                Group {
+                    if state.setUpHeight >= scrollMaxHeight {
+                        LinearGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: Color.black, location: 0),
+                                .init(color: Color.black.opacity(0), location: 1)
+                            ]),
+                            startPoint: .bottom,
+                            endPoint: .top
+                        )
+                        .frame(height: 50)
+                    }
+                },
+                alignment: .bottom
+            )
+        } else {
+            EmptyView()
         }
-        .frame(maxHeight: min(state.setUpHeight, scrollMaxHeight))
-        .overlay(
-            Group {
-                if state.setUpHeight >= scrollMaxHeight {
-                    LinearGradient(
-                        gradient: Gradient(stops: [
-                            .init(color: Color.black, location: 0),
-                            .init(color: Color.black.opacity(0), location: 1)
-                        ]),
-                        startPoint: .bottom,
-                        endPoint: .top
-                    )
-                    .frame(height: 50)
-                }
-            },
-            alignment: .bottom
-        )
     }
     
     private func updateHeight(newHeight: CGFloat) {
         debounceTask?.cancel()
         
         let task = DispatchWorkItem {
-            guard state.panel?.isVisible == true else {
-                state.setUpHeight = 0
+            guard state?.panel?.isVisible == true else {
+                state?.setUpHeight = 0
                 return
             }
             
-            state.setUpHeight = newHeight
+            state?.setUpHeight = newHeight
         }
         debounceTask = task
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: task)

--- a/macos/Onit/UI/Prompt/Files/ContextItem.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextItem.swift
@@ -91,6 +91,7 @@ struct ContextItem: View {
 
 extension ContextItem {
     private func showContextWindow() {
+        guard let state = state else { return }
         ContextWindowsManager.shared.showContextWindow(
             windowState: state,
             context: item
@@ -101,7 +102,7 @@ extension ContextItem {
         ContextWindowsManager.shared.deleteContextItem(
             item: item
         )
-        state.removeContext(context: item)
+        state?.removeContext(context: item)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Files/ContextMenu.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextMenu.swift
@@ -14,38 +14,45 @@ struct ContextMenu: View {
     @State private var currentArrowKeyIndex: Int = 0
     @State private var maxArrowKeyIndex: Int = 0
     
-    // TODO: LOYD - Might want to delete later, as browser tabs are currently not implemented?
-    var showBrowserTabs: Bool {
-        return windowState.showContextMenuBrowserTabs
+    private var showBrowserTabsContextMenu: Bool {
+        return windowState?.showContextMenuBrowserTabs ?? false
     }
     
     var body: some View {
-        MenuList(
-            header: menuHeader,
-            search: MenuList.Search(
-                query: $searchQuery,
-                placeholder: "Search windows, tabs & files"
-            )
-        ) {
-            ContextMenuWindows(
-                searchQuery: $searchQuery,
-                currentArrowKeyIndex: $currentArrowKeyIndex,
-                maxArrowKeyIndex: $maxArrowKeyIndex
-            ) {
-                closeContextMenu()
-            } showBrowserTabsSubMenu: {
-                showBrowserTabsSubMenu()
+        VStack(spacing: 0) {
+            if windowState?.showContextMenu == true {
+                MenuList(
+                    header: menuHeader,
+                    search: MenuList.Search(
+                        query: $searchQuery,
+                        placeholder: "Search windows, tabs & files"
+                    )
+                ) {
+                    ContextMenuWindows(
+                        searchQuery: $searchQuery,
+                        currentArrowKeyIndex: $currentArrowKeyIndex,
+                        maxArrowKeyIndex: $maxArrowKeyIndex
+                    ) {
+                        closeContextMenu()
+                    } showBrowserTabsSubMenu: {
+                        showBrowserTabsSubMenu()
+                    }
+                }
+            }
+            
+            Button("Close") {
+                windowState?.showContextMenuBrowserTabs = false
             }
         }
-        .background {
-            if windowState.showContextMenu {
-                upListener
-                downListener
-            }
+        .background(Color.gray800)
+        .cornerRadius(12)
+        .onTapGesture {
+            windowState?.showContextMenu = false
         }
-        .onChange(of: showBrowserTabs) { _, _ in
-            searchQuery = ""
-            currentArrowKeyIndex = 0
+        .onChange(of: showBrowserTabsContextMenu) { _, new in
+            if new {
+                windowState?.showContextMenuBrowserTabs = true
+            }
         }
     }
 }
@@ -82,7 +89,7 @@ extension ContextMenu {
             icon: .chevLeft
         ) {
             searchQuery = ""
-            windowState.showContextMenuBrowserTabs = false
+            windowState?.showContextMenuBrowserTabs = false
         }
     }
     
@@ -96,8 +103,8 @@ extension ContextMenu {
     }
     
     private var menuHeader: MenuHeader<IconButton> {
-        MenuHeader(title: showBrowserTabs ? "Browser tabs" : "Add context") {
-            showBrowserTabs ? backButton : closeButton
+        MenuHeader(title: showBrowserTabsContextMenu ? "Browser tabs" : "Add context") {
+            showBrowserTabsContextMenu ? backButton : closeButton
         }
     }
 }
@@ -106,11 +113,11 @@ extension ContextMenu {
 
 extension ContextMenu {
     private func closeContextMenu() {
-        windowState.showContextMenu = false
+        windowState?.showContextMenu = false
     }
     
     private func showBrowserTabsSubMenu() {
         searchQuery = ""
-        windowState.showContextMenuBrowserTabs = true
+        windowState?.showContextMenuBrowserTabs = true
     }
 }

--- a/macos/Onit/UI/Prompt/Files/ContextMenu.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextMenu.swift
@@ -14,45 +14,38 @@ struct ContextMenu: View {
     @State private var currentArrowKeyIndex: Int = 0
     @State private var maxArrowKeyIndex: Int = 0
     
-    private var showBrowserTabsContextMenu: Bool {
+    // TODO: LOYD - Might want to delete later, as browser tabs are currently not implemented?
+    var showBrowserTabs: Bool {
         return windowState?.showContextMenuBrowserTabs ?? false
     }
     
     var body: some View {
-        VStack(spacing: 0) {
-            if windowState?.showContextMenu == true {
-                MenuList(
-                    header: menuHeader,
-                    search: MenuList.Search(
-                        query: $searchQuery,
-                        placeholder: "Search windows, tabs & files"
-                    )
-                ) {
-                    ContextMenuWindows(
-                        searchQuery: $searchQuery,
-                        currentArrowKeyIndex: $currentArrowKeyIndex,
-                        maxArrowKeyIndex: $maxArrowKeyIndex
-                    ) {
-                        closeContextMenu()
-                    } showBrowserTabsSubMenu: {
-                        showBrowserTabsSubMenu()
-                    }
-                }
-            }
-            
-            Button("Close") {
-                windowState?.showContextMenuBrowserTabs = false
+        MenuList(
+            header: menuHeader,
+            search: MenuList.Search(
+                query: $searchQuery,
+                placeholder: "Search windows, tabs & files"
+            )
+        ) {
+            ContextMenuWindows(
+                searchQuery: $searchQuery,
+                currentArrowKeyIndex: $currentArrowKeyIndex,
+                maxArrowKeyIndex: $maxArrowKeyIndex
+            ) {
+                closeContextMenu()
+            } showBrowserTabsSubMenu: {
+                showBrowserTabsSubMenu()
             }
         }
-        .background(Color.gray800)
-        .cornerRadius(12)
-        .onTapGesture {
-            windowState?.showContextMenu = false
-        }
-        .onChange(of: showBrowserTabsContextMenu) { _, new in
-            if new {
-                windowState?.showContextMenuBrowserTabs = true
+        .background {
+            if windowState?.showContextMenu ?? false {
+                upListener
+                downListener
             }
+        }
+        .onChange(of: showBrowserTabs) { _, _ in
+            searchQuery = ""
+            currentArrowKeyIndex = 0
         }
     }
 }
@@ -103,8 +96,8 @@ extension ContextMenu {
     }
     
     private var menuHeader: MenuHeader<IconButton> {
-        MenuHeader(title: showBrowserTabsContextMenu ? "Browser tabs" : "Add context") {
-            showBrowserTabsContextMenu ? backButton : closeButton
+        MenuHeader(title: showBrowserTabs ? "Browser tabs" : "Add context") {
+            showBrowserTabs ? backButton : closeButton
         }
     }
 }

--- a/macos/Onit/UI/Prompt/Files/ContextMenuWindowButton.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextMenuWindowButton.swift
@@ -39,28 +39,23 @@ struct ContextMenuWindowButton: View {
     }
     
     var body: some View {
-        // Only show content if windowState is available
-        if let windowState = windowState {
-            TextButton(
-                background: selected ? .gray600 : .clear,
-                icon: windowIcon == nil ? .stars : nil,
-                iconImage: windowIcon,
-                text: windowName
-            ){
-                if isLoadingIntoContext {
-                    LoaderPulse()
-                } else if windowContextItem == nil {
-                    checkEmpty
-                } else {
-                    checkFilled
-                }
-            } action: {
-                action()
+        TextButton(
+            background: selected ? .gray600 : .clear,
+            icon: windowIcon == nil ? .stars : nil,
+            iconImage: windowIcon,
+            text: windowName
+        ){
+            if isLoadingIntoContext {
+                LoaderPulse()
+            } else if windowContextItem == nil {
+                checkEmpty
+            } else {
+                checkFilled
             }
-            .addAnimation(dependency: selected)
-        } else {
-            EmptyView()
+        } action: {
+            action()
         }
+        .addAnimation(dependency: selected)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Files/ContextMenuWindowButton.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextMenuWindowButton.swift
@@ -39,23 +39,28 @@ struct ContextMenuWindowButton: View {
     }
     
     var body: some View {
-        TextButton(
-            background: selected ? .gray600 : .clear,
-            icon: windowIcon == nil ? .stars : nil,
-            iconImage: windowIcon,
-            text: windowName
-        ){
-            if isLoadingIntoContext {
-                LoaderPulse()
-            } else if windowContextItem == nil {
-                checkEmpty
-            } else {
-                checkFilled
+        // Only show content if windowState is available
+        if let windowState = windowState {
+            TextButton(
+                background: selected ? .gray600 : .clear,
+                icon: windowIcon == nil ? .stars : nil,
+                iconImage: windowIcon,
+                text: windowName
+            ){
+                if isLoadingIntoContext {
+                    LoaderPulse()
+                } else if windowContextItem == nil {
+                    checkEmpty
+                } else {
+                    checkFilled
+                }
+            } action: {
+                action()
             }
-        } action: {
-            action()
+            .addAnimation(dependency: selected)
+        } else {
+            EmptyView()
         }
-        .addAnimation(dependency: selected)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Files/ContextMenuWindows.swift
+++ b/macos/Onit/UI/Prompt/Files/ContextMenuWindows.swift
@@ -64,17 +64,17 @@ struct ContextMenuWindows: View {
         }
     }
     
-    private var windowsAvailable: Bool {
+    private var foregroundWindowCaptured: Bool {
         return windowState?.foregroundWindow != nil
     }
     
     private var allBrowserTabsButtonIndex: Int {
-        return windowsAvailable ? filteredCapturedWindows.count + 1 : filteredCapturedWindows.count
+        return foregroundWindowCaptured ? filteredCapturedWindows.count + 1 : filteredCapturedWindows.count
     }
     
     private var uploadFileButtonIndex: Int {
         // TODO: LOYD - This should be updated to be +2, +1 when bringing the browser tab button back in.
-        return windowsAvailable ? filteredCapturedWindows.count + 1 : filteredCapturedWindows.count
+        return foregroundWindowCaptured ? filteredCapturedWindows.count + 1 : filteredCapturedWindows.count
     }
     
     var body: some View {
@@ -318,50 +318,5 @@ extension ContextMenuWindows {
         
         isCapturingWindows = false
         return orderCapturedWindowsByMostRecent(capturedOpenWindows)
-    }
-    
-    private func handleAddFiles() {
-        windowState?.showFileImporter = true
-    }
-    
-    private func getCurrentContext() -> Context? {
-        return windowState?.getPendingContextList().first { context in
-            if case .web = context {
-                return false
-            }
-            return true
-        }
-    }
-    
-    private func isWindowBeingTracked(window: TrackedWindow) -> Bool {
-        let uniqueWindowIdentifier = window.hash
-        return windowState?.windowContextTasks[uniqueWindowIdentifier] != nil
-    }
-    
-    private func removeContext(contextItem: Context) {
-        windowState?.removeContext(context: contextItem)
-    }
-    
-    private func showProgressIndicator(window: TrackedWindow) {
-        let uniqueWindowIdentifier = window.hash
-        windowState?.cleanupWindowContextTask(
-            uniqueWindowIdentifier: uniqueWindowIdentifier
-        )
-    }
-    
-    private func addWindowToContext(trackedWindow: TrackedWindow) {
-        windowState?.addWindowToContext(window: trackedWindow.element)
-    }
-    
-    private func fetchForegroundedWindowsWithScreenshot() -> [TrackedWindow] {
-        guard let windowState = windowState else { return [] }
-        
-        let windowContextTaskWindowHashes = Set(windowState.windowContextTasks.keys)
-        
-        var windowsToFetch: [TrackedWindow] = []
-        
-        // TODO: Implement the logic for fetching foregrounded windows
-        
-        return windowsToFetch
     }
 }

--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -18,16 +18,27 @@ struct FileRow: View {
         accessibilityPermissionManager.accessibilityPermissionStatus == .granted
     }
     
-    var windowBeingAddedToContext: Bool {
+    private var isWindowBeingTracked: Bool {
+        guard let windowState = windowState else { return false }
+        
         if let foregroundWindow = windowState.foregroundWindow {
             return windowState.windowContextTasks[foregroundWindow.hash] != nil
-        } else {
-            return false
+        }
+        return false
+    }
+    
+    private func showProgressIndicator() {
+        guard let windowState = windowState else { return }
+        
+        if let foregroundWindow = windowState.foregroundWindow {
+            windowState.cleanupWindowContextTask(
+                uniqueWindowIdentifier: foregroundWindow.hash
+            )
         }
     }
     
     var windowAlreadyInContext: Bool {
-        if let foregroundWindow = windowState.foregroundWindow,
+        if let foregroundWindow = windowState?.foregroundWindow,
            !contextList.isEmpty
         {
             let windowName = WindowHelpers.getWindowName(window: foregroundWindow.element)
@@ -35,7 +46,7 @@ struct FileRow: View {
             for contextItem in contextList {
                 if case .auto(let autoContext) = contextItem {
                     if windowName == autoContext.appTitle {
-                        windowState.cleanupWindowContextTask(
+                        windowState?.cleanupWindowContextTask(
                             uniqueWindowIdentifier: foregroundWindow.hash
                         )
                         return true
@@ -60,7 +71,7 @@ struct FileRow: View {
             addedWindowContextItems
         }
         .onDisappear {
-            windowState.cleanUpPendingWindowContextTasks()
+            cleanUpPendingWindowContextTasks()
         }
     }
 }
@@ -72,8 +83,8 @@ extension FileRow {
     private var addForegroundWindowToContextButton: some View {
         if accessibilityEnabled,
            autoContextFromCurrentWindow,
-           !(windowBeingAddedToContext || windowAlreadyInContext),
-           let foregroundWindow = windowState.foregroundWindow
+           !(isWindowBeingTracked || windowAlreadyInContext),
+           let foregroundWindow = windowState?.foregroundWindow
         {
             let foregroundWindowName = WindowHelpers.getWindowName(window: foregroundWindow.element)
             let iconBundleURL = WindowHelpers.getWindowAppBundleUrl(window: foregroundWindow.element)
@@ -88,32 +99,34 @@ extension FileRow {
                 iconBundleURL: iconBundleURL,
                 tooltip: "Add \(foregroundWindowName) Context"
             ) {
-                windowState.addWindowToContext(
-                    window: foregroundWindow.element
-                )
+                addWindowToContext()
             }
         }
     }
     
     private var pendingWindowContextItems: some View {
-        ForEach(Array(windowState.windowContextTasks.keys), id: \.self) { uniqueWindowIdentifier in
-            let trackedWindow = AccessibilityNotificationsManager.shared.windowsManager.findTrackedWindow(
-                trackedWindowHash: uniqueWindowIdentifier
-            )
-            
-            if let trackedWindow = trackedWindow {
-                ContextTag(
-                    text: WindowHelpers.getWindowName(window: trackedWindow.element),
-                    background: .clear,
-                    hoverBackground: .clear,
-                    isLoading: true,
-                    iconView: LoaderPulse(),
-                    removeAction: {
-                        windowState.cleanupWindowContextTask(
-                            uniqueWindowIdentifier: uniqueWindowIdentifier
+        Group {
+            if let windowState = windowState {
+                ForEach(Array(windowState.windowContextTasks.keys), id: \.self) { uniqueWindowIdentifier in
+                    let trackedWindow = AccessibilityNotificationsManager.shared.windowsManager.findTrackedWindow(
+                        trackedWindowHash: uniqueWindowIdentifier
+                    )
+                    
+                    if let trackedWindow = trackedWindow {
+                        ContextTag(
+                            text: WindowHelpers.getWindowName(window: trackedWindow.element),
+                            background: .clear,
+                            hoverBackground: .clear,
+                            isLoading: true,
+                            iconView: LoaderPulse(),
+                            removeAction: {
+                                windowState.cleanupWindowContextTask(
+                                    uniqueWindowIdentifier: uniqueWindowIdentifier
+                                )
+                            }
                         )
                     }
-                )
+                }
             }
         }
     }
@@ -137,3 +150,23 @@ extension FileRow {
         FileRow(contextList: [])
     }
 #endif
+
+// MARK: - Helper Functions
+
+extension FileRow {
+    private func cleanUpPendingWindowContextTasks() {
+        windowState?.cleanUpPendingWindowContextTasks()
+    }
+    
+    private func addWindowToContext() {
+        guard let windowState = windowState else { return }
+        
+        let foregroundWindow = windowState.foregroundWindow
+        
+        if let foregroundWindow = foregroundWindow {
+            windowState.addWindowToContext(
+                window: foregroundWindow.element
+            )
+        }
+    }
+}

--- a/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
+++ b/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
@@ -46,7 +46,7 @@ struct PaperclipButton: View {
                 }
             }
 
-            if windowState?.pendingContextList.isEmpty != false {
+            if windowState?.pendingContextList.isEmpty ?? true {
                 if !accessibilityAutoContextEnabled && !closedAutoContextTag {
                     EnableAutocontextTag()
                 }
@@ -79,8 +79,10 @@ struct PaperclipButton: View {
     }
 
     private func handleAddContext() {
+        guard let windowState = windowState else { return }
+        
         if accessibilityAutoContextEnabled {
-            if let windowState = windowState, let panel = windowState.panel {
+            if let panel = windowState.panel {
                 if !panel.isKeyWindow {
                     panel.makeKey()
                 }
@@ -94,7 +96,7 @@ struct PaperclipButton: View {
             
             OverlayManager.shared.showOverlay(content: view)
         } else {
-            windowState?.showFileImporter = true
+            windowState.showFileImporter = true
         }
     }
 }

--- a/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
+++ b/macos/Onit/UI/Prompt/Files/PaperclipButton.swift
@@ -24,8 +24,8 @@ struct PaperclipButton: View {
     
     private var showContextMenuBinding: Binding<Bool> {
           Binding(
-              get: { windowState.showContextMenu },
-              set: { windowState.showContextMenu = $0 }
+              get: { windowState?.showContextMenu ?? false },
+              set: { windowState?.showContextMenu = $0 }
           )
       }
 
@@ -40,13 +40,13 @@ struct PaperclipButton: View {
                 AnalyticsManager.Chat.paperclipPressed()
                 
                 if accessibilityAutoContextEnabled && autoContextFromCurrentWindow {
-                    windowState.showContextMenu = true
+                    windowState?.showContextMenu = true
                 } else {
                     handleAddContext()
                 }
             }
 
-            if windowState.pendingContextList.isEmpty {
+            if windowState?.pendingContextList.isEmpty != false {
                 if !accessibilityAutoContextEnabled && !closedAutoContextTag {
                     EnableAutocontextTag()
                 }
@@ -80,7 +80,7 @@ struct PaperclipButton: View {
 
     private func handleAddContext() {
         if accessibilityAutoContextEnabled {
-            if let panel = windowState.panel {
+            if let windowState = windowState, let panel = windowState.panel {
                 if !panel.isKeyWindow {
                     panel.makeKey()
                 }
@@ -94,7 +94,7 @@ struct PaperclipButton: View {
             
             OverlayManager.shared.showOverlay(content: view)
         } else {
-            windowState.showFileImporter = true
+            windowState?.showFileImporter = true
         }
     }
 }

--- a/macos/Onit/UI/Prompt/Files/WebContextItem.swift
+++ b/macos/Onit/UI/Prompt/Files/WebContextItem.swift
@@ -38,7 +38,7 @@ struct WebContextItem: View {
     }
     
     var body: some View {
-        let websiteUndergoingScrape = isWebsiteBeingScrapeOrScrapeCompleted
+        let websiteUndergoingScrape = windowState?.websiteUrlsScrapeQueue.keys.contains(websiteUrl.absoluteString) ?? false
 
         ContextTag(
             text: getCurrentWebsiteTitle(),
@@ -46,8 +46,8 @@ struct WebContextItem: View {
             background: websiteUndergoingScrape || !isEditing ? .clear : .gray500,
             hoverBackground: isEditing ? .gray400 : .gray600,
             maxWidth: isEditing ? 155 : .infinity,
-            isLoading: shouldShowProgressView,
-            iconView: shouldShowProgressView ? LoaderPulse() : favicon,
+            isLoading: websiteUndergoingScrape,
+            iconView: websiteUndergoingScrape ? LoaderPulse() : favicon,
             caption: item.fileType,
             tooltip: getCurrentWebsiteTitle(),
             action: action,
@@ -105,26 +105,5 @@ extension WebContextItem {
         }
 
         return websiteTitle
-    }
-    
-    private var isWebsiteBeingScrapeOrScrapeCompleted: Bool {
-        guard let windowState = windowState else { return false }
-        
-        let websiteUndergoingScrape = windowState.websiteUrlsScrapeQueue.keys.contains(websiteUrl.absoluteString)
-        
-        return websiteUndergoingScrape
-    }
-    
-    private var shouldShowProgressView: Bool {
-        guard let windowState = windowState else { return false }
-        
-        let pendingContextList = windowState.getPendingContextList()
-        
-        return pendingContextList.contains { context in
-            if case .web(let existingWebsiteUrl, _, _) = context {
-                return existingWebsiteUrl.absoluteString == websiteUrl.absoluteString
-            }
-            return false
-        }
     }
 }

--- a/macos/Onit/UI/Prompt/FinalContextView.swift
+++ b/macos/Onit/UI/Prompt/FinalContextView.swift
@@ -44,7 +44,7 @@ struct FinalContextView: View {
                         get: { prompt.instruction },
                         set: {
                             prompt.instruction = $0
-                            windowState.detectIsTyping()
+                            windowState?.detectIsTyping()
                         }
                     ),
                     cursorPosition: $cursorPosition,
@@ -73,7 +73,7 @@ struct FinalContextView: View {
                 .background(.gray800) // To match the TextField style
                 .padding(0) // To match the TextField padding
                 .onChange(of: cursorPosition) {
-                    windowState.detectIsTyping()
+                    windowState?.detectIsTyping()
                 }
 
                 if isEditing {
@@ -81,7 +81,7 @@ struct FinalContextView: View {
                         Spacer()
                         Button("Cancel") {
                             isEditing = false
-                            windowState.textFocusTrigger.toggle()
+                            windowState?.textFocusTrigger.toggle()
                         }
                         .padding(.vertical, 6)
                         .padding(.horizontal, 8)
@@ -97,7 +97,7 @@ struct FinalContextView: View {
                                 await handleSend()
                             }
                             
-                            windowState.textFocusTrigger.toggle()
+                            windowState?.textFocusTrigger.toggle()
                         }
                         .padding(.vertical, 6)
                         .padding(.horizontal, 8)
@@ -133,7 +133,7 @@ struct FinalContextView: View {
                 isHoveringInstruction = hovering
             }
             
-            if windowState.isSearchingWeb[prompt.id] ?? false {
+            if windowState?.isSearchingWeb[prompt.id] ?? false {
                 HStack {
                     Image(.web)
                         .resizable()
@@ -173,7 +173,9 @@ struct FinalContextView: View {
                             if context.isWebSearchContext, let url = context.webURL {
                                 NSWorkspace.shared.open(url)
                             } else {
-                                ContextWindowsManager.shared.showContextWindow(windowState: windowState, context: context)
+                                if let windowState = windowState {
+                                    ContextWindowsManager.shared.showContextWindow(windowState: windowState, context: context)
+                                }
                             }
                         })
                             .background {
@@ -195,7 +197,7 @@ struct FinalContextView: View {
 extension FinalContextView {
     private func handleSend() async {
         await appState.checkSubscriptionAlerts {
-            windowState.generate(prompt)
+            windowState?.generate(prompt)
         }
     }
 }

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -25,7 +25,7 @@ struct GeneratedContentView: View {
             return ""
         }
         let response = prompt.sortedResponses[safeIndex]
-        return response.isPartial ? state.streamedResponse : response.text
+        return response.isPartial ? (state?.streamedResponse ?? "") : response.text
     }
     
     var configuration: LLMStreamConfiguration {
@@ -46,7 +46,7 @@ struct GeneratedContentView: View {
                           onCodeAction: codeAction)
                 .padding(.horizontal, 12)
             Spacer()
-            if textToRead.isEmpty && !(state.isSearchingWeb[prompt.id] ?? false) {
+            if textToRead.isEmpty && !(state?.isSearchingWeb[prompt.id] ?? false) {
                 HStack {
                     Spacer()
                     QLImage("loader_rotated-200")

--- a/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
@@ -44,7 +44,7 @@ struct GeneratedToolbar: View {
             icon: .arrowsSpin,
             tooltipPrompt: "Retry"
         ) {
-            state.generate(prompt)
+            state?.generate(prompt)
         }
     }
 

--- a/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
+++ b/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
@@ -34,7 +34,7 @@ struct ToggleOutputsView: View {
         .foregroundStyle(prompt.canDecrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canDecrementGeneration)
         .background {
-            if !windowState.isTyping {
+            if windowState?.isTyping != true {
                 Button { decrementGenerationIndex() }
                 label: { EmptyView() }
                     .keyboardShortcut(.leftArrow, modifiers: [])
@@ -64,7 +64,7 @@ struct ToggleOutputsView: View {
         .foregroundStyle(prompt.canIncrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canIncrementGeneration)
         .background {
-            if !windowState.isTyping {
+            if windowState?.isTyping != true {
                 Button { incrementGenerationIndex() }
                 label: { EmptyView() }
                     .keyboardShortcut(.rightArrow, modifiers: [])

--- a/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
+++ b/macos/Onit/UI/Prompt/Generated/ToggleOutputsView.swift
@@ -12,6 +12,8 @@ struct ToggleOutputsView: View {
     
     var prompt: Prompt
 
+    private var isTyping: Bool { windowState?.isTyping ?? false }
+    
     var body: some View {
         HStack(spacing: 0) {
             `left`
@@ -34,7 +36,7 @@ struct ToggleOutputsView: View {
         .foregroundStyle(prompt.canDecrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canDecrementGeneration)
         .background {
-            if windowState?.isTyping != true {
+            if isTyping {
                 Button { decrementGenerationIndex() }
                 label: { EmptyView() }
                     .keyboardShortcut(.leftArrow, modifiers: [])
@@ -64,7 +66,7 @@ struct ToggleOutputsView: View {
         .foregroundStyle(prompt.canIncrementGeneration ? .FG : .gray300)
         .disabled(!prompt.canIncrementGeneration)
         .background {
-            if windowState?.isTyping != true {
+            if isTyping {
                 Button { incrementGenerationIndex() }
                 label: { EmptyView() }
                     .keyboardShortcut(.rightArrow, modifiers: [])

--- a/macos/Onit/UI/Prompt/GeneratingView.swift
+++ b/macos/Onit/UI/Prompt/GeneratingView.swift
@@ -17,22 +17,27 @@ struct GeneratingView: View {
     }
 
     var body: some View {
-        HStack {
-            Spacer()
-            
-            Button {
-                state.cancelGenerate()
-                state.textFocusTrigger.toggle()
-            } label: {
-                VStack(spacing: 12) {
-                    icon
-                    text
+        // Only show content if windowState is available
+        if let state = state {
+            HStack {
+                Spacer()
+                
+                Button {
+                    state.cancelGenerate()
+                    state.textFocusTrigger.toggle()
+                } label: {
+                    VStack(spacing: 12) {
+                        icon
+                        text
+                    }
+                    .padding(20)
                 }
-                .padding(20)
+                .buttonStyle(.plain)
+                .keyboardShortcut(delete)
+                Spacer()
             }
-            .buttonStyle(.plain)
-            .keyboardShortcut(delete)
-            Spacer()
+        } else {
+            EmptyView()
         }
     }
 

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -15,10 +15,8 @@ struct InputButtons: View {
     var input: Input
 
     var body: some View {
-        @Bindable var state = state
-
         Group {
-            if input == state.pendingInput {
+            if let state = state, input == state.pendingInput {
                 Button {
                     state.pendingInput = nil
                 } label: {

--- a/macos/Onit/UI/Prompt/MicrophoneButton.swift
+++ b/macos/Onit/UI/Prompt/MicrophoneButton.swift
@@ -314,32 +314,4 @@ extension MicrophoneButton {
         
         addedRecordingSpaces = false
     }
-    
-    private func insertTranscriptAtCursor(_ transcript: String) {
-        guard let windowState = windowState else { return }
-        
-        let cursorPosition = windowState.pendingInstructionCursorPosition
-        let cursorPositionWithinBounds = min(max(0, cursorPosition), windowState.pendingInstruction.count)
-        
-        windowState.pendingInstruction.insert(
-            contentsOf: transcript,
-            at: windowState.pendingInstruction.index(
-                windowState.pendingInstruction.startIndex,
-                offsetBy: cursorPositionWithinBounds
-            )
-        )
-    }
-    
-    private func insertSpacesAtCursor() {
-        guard let windowState = windowState else { return }
-        
-        let cursorPosition = windowState.pendingInstructionCursorPosition
-        let spaces = "    " // 4 spaces for indentation
-        
-        let targetIndex = windowState.pendingInstruction.index(
-            windowState.pendingInstruction.startIndex,
-            offsetBy: min(max(0, cursorPosition), windowState.pendingInstruction.count)
-        )
-        windowState.pendingInstruction.insert(contentsOf: spaces, at: targetIndex)
-    }
 }

--- a/macos/Onit/UI/Prompt/MicrophoneButton.swift
+++ b/macos/Onit/UI/Prompt/MicrophoneButton.swift
@@ -142,6 +142,8 @@ extension MicrophoneButton {
     private func handleTranscriptionSuccess(_ transcription: String) {
         removeSpacesAtCursor()
         
+        guard let windowState = windowState else { return }
+        
         let cursorPosition = windowState.pendingInstructionCursorPosition
         let cursorPositionWithinBounds = min(max(0, cursorPosition), windowState.pendingInstruction.count)
         
@@ -272,6 +274,7 @@ extension MicrophoneButton {
     
     private func addSpacesAtCursor() {
         guard !addedRecordingSpaces else { return }
+        guard let windowState = windowState else { return }
         
         let cursorPosition = windowState.pendingInstructionCursorPosition
         let spaces = String(repeating: " ", count: recordingSpacesCount)
@@ -287,6 +290,7 @@ extension MicrophoneButton {
     
     private func removeSpacesAtCursor() {
         guard addedRecordingSpaces else { return }
+        guard let windowState = windowState else { return }
         
         let cursorPosition = windowState.pendingInstructionCursorPosition
         
@@ -309,5 +313,33 @@ extension MicrophoneButton {
         windowState.pendingInstruction.removeSubrange(startIndex..<endIndex)
         
         addedRecordingSpaces = false
+    }
+    
+    private func insertTranscriptAtCursor(_ transcript: String) {
+        guard let windowState = windowState else { return }
+        
+        let cursorPosition = windowState.pendingInstructionCursorPosition
+        let cursorPositionWithinBounds = min(max(0, cursorPosition), windowState.pendingInstruction.count)
+        
+        windowState.pendingInstruction.insert(
+            contentsOf: transcript,
+            at: windowState.pendingInstruction.index(
+                windowState.pendingInstruction.startIndex,
+                offsetBy: cursorPositionWithinBounds
+            )
+        )
+    }
+    
+    private func insertSpacesAtCursor() {
+        guard let windowState = windowState else { return }
+        
+        let cursorPosition = windowState.pendingInstructionCursorPosition
+        let spaces = "    " // 4 spaces for indentation
+        
+        let targetIndex = windowState.pendingInstruction.index(
+            windowState.pendingInstruction.startIndex,
+            offsetBy: min(max(0, cursorPosition), windowState.pendingInstruction.count)
+        )
+        windowState.pendingInstruction.insert(contentsOf: spaces, at: targetIndex)
     }
 }

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -84,8 +84,8 @@ struct PromptCore: View {
             }
         }
         .background {
-            if !isEditing {
-                if !showSlashMenu && (windowState?.showContextMenu != true) && (windowState?.isTyping != true) {
+            if !isEditing, let windowState = windowState {
+                if !showSlashMenu && (windowState.showContextMenu != true) && (windowState.isTyping != true) {
                     upListener
                     downListener
                 }
@@ -136,7 +136,7 @@ struct PromptCore: View {
 extension PromptCore {
     @ViewBuilder
     private var textField: some View {
-        if let windowState = windowState {
+        if let windowState = windowState, false {
             @Bindable var bindableWindowState = windowState
             
             TextViewWrapper(
@@ -164,11 +164,14 @@ extension PromptCore {
             }
             .disabled(showingAlert)
             .allowsHitTesting(!showingAlert)
+            // TODO: LOYD - This should be commented in when the Slash Menu is built.
+//          .popover(
+//              isPresented: $showSlashMenu
+//          ) {
+//              SlashMenu()
+//          }
         } else {
-            Text("Loading...")
-                .appFont(.medium16)
-                .foregroundStyle(.gray500)
-                .frame(height: min(textHeight, maxHeightLimit))
+            EmptyView()
         }
     }
     
@@ -245,7 +248,7 @@ extension PromptCore {
 
 extension PromptCore {
     private var shouldIndicateDisabled: Bool {
-        guard let windowState = windowState else { return false }
+        guard let windowState = windowState else { return true }
         return !windowState.websiteUrlsScrapeQueue.isEmpty || !windowState.windowContextTasks.isEmpty
     }
     
@@ -262,7 +265,7 @@ extension PromptCore {
     
     private var placeholderText: String {
         guard let windowState = windowState else {
-            return "Loading..."
+            return ""
         }
         
         if let currentChat = windowState.currentChat {

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -136,7 +136,7 @@ struct PromptCore: View {
 extension PromptCore {
     @ViewBuilder
     private var textField: some View {
-        if let windowState = windowState, false {
+        if let windowState = windowState {
             @Bindable var bindableWindowState = windowState
             
             TextViewWrapper(

--- a/macos/Onit/UI/Prompt/StopGenerationButton.swift
+++ b/macos/Onit/UI/Prompt/StopGenerationButton.swift
@@ -15,35 +15,40 @@ struct StopGenerationButton: View {
     private let shortcut = KeyboardShortcut(.delete, modifiers: [.command])
 
     var body: some View {
-        Button(action: { state.stopGeneration() }) {
-            HStack(spacing: 4) {
-                Image(systemName: "command")
-                    .font(.system(size: 10))
-                    .foregroundColor(.white)
-                
-                Image(systemName: "delete.left")
-                    .font(.system(size: 10))
-                    .foregroundColor(.white)
-                
-                Text("Stop")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.white)
+        // Only show content if windowState is available
+        if let state = state {
+            Button(action: { state.stopGeneration() }) {
+                HStack(spacing: 4) {
+                    Image(systemName: "command")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white)
+                    
+                    Image(systemName: "delete.left")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white)
+                    
+                    Text("Stop")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 0)
+                .frame(height: 26)
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 0)
-            .frame(height: 26)
+            .buttonStyle(PlainButtonStyle())
+            .background(isHovered ? .gray400 : .gray800)
+            .cornerRadius(6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(.gray500, lineWidth: 1)
+            )
+            .keyboardShortcut(shortcut)
+            .onHover { hovering in
+                isHovered = hovering
+            }
+            .addAnimation(dependency: isHovered)
+        } else {
+            EmptyView()
         }
-        .buttonStyle(PlainButtonStyle())
-        .background(isHovered ? .gray400 : .gray800)
-        .cornerRadius(6)
-        .overlay(
-            RoundedRectangle(cornerRadius: 6)
-                .stroke(.gray500, lineWidth: 1)
-        )
-        .keyboardShortcut(shortcut)
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .addAnimation(dependency: isHovered)
     }
 }

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptDetailView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptDetailView.swift
@@ -115,7 +115,7 @@ struct SystemPromptDetailView: View {
             
             Spacer()
             
-            if windowState?.systemPromptId != SystemPrompt.outputOnly.id {
+            if let windowState = windowState, windowState.systemPromptId != SystemPrompt.outputOnly.id {
                 Button {
                     showEditPrompt = true
                     dismiss()

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptDetailView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptDetailView.swift
@@ -59,10 +59,11 @@ struct SystemPromptDetailView: View {
                 .strokeBorder(.gray600)
         }
         .frame(width: size.width - 16)
-        .onChange(of: windowState.systemPromptId, initial: true) { oldValue, newValue in
+        .onChange(of: windowState?.systemPromptId, initial: true) { oldValue, newValue in
             let descriptor = FetchDescriptor<SystemPrompt>()
             
-            guard let prompt = try? modelContext.fetch(descriptor).first(where: { $0.id == newValue }) else {
+            guard let newValue = newValue,
+                  let prompt = try? modelContext.fetch(descriptor).first(where: { $0.id == newValue }) else {
                 storedPrompt = .outputOnly
                 print("Could not find prompt")
                 return
@@ -114,7 +115,7 @@ struct SystemPromptDetailView: View {
             
             Spacer()
             
-            if windowState.systemPromptId != SystemPrompt.outputOnly.id {
+            if windowState?.systemPromptId != SystemPrompt.outputOnly.id {
                 Button {
                     showEditPrompt = true
                     dismiss()

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionRowView.swift
@@ -15,7 +15,7 @@ struct SystemPromptSelectionRowView: View {
     var prompt: SystemPrompt
     
     var body: some View {
-        let isSelected: Bool = windowState.systemPromptId == prompt.id
+        let isSelected: Bool = windowState?.systemPromptId == prompt.id
         
         TextButton(
             selected: isSelected,
@@ -37,8 +37,8 @@ struct SystemPromptSelectionRowView: View {
 extension SystemPromptSelectionRowView {
     func selectPrompt() {
         prompt.lastUsed = Date()
-        windowState.systemPromptId = prompt.id
-        windowState.systemPromptState.userSelectedPrompt = true
+        windowState?.systemPromptId = prompt.id
+        windowState?.systemPromptState.userSelectedPrompt = true
     }
 }
 

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionView.swift
@@ -22,13 +22,13 @@ struct SystemPromptSelectionView: View {
         self._showNewPrompt = showNewPrompt
     }
     
-    private var systemPrompts: [SystemPrompt] {
+    private var suggestedPrompts: [SystemPrompt] {
         state?.promptSuggestionService?.suggestedPrompts ?? []
     }
     
     private var allPrompts: [SystemPrompt] {
         prompts.filter { prompt in
-            !systemPrompts.contains { $0.id == prompt.id }
+            !suggestedPrompts.contains { $0.id == prompt.id }
         }
     }
     
@@ -76,8 +76,8 @@ struct SystemPromptSelectionView: View {
                 List() {
                     EmptyView().id("topScrollPoint")
                     
-                    if !systemPrompts.isEmpty && searchText.isEmpty {
-                        sectionView(title: "Suggested", prompts: systemPrompts)
+                    if !suggestedPrompts.isEmpty && searchText.isEmpty {
+                        sectionView(title: "Suggested", prompts: suggestedPrompts)
                         sectionView(title: "All", prompts: allPrompts)
                     } else {
                         sectionView(title: nil, prompts: filteredPrompts)

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptSelectionView.swift
@@ -22,13 +22,13 @@ struct SystemPromptSelectionView: View {
         self._showNewPrompt = showNewPrompt
     }
     
-    private var suggestedPrompts: [SystemPrompt] {
-        state.promptSuggestionService?.suggestedPrompts ?? []
+    private var systemPrompts: [SystemPrompt] {
+        state?.promptSuggestionService?.suggestedPrompts ?? []
     }
     
     private var allPrompts: [SystemPrompt] {
         prompts.filter { prompt in
-            !suggestedPrompts.contains { $0.id == prompt.id }
+            !systemPrompts.contains { $0.id == prompt.id }
         }
     }
     
@@ -57,7 +57,7 @@ struct SystemPromptSelectionView: View {
                     icon: .cross,
                     iconSize: 10
                 ) {
-                    state.systemPromptState.shouldShowSelection = false
+                    state?.systemPromptState.shouldShowSelection = false
                 }
             },
             search: MenuList.Search(
@@ -76,8 +76,8 @@ struct SystemPromptSelectionView: View {
                 List() {
                     EmptyView().id("topScrollPoint")
                     
-                    if !suggestedPrompts.isEmpty && searchText.isEmpty {
-                        sectionView(title: "Suggested", prompts: suggestedPrompts)
+                    if !systemPrompts.isEmpty && searchText.isEmpty {
+                        sectionView(title: "Suggested", prompts: systemPrompts)
                         sectionView(title: "All", prompts: allPrompts)
                     } else {
                         sectionView(title: nil, prompts: filteredPrompts)

--- a/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptView.swift
+++ b/macos/Onit/UI/Prompt/SystemPrompt/SystemPromptView.swift
@@ -58,7 +58,7 @@ struct SystemPromptView: View {
                 .frame(width: 4)
             
             Button {
-                windowState.systemPromptState.shouldShowSystemPrompt = false
+                windowState?.systemPromptState.shouldShowSystemPrompt = false
             } label: {
                 Image(.remove)
                     .resizable()
@@ -67,10 +67,10 @@ struct SystemPromptView: View {
             }
         }
         .popover(isPresented: .init(
-            get: { showSelection || windowState.systemPromptState.shouldShowSelection },
+            get: { showSelection || windowState?.systemPromptState.shouldShowSelection == true },
             set: {
                 showSelection = $0
-                windowState.systemPromptState.shouldShowSelection = $0
+                windowState?.systemPromptState.shouldShowSelection = $0
             }
         ), arrowEdge: .leading) {
             SystemPromptSelectionView(showNewPrompt: $showNewPrompt)
@@ -87,7 +87,7 @@ struct SystemPromptView: View {
         .onChange(of: shouldSavePrompt) { _, new in
             if new { addPrompt() }
         }
-        .onChange(of: windowState.systemPromptId, initial: true) { _, systemPromptId in
+        .onChange(of: windowState?.systemPromptId, initial: true) { _, systemPromptId in
             guard let prompts = try? modelContext.fetch(FetchDescriptor<SystemPrompt>()),
                   let prompt = prompts.first(where: { $0.id == systemPromptId }) else {
                 selectedPrompt = .outputOnly
@@ -123,7 +123,7 @@ struct SystemPromptView: View {
         do {
             try modelContext.save()
             KeyboardShortcutsManager.register(systemPrompt: promptToAdd)
-            windowState.systemPromptId = promptToAdd.id
+            windowState?.systemPromptId = promptToAdd.id
             promptToAdd = SystemPrompt()
             shouldSavePrompt = false
         } catch {

--- a/macos/Onit/UI/Settings/ShortcutsTab.swift
+++ b/macos/Onit/UI/Settings/ShortcutsTab.swift
@@ -37,6 +37,11 @@ struct ShortcutsTab: View {
                 )
                 .padding()
                 
+                KeyboardShortcuts.Recorder(
+                    "Add Current Window to Context", name: .addForegroundWindowToContext
+                )
+                .padding()
+                
                 Toggle("Disable 'ESC' shortcut", isOn: $escapeShortcutDisabled)
                 .padding()
             }

--- a/macos/Onit/UI/Windows/ContextPickerItemView.swift
+++ b/macos/Onit/UI/Windows/ContextPickerItemView.swift
@@ -34,8 +34,7 @@ struct ContextPickerItemView: View {
     @State private var isPressed: Bool = false
     
     private var windowIcon: NSImage? {
-        guard let windowState = windowState,
-              let foregroundWindow = windowState.foregroundWindow,
+        guard let foregroundWindow = windowState?.foregroundWindow,
               let bundleUrl = WindowHelpers.getWindowAppBundleUrl(window: foregroundWindow.element)
         else {
             return nil

--- a/macos/Onit/UI/Windows/ContextPickerItemView.swift
+++ b/macos/Onit/UI/Windows/ContextPickerItemView.swift
@@ -34,7 +34,8 @@ struct ContextPickerItemView: View {
     @State private var isPressed: Bool = false
     
     private var windowIcon: NSImage? {
-        guard let foregroundWindow = windowState.foregroundWindow,
+        guard let windowState = windowState,
+              let foregroundWindow = windowState.foregroundWindow,
               let bundleUrl = WindowHelpers.getWindowAppBundleUrl(window: foregroundWindow.element)
         else {
             return nil

--- a/macos/Onit/UI/Windows/ContextPickerView.swift
+++ b/macos/Onit/UI/Windows/ContextPickerView.swift
@@ -14,7 +14,7 @@ struct ContextPickerView: View {
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
     
     var autoContextDisabled: Bool {
-        return autoContextFromCurrentWindow && windowState.foregroundWindow != nil
+        return autoContextFromCurrentWindow && windowState?.foregroundWindow != nil
     }
     
     var body: some View {
@@ -26,7 +26,7 @@ struct ContextPickerView: View {
             ) {
                 AnalyticsManager.ContextPicker.uploadFilePressed()
                 OverlayManager.shared.dismissOverlay()
-                windowState.showFileImporter = true
+                windowState?.showFileImporter = true
             }
             
             ContextPickerItemView(
@@ -61,7 +61,7 @@ extension ContextPickerView {
         } else if !autoContextFromCurrentWindow {
             return "Click to enable"
         } else {
-            if let foregroundWindow = windowState.foregroundWindow {
+            if let windowState = windowState, let foregroundWindow = windowState.foregroundWindow {
                 return WindowHelpers.getWindowName(window: foregroundWindow.element)
             } else {
                 return "Current window"
@@ -71,6 +71,8 @@ extension ContextPickerView {
     
     private func addWindowToContext() {
         AnalyticsManager.ContextPicker.autoContextPressed()
+        
+        guard let windowState = windowState else { return }
         
         if let foregroundWindow = windowState.foregroundWindow {
             windowState.addWindowToContext(

--- a/macos/Onit/UI/Windows/ContextPickerView.swift
+++ b/macos/Onit/UI/Windows/ContextPickerView.swift
@@ -61,7 +61,7 @@ extension ContextPickerView {
         } else if !autoContextFromCurrentWindow {
             return "Click to enable"
         } else {
-            if let windowState = windowState, let foregroundWindow = windowState.foregroundWindow {
+            if let foregroundWindow = windowState?.foregroundWindow {
                 return WindowHelpers.getWindowName(window: foregroundWindow.element)
             } else {
                 return "Current window"


### PR DESCRIPTION
Here is one potential solution for the Environment+Values crash that we're seeing in production. 

**Repro steps are as follows:** 
1. Generate a response (my prompt is "write an email about XYZ")
4. Open Gmail, have Gmail foregrounded. 
5. Click Onit's 'copy' button while Gmail is in the foreground. 
6. Repeat this until the crash occurs (usually takes 3 or 4 tries). 

**The issue seems to stem from the following:** 
1. Our main ContentView is in an NSHostingView, which is a legacy MacOS abstraction. 
2. NSHostingView uses async rendering, which performs UI work on a background thread called "DisplayLink".
3. Our main SwiftUI code references an OnitPanelState object, stored in the SwiftUI Environment. When the DisplayLink tries to do UI layout work, it needs to read this OnitPanelState object. 
4. OnitPanelState is marked as @MainActor, so the app crashes when DisplayLink reads it. 

Given that cause, I see a few possible paths to explore: 
1. We could make the windowState optional, and update all of our views to work without a state object. 
2. We could make OnitPanelState not @MainActor isolated.
3. We could explore alternatives to NSHostingView, like SwiftUI's Window or WindowGroup.  

This PR implements option #1. I have confirmed that it works by following the repro steps above. I have a print statement when the windowState gets read and we're not on the main thread. I can see that print statement in the logs, and the app no longer crashes.  I don't like this solution very much. It's annoying to have to unwrap the windowState in every view, and it seems likely that we're introducing bugs. However, it's much better than the current crash. 

Regarding the other solutions, I didn't try option #2, given how closely OnitPanelState is integrated with our UI. It seems like it will be tough, perhaps impossible, to have OnitPanelState off the MainActor. It seems almost sure to introduce bugs.  I haven't tried option #3, but I think it's worth looking into. 

*NOTES* This is marked as DO NOT MERGE because I have not thoroughly tested the code. It is possible that I've introduced bugs in handling the optional windowState. We need to review each change closely and ensure that we do not introduce new crashes when the windowState is optional. Also, I used Cursor heavily when making this, and it seems to have introduced some unrelated code. I'll need to go through and remove that, too. 

