### PR TITLE
Introduce DB migration to deal with deleted prompt references

### DIFF
--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -85,6 +85,8 @@ extension Defaults.Keys {
     // This migration adds the 'instruction' the response object, so it can be dynamic
     static let hasPerformedInstructionResponseMigration = Key<Bool>(
         "hasPerformedInstructionResponseMigration", default: false)
+    static let needsHangingPromptCleanup = Key<Bool>(
+        "needsHangingPromptCleanup", default: true)
 
     static let localEndpointURL = Key<URL>(
         "localEndpointURL", default: URL(string: "http://localhost:11434")!)


### PR DESCRIPTION
The crash in the Stop generation button (described in #295) could leave the database in a weird state. 

We sometimes encountered a situation where a Prompt object was deleted, but if the app crashed before we could update the ‘priorPrompt’ and ‘nextPrompt’ chains, we ended up with occasional dangling references. These references would point to Prompt objects that had already been deleted. This could cause a new, second crash. 

Here are the repro steps: 
1. Send a message in a new chat. 
2. Send another message and "stop" it before it finishes generating. 
3. Repeat Step 2 until you observe a crash. 

Then...
4. Relaunch the app
5. Navigate back to the crashed chat in History. 
6. Try to send a new Prompt in that chat. 

You’ll now encounter a different crash, this time caused by referencing a deleted Prompt object. Specifically, the first Prompt in this chat still points to the deleted Prompt. When we deleted the second Prompt, we should have set the first Prompt’s ‘nextPrompt’ field to nil, but the app crashed before that code could run.

As a result, any user who experienced the initial crash will face this second crash when they revisit chats where the delete button previously caused an issue. 

This PR introduces a migration that detects 'dangling' nextPrompt references and rebuilds the next/prior prompt chains as needed. We use the timestamps of the remaining Prompt objects to rebuild the chain in chronological order. 

Notes for posterity: 
- This was challenging because accessing ‘nextPrompt’ on a deleted Prompt causes a fatal error, which can’t be caught with try/catch. To avoid this, I needed a way to check if a prompt was deleted without accessing its ‘nextPrompt’ field. I used the ‘persistentModelID’, which remains readable even on deleted objects. Although the ‘isDeleted’ field seemed like a solution, it didn’t work. Instead, I built a lookup table of valid persistentModelIDs by iterating through all remaining prompts. Then, in a second pass, I identified prompts referencing persistentModelIDs not found in the lookup table.