### PR TITLE
Use safe generation index when deleting responses

### DIFF
--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -294,9 +294,8 @@ extension OnitPanelState {
     func removePartialResponse(prompt: Prompt) {
         // If the prompt already has a response, we can just remove the last, partial response.
         if prompt.responses.count > 1, let lastResponse = prompt.responses.last, let lastInstruction = prompt.priorInstructions.last {
-            prompt.responses.removeLast()
+            prompt.removeLastResponse()  // Use safe removal method
             prompt.priorInstructions.removeLast()
-            prompt.generationIndex = (prompt.responses.count - 1)
             do {
                 try container.mainContext.save()
             } catch {

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -20,8 +20,11 @@ struct GeneratedContentView: View {
     var prompt: Prompt
     
     var textToRead: String {
-        let response = prompt.sortedResponses[prompt.generationIndex]
-        
+        let safeIndex = prompt.safeGenerationIndex
+        guard safeIndex >= 0 && safeIndex < prompt.sortedResponses.count else {
+            return ""
+        }
+        let response = prompt.sortedResponses[safeIndex]
         return response.isPartial ? state.streamedResponse : response.text
     }
     

--- a/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedToolbar.swift
@@ -22,9 +22,9 @@ struct GeneratedToolbar: View {
             
             Spacer()
             
-            if prompt.generationIndex >= 0 &&
-                prompt.generationIndex < prompt.responses.count,
-                let model = prompt.sortedResponses[prompt.generationIndex].model {
+            if prompt.safeGenerationIndex >= 0 &&
+                prompt.safeGenerationIndex < prompt.responses.count,
+                let model = prompt.sortedResponses[prompt.safeGenerationIndex].model {
                 Text("\(model)")
                     .foregroundColor(Color.gray300)
             }

--- a/macos/Onit/UI/Prompt/Generated/GeneratedView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedView.swift
@@ -13,13 +13,16 @@ struct GeneratedView: View {
     var body: some View {
         VStack(spacing: 0) {
             if !prompt.responses.isEmpty {
-                let curResponse = prompt.sortedResponses[prompt.generationIndex]
-                
-                switch curResponse.type {
-                case .error:
-                    GeneratedErrorView(errorDescription: prompt.sortedResponses[prompt.generationIndex].text)
-                default:
-                    GeneratedContentView(prompt: prompt)
+                let safeIndex = prompt.safeGenerationIndex
+                if safeIndex >= 0 && safeIndex < prompt.sortedResponses.count {
+                    let curResponse = prompt.sortedResponses[safeIndex]
+                    
+                    switch curResponse.type {
+                    case .error:
+                        GeneratedErrorView(errorDescription: curResponse.text)
+                    default:
+                        GeneratedContentView(prompt: prompt)
+                    }
                 }
             }
             


### PR DESCRIPTION
This offers a solution to an 'out of bounds' error that emerged when we added the "stopGeneration" button in v2.5. 

The issue is caused by the following: 
- When we stop a generation, if it's the first 'instruction' for the current prompt, we delete the prompt. 
- We update the underlying "Chat" to remove the prompt and also delete the Prompt itself. 
- Finally we reset the generationIndex, removing 1 to account for the deletion.
- Many views are listening for changes in Chat and Prompt. 
- We have race conditions, where the a view can update before the generationIndex is set. 
- Specifically, this was causing out-of-bounds error in 'textToRead()' function of GeneratedContentView. We were reading from 'sortedResponses' after a response had been removed, but before the generationIndex had been updated. 

In this PR, I  introduce a "safeGenerationIndex", a computed property that is always within the bounds of the sortedResponses array. I also added a "validateGenerationIndex" function, which is always called when we update the responses array. Finally, I added safe helper methods for removing responses that automatically update all of this. From local testing, this appears to resolve the crash and also provides us with helper methods for deleting responses in the future. 