### PR TITLE
Implement AccessibilityParser for messages

### DIFF
--- a/macos/Onit/Accessibility/AXUIElement+Accessors.swift
+++ b/macos/Onit/Accessibility/AXUIElement+Accessors.swift
@@ -19,6 +19,16 @@ extension AXUIElement {
         }
     }
 
+    func allAttributes() -> [String]? {
+        var value: CFArray?
+        let result = AXUIElementCopyAttributeNames(self, &value)
+        if result == .success {
+            return value as? [String]
+        } else {
+            return nil
+        }
+    }
+    
     func value() -> String? {
         return self.attribute(forAttribute: kAXValueAttribute as CFString) as? String
     }

--- a/macos/Onit/Accessibility/Parser/AccessibilityParser.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParser.swift
@@ -19,7 +19,8 @@ class AccessibilityParser {
     private let parsers: [String: AccessibilityParserLogic] = [
         "Xcode": AccessibilityParserXCode(),
         "Calendar": AccessibilityParserCalendar(),
-        "Pages": ClipboardParser()
+        "Pages": ClipboardParser(),
+        "Messages": AccessibilityParserMessages()
     ]
 
     // MARK: - Functions

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserCalendar.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserCalendar.swift
@@ -21,7 +21,7 @@ class AccessibilityParserCalendar: AccessibilityParserBase {
         _ = AccessibilityParserUtility.recursivelyParse(
             element: element,
             maxDepth: AccessibilityParserConfig.recursiveDepthMax
-        ) { element in
+        ) { element, depth in
             
             if !highlightedTextFound {
                 let parentResult = super.parse(element: element)
@@ -36,12 +36,12 @@ class AccessibilityParserCalendar: AccessibilityParserBase {
                   let description = element.description(),
                   !description.isEmpty,
                   !screen.contains(description) else {
-                return nil
+                return .continueRecursing(nil)
             }
             
             screen += "\(description)\n"
 
-            return nil
+            return .continueRecursing(nil)
         }
         
         result[AccessibilityParsedElements.screen] = screen

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserGeneric.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserGeneric.swift
@@ -21,7 +21,7 @@ class AccessibilityParserGeneric: AccessibilityParserBase {
         _ = AccessibilityParserUtility.recursivelyParse(
             element: element,
             maxDepth: AccessibilityParserConfig.recursiveDepthMax
-        ) { element in
+        ) { element, depth in
             
             if !highlightedTextFound {
                 let parentResult = super.parse(element: element)
@@ -31,12 +31,12 @@ class AccessibilityParserGeneric: AccessibilityParserBase {
                     result.merge(parentResult) { _, new in new }
                 }
             }
-            
+
             if let value = element.value(), !value.isEmpty {
                 screen += "\(value) "
             }
-
-            return nil
+            
+            return .continueRecursing(nil)
         }
 
         result[AccessibilityParsedElements.screen] = screen

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserMessages.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserMessages.swift
@@ -31,17 +31,6 @@ class AccessibilityParserMessages: AccessibilityParserBase {
                 }
             }
           
-            // Get all accessibility attributes for the element
-//             if let attributes = element.attributes() {
-//                 let indent = String(repeating: "  ", count: depth)
-//                 print("\(indent)Element attributes for \(element.title() ?? "unknown"):")
-//                 for attribute in attributes {
-//                     if let value = element.attribute(forAttribute: attribute as CFString) {
-//                         print("\(indent)  \(attribute): \(value)")
-//                     }
-//                 }
-//                 print("\(indent)---")
-//             }
             
             guard let role = element.role(),
                   (role == kAXStaticTextRole || role == kAXGroupRole),

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserMessages.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserMessages.swift
@@ -1,0 +1,72 @@
+//
+//  AccessibilityParserMessages.swift
+//  Onit
+//
+//  Created by Assistant on 23/01/2025.
+//
+
+import ApplicationServices.HIServices
+
+/// Implementation of `AccessibilityParserLogic` for Messages app
+class AccessibilityParserMessages: AccessibilityParserBase {
+
+    // MARK: - AccessibilityParserLogic
+
+    /** See ``AccessibilityParserLogic`` parse function */
+    override func parse(element: AXUIElement) -> [String: String] {
+        var result: [String: String] = [:]
+        var messagesContent: String = ""
+        var highlightedTextFound = false
+
+        _ = AccessibilityParserUtility.recursivelyParse(
+            element: element,
+            maxDepth: AccessibilityParserConfig.recursiveDepthMax
+        ) { element, depth in
+            if !highlightedTextFound {
+                let parentResult = super.parse(element: element)
+                
+                if !parentResult.isEmpty {
+                    highlightedTextFound = true
+                    result.merge(parentResult) { _, new in new }
+                }
+            }
+          
+            // Get all accessibility attributes for the element
+//             if let attributes = element.attributes() {
+//                 let indent = String(repeating: "  ", count: depth)
+//                 print("\(indent)Element attributes for \(element.title() ?? "unknown"):")
+//                 for attribute in attributes {
+//                     if let value = element.attribute(forAttribute: attribute as CFString) {
+//                         print("\(indent)  \(attribute): \(value)")
+//                     }
+//                 }
+//                 print("\(indent)---")
+//             }
+            
+            guard let role = element.role(),
+                  (role == kAXStaticTextRole || role == kAXGroupRole),
+                  let description = element.description(),
+                  !description.isEmpty,
+                  !messagesContent.contains(description)
+            else {
+                return .continueRecursing(nil)
+            }
+
+            // Stop recursing if we hit "Conversations" but still process this element
+            if description == "Conversations" {
+                return .stopRecursing(nil)
+            }
+        
+            print("Adding \(description)")
+            messagesContent += "\(description)\n"
+
+            return .continueRecursing(nil)
+        }
+        
+        if !messagesContent.isEmpty {
+            result[AccessibilityParsedElements.screen] = messagesContent
+        }
+        
+        return result
+    }
+} 

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserUtility.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserUtility.swift
@@ -8,21 +8,43 @@
 import AppKit
 import ApplicationServices.HIServices
 
+/// Result of parsing an accessibility element
+enum AccessibilityParseResult {
+    case continueRecursing([String: String]?)
+    case stopRecursing([String: String]?)
+    
+    var results: [String: String]? {
+        switch self {
+        case .continueRecursing(let results), .stopRecursing(let results):
+            return results
+        }
+    }
+    
+    var shouldContinue: Bool {
+        switch self {
+        case .continueRecursing:
+            return true
+        case .stopRecursing:
+            return false
+        }
+    }
+}
+
 /// An utility class helping for parsing Accessibility
 class AccessibilityParserUtility {
 
     /**
      * Perform a parsing logic using `handler` on an `element` and recursively do it on its children
-     * Parsing will stop when `maxDepth` is reached
+     * Parsing will stop when `maxDepth` is reached or when handler returns `.stopRecursing`
      *
      * - parameter element: `AXUIElement` to parse
      * - parameter maxDepth: Children's depth maximum where the parsing stops
-     * - parameter handler: Handler which apply the parsing logic
+     * - parameter handler: Handler which apply the parsing logic, receives element and current depth. Return `.stopRecursing` to prevent recursing into children of this element.
      */
     static func recursivelyParse(
         element: AXUIElement,
         maxDepth: Int,
-        handler: (AXUIElement) -> [String: String]?
+        handler: (AXUIElement, Int) -> AccessibilityParseResult
     ) -> [String: String] {
         var results: [String: String] = [:]
 
@@ -45,17 +67,18 @@ class AccessibilityParserUtility {
             // Skip off-screen element
             if let frame = currentElement.getFrame(convertedToGlobalCoordinateSpace: true),
                 frame.width <= 0 || frame.height <= 0 || !currentScreen.visibleFrame.intersects(frame) {
-                // print("Element is off-screen. Skipping.")
+                print("Element is off-screen. Skipping.")
                 return
             }
 
             // Apply parsing handler on element and merge results
-            if let result = handler(currentElement) {
+            let parseResult = handler(currentElement, currentDepth)
+            if let result = parseResult.results {
                 results.merge(result) { _, new in new }
             }
 
-            // Recusively parse children
-            if let children = currentElement.children() {
+            // Only recursively parse children if handler didn't return .stopRecursing
+            if parseResult.shouldContinue, let children = currentElement.children() {
                 for child in children {
                     helper(currentElement: child, currentDepth: currentDepth + 1)
                 }

--- a/macos/Onit/Accessibility/Parser/AccessibilityParserXCode.swift
+++ b/macos/Onit/Accessibility/Parser/AccessibilityParserXCode.swift
@@ -20,7 +20,7 @@ class AccessibilityParserXCode: AccessibilityParserBase {
         return AccessibilityParserUtility.recursivelyParse(
             element: element,
             maxDepth: AccessibilityParserConfig.recursiveDepthMax
-        ) { element in
+        ) { element, depth in
             
             if !highlightedTextFound {
                 let parentResult = super.parse(element: element)
@@ -32,13 +32,17 @@ class AccessibilityParserXCode: AccessibilityParserBase {
             }
             
             guard let description = element.description(),
-                  description != "Console",
                   let role = element.role(),
                   role == kAXTextAreaRole,
                   let value = element.value(),
                   !value.isEmpty
             else {
-                return result
+                return .continueRecursing(result.isEmpty ? nil : result)
+            }
+            
+            // Stop recursing if we hit "Console" but don't process this element
+            if description == "Console" {
+                return .stopRecursing(result.isEmpty ? nil : result)
             }
 
             switch description {
@@ -48,7 +52,7 @@ class AccessibilityParserXCode: AccessibilityParserBase {
                 break
             }
 
-            return result
+            return .continueRecursing(result.isEmpty ? nil : result)
         }
     }
 }


### PR DESCRIPTION
This feature implements a custom Accessibility parser for Apple's Messages app. 

The problem was quite simple: In Messages, the content is stored in the 'description' field, rather than the 'value' field that is more commonly used in other apps. The new custom parser, AccessibilityParserMessages, reads the description() field, instead of value() field, and now it works!

In debugging this, I made a few other changes to the AccessibilityParser: 

1. I added a method for the parsers to stop the recursive process when an element is reached. For Messages, I didn't want to include the other Conversations. For Xcode, we dont' want to include the Console. I added a new return type that can be either .continueRecursing or .stopRecursing, and updated the recursive logic in AccessibilityParserUtility to use this. 
2. I added an "allAttributes" function to the AXUIElement+Accessors, which is very helpful when debugging situations like this. I chose to leave this in, since I suspect we'll be needing it again!
3. I updated the recursive callback function to include the current level of the recursion. Again, this is helpful for debugging. Again, I chose to leave it in, since I suspect we'll need it again soon!

<img width="969" alt="Screenshot 2025-06-25 at 11 50 54 AM" src="https://github.com/user-attachments/assets/f3175293-4aa0-499c-9860-9b0e998558d3" />

