### PR TITLE
Search polishing

### DIFF
--- a/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
@@ -16,7 +16,8 @@ struct ChatEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) throws -> any Endpoint {
         switch model.provider {
         case .openAI:
@@ -26,7 +27,8 @@ struct ChatEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .anthropic:
             return ChatEndpointBuilder.anthropic(
                 model: model,
@@ -34,7 +36,8 @@ struct ChatEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .xAI:
             return ChatEndpointBuilder.xAI(
                 model: model,
@@ -83,7 +86,8 @@ struct ChatEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> OpenAIChatEndpoint {
         let messages = ChatEndpointMessagesBuilder.openAI(
             model: model,
@@ -93,7 +97,7 @@ struct ChatEndpointBuilder {
             userMessages: userMessages)
 
         return OpenAIChatEndpoint(
-            messages: messages, token: apiToken, model: model.id)
+            messages: messages, token: apiToken, model: model.id, includeSearch: includeSearch)
     }
 
     private static func anthropic(
@@ -102,7 +106,8 @@ struct ChatEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> AnthropicChatEndpoint {
         let messages = ChatEndpointMessagesBuilder.anthropic(
             model: model,
@@ -115,7 +120,8 @@ struct ChatEndpointBuilder {
             system: model.supportsSystemPrompts ? systemMessage : "",
             token: apiToken,
             messages: messages,
-            maxTokens: 4096
+            maxTokens: 4096,
+            includeSearch: includeSearch
         )
     }
 

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/AnthropicChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/AnthropicChatEndpoint.swift
@@ -17,16 +17,22 @@ struct AnthropicChatEndpoint: Endpoint {
     let token: String?
     let messages: [AnthropicMessage]
     let maxTokens: Int
+    let includeSearch: Bool?
 
     var path: String { "/v1/messages" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
 
     var requestBody: AnthropicChatRequest? {
-        AnthropicChatRequest(
+        var tools: [AnthropicChatTool] = []
+        if includeSearch == true {
+            tools.append(AnthropicChatTool(type: "web_search_20250305", name: "web_search", maxUses: 5))
+        }
+        return AnthropicChatRequest(
             model: model,
             system: system,
             messages: messages,
+            tools: tools,
             max_tokens: maxTokens,
             stream: false
         )
@@ -65,8 +71,21 @@ struct AnthropicChatRequest: Codable {
     let model: String
     let system: String
     let messages: [AnthropicMessage]
+    let tools: [AnthropicChatTool]
     let max_tokens: Int
     let stream: Bool
+}
+
+struct AnthropicChatTool: Codable {
+    let type: String
+    let name: String
+    let maxUses: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case name
+        case maxUses = "max_uses"
+    }
 }
 
 struct AnthropicChatResponse: Codable {

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/AnthropicChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/AnthropicChatEndpoint.swift
@@ -26,7 +26,7 @@ struct AnthropicChatEndpoint: Endpoint {
     var requestBody: AnthropicChatRequest? {
         var tools: [AnthropicChatTool] = []
         if includeSearch == true {
-            tools.append(AnthropicChatTool(type: "web_search_20250305", name: "web_search", maxUses: 5))
+            tools.append(AnthropicChatTool.search(maxUses: 5))
         }
         return AnthropicChatRequest(
             model: model,
@@ -85,6 +85,10 @@ struct AnthropicChatTool: Codable {
         case type
         case name
         case maxUses = "max_uses"
+    }
+
+    static func search(maxUses: Int) -> AnthropicChatTool {
+        return AnthropicChatTool(type: "web_search_20250305", name: "web_search", maxUses: maxUses)
     }
 }
 

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/OpenAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/OpenAIChatEndpoint.swift
@@ -15,12 +15,17 @@ struct OpenAIChatEndpoint: Endpoint {
     let messages: [OpenAIChatMessage]
     let token: String?
     let model: String
+    let includeSearch: Bool?
 
     var path: String { "/v1/responses" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
     var requestBody: OpenAIChatRequest? {
-        OpenAIChatRequest(model: model, input: messages, stream: false)
+        var tools: [OpenAIChatTool] = []
+        if includeSearch == true {
+            tools.append(OpenAIChatTool(type: "web_search_preview"))
+        }
+        return OpenAIChatRequest(model: model, input: messages, tools: tools, stream: false)
     }
     var additionalHeaders: [String: String]? {
         ["Authorization": "Bearer \(token ?? "")"]
@@ -73,7 +78,12 @@ struct OpenAIChatContentPart: Codable {
 struct OpenAIChatRequest: Codable {
     let model: String
     let input: [OpenAIChatMessage]
+    let tools: [OpenAIChatTool]
     let stream: Bool
+}
+
+struct OpenAIChatTool: Codable {
+    let type: String
 }
 
 struct OpenAIChatResponse: Codable {

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/OpenAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/OpenAIChatEndpoint.swift
@@ -23,7 +23,7 @@ struct OpenAIChatEndpoint: Endpoint {
     var requestBody: OpenAIChatRequest? {
         var tools: [OpenAIChatTool] = []
         if includeSearch == true {
-            tools.append(OpenAIChatTool(type: "web_search_preview"))
+            tools.append(OpenAIChatTool.search())
         }
         return OpenAIChatRequest(model: model, input: messages, tools: tools, stream: false)
     }
@@ -84,6 +84,10 @@ struct OpenAIChatRequest: Codable {
 
 struct OpenAIChatTool: Codable {
     let type: String
+
+    static func search() -> OpenAIChatTool {
+        return OpenAIChatTool(type: "web_search_preview")
+    }
 }
 
 struct OpenAIChatResponse: Codable {

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/AnthropicChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/AnthropicChatStreamingEndpoint.swift
@@ -26,7 +26,7 @@ struct AnthropicChatStreamingEndpoint: StreamingEndpoint {
     var requestBody: AnthropicChatRequest? {
         var tools: [AnthropicChatTool] = []
         if includeSearch == true {
-            tools.append(AnthropicChatTool(type: "web_search_20250305", name: "web_search", maxUses: 5))
+            tools.append(AnthropicChatTool.search(maxUses: 5))
         }
         return AnthropicChatRequest(
             model: model,

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/AnthropicChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/AnthropicChatStreamingEndpoint.swift
@@ -17,16 +17,22 @@ struct AnthropicChatStreamingEndpoint: StreamingEndpoint {
     let token: String?
     let messages: [AnthropicMessage]
     let maxTokens: Int
+    let includeSearch: Bool?
     
     var path: String { "/v1/messages" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
     
     var requestBody: AnthropicChatRequest? {
-        AnthropicChatRequest(
+        var tools: [AnthropicChatTool] = []
+        if includeSearch == true {
+            tools.append(AnthropicChatTool(type: "web_search_20250305", name: "web_search", maxUses: 5))
+        }
+        return AnthropicChatRequest(
             model: model,
             system: system,
             messages: messages,
+            tools: tools,
             max_tokens: maxTokens,
             stream: true
         )
@@ -41,13 +47,13 @@ struct AnthropicChatStreamingEndpoint: StreamingEndpoint {
     var timeout: TimeInterval? { nil }
     
     func getContentFromSSE(event: EVEvent) throws -> String? {
-        guard let eventString = event.event,
-              let dataStart = eventString.range(of: "data: ")?.upperBound else { return nil }
         
-        let jsonString = String(eventString[dataStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        if let data = jsonString.data(using: .utf8) {
+        if let data = event.data?.data(using: .utf8) {
             let response = try JSONDecoder().decode(Response.self, from: data)
+            
+            if response.contentBlock?.type == "server_tool_use" {
+                return "\n\n...\n\n"
+            }
             
             return response.delta?.text
         }
@@ -65,6 +71,7 @@ struct AnthropicChatStreamingEndpoint: StreamingEndpoint {
 struct AnthropicChatStreamingResponse: Codable {
     let type: String
     let delta: Delta?
+    let contentBlock: ContentBlock?
 
     struct Delta: Codable {
         let type: String?
@@ -77,19 +84,14 @@ struct AnthropicChatStreamingResponse: Codable {
         }
     }
 
-    struct Content: Codable {
-        let type: String
-        let text: String
+    struct ContentBlock: Codable {
+        let type: String?
     }
-
-    struct Usage: Codable {
-        let inputTokens: Int
-        let outputTokens: Int
-
-        enum CodingKeys: String, CodingKey {
-            case inputTokens = "input_tokens"
-            case outputTokens = "output_tokens"
-        }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case delta
+        case contentBlock = "content_block"
     }
 }
 

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/OpenAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/OpenAIChatStreamingEndpoint.swift
@@ -23,7 +23,7 @@ struct OpenAIChatStreamingEndpoint: StreamingEndpoint {
     var requestBody: OpenAIChatRequest? {
         var tools: [OpenAIChatTool] = []
         if includeSearch == true {
-            tools.append(OpenAIChatTool(type: "web_search_preview"))
+            tools.append(OpenAIChatTool.search())
         }
         return OpenAIChatRequest(model: model, input: messages, tools: tools, stream: true)
     }

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/OpenAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/OpenAIChatStreamingEndpoint.swift
@@ -15,12 +15,17 @@ struct OpenAIChatStreamingEndpoint: StreamingEndpoint {
     let messages: [OpenAIChatMessage]
     let token: String?
     let model: String
+    let includeSearch: Bool?
     
     var path: String { "/v1/responses" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
     var requestBody: OpenAIChatRequest? {
-        OpenAIChatRequest(model: model, input: messages, stream: true)
+        var tools: [OpenAIChatTool] = []
+        if includeSearch == true {
+            tools.append(OpenAIChatTool(type: "web_search_preview"))
+        }
+        return OpenAIChatRequest(model: model, input: messages, tools: tools, stream: true)
     }
     var additionalHeaders: [String: String]? {
         ["Authorization": "Bearer \(token ?? "")"]

--- a/macos/Onit/Data/Fetching/Endpoints/Onit/Chat/GetChatSearchProvidersEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Onit/Chat/GetChatSearchProvidersEndpoint.swift
@@ -1,0 +1,43 @@
+//
+//  GetChatSearchProvidersEndpoint.swift
+//  Onit
+//
+//  Created by Jay Swanson on 6/25/25.
+//
+
+import Foundation
+
+extension FetchingClient {
+    func getChatSearchProviders() async throws -> [String] {
+        let endpoint = GetChatSearchProvidersEndpoint()
+        let response = try await execute(endpoint)
+        return response.providers
+    }
+}
+
+struct GetChatSearchProvidersEndpoint: Endpoint {
+    typealias Request = EmptyRequest
+
+    typealias Response = GetChatSearchProvidersResponse
+
+    var baseURL: URL { OnitServer.baseURL }
+
+    var path: String { "/v1/chat/search-providers" }
+
+    var getParams: [String: String]? { nil }
+
+    var method: HTTPMethod { .get }
+
+    var token: String? { TokenManager.token }
+
+    var requestBody: Request? { nil }
+
+    var additionalHeaders: [String: String]? { nil }
+
+    var timeout: TimeInterval? { nil }
+
+}
+
+struct GetChatSearchProvidersResponse: Codable {
+    let providers: [String]
+}

--- a/macos/Onit/Data/Fetching/FetchingClient.swift
+++ b/macos/Onit/Data/Fetching/FetchingClient.swift
@@ -29,7 +29,8 @@ actor FetchingClient {
         webSearchContexts: [[(title: String, content: String, source: String, url: URL?)]],
         responses: [String],
         model: AIModel,
-        apiToken: String?
+        apiToken: String?,
+        includeSearch: Bool? = nil
     ) async throws -> String {
         let userMessages = ChatEndpointMessagesBuilder.user(
             instructions: instructions,
@@ -44,7 +45,8 @@ actor FetchingClient {
             responses: responses,
             apiToken: apiToken,
             systemMessage: systemMessage,
-            userMessages: userMessages)
+            userMessages: userMessages,
+            includeSearch: includeSearch)
         
         return try await fetchChatContent(from: endpoint)
     }

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -127,7 +127,7 @@ struct ChatStreamingEndpointBuilder {
             userMessages: userMessages)
 
         return OpenAIChatStreamingEndpoint(
-            messages: messages, token: apiToken, model: model.id,includeSearch: includeSearch)
+            messages: messages, token: apiToken, model: model.id, includeSearch: includeSearch)
     }
 
     private static func anthropic(

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -38,7 +38,8 @@ struct ChatStreamingEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .anthropic:
             return ChatStreamingEndpointBuilder.anthropic(
                 model: model,
@@ -46,7 +47,8 @@ struct ChatStreamingEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .xAI:
             return ChatStreamingEndpointBuilder.xAI(
                 model: model,
@@ -114,7 +116,8 @@ struct ChatStreamingEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> OpenAIChatStreamingEndpoint {
         let messages = ChatEndpointMessagesBuilder.openAI(
             model: model,
@@ -124,7 +127,7 @@ struct ChatStreamingEndpointBuilder {
             userMessages: userMessages)
 
         return OpenAIChatStreamingEndpoint(
-            messages: messages, token: apiToken, model: model.id)
+            messages: messages, token: apiToken, model: model.id,includeSearch: includeSearch)
     }
 
     private static func anthropic(
@@ -133,7 +136,8 @@ struct ChatStreamingEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> AnthropicChatStreamingEndpoint {
         let messages = ChatEndpointMessagesBuilder.anthropic(
             model: model,
@@ -146,7 +150,8 @@ struct ChatStreamingEndpointBuilder {
             system: model.supportsSystemPrompts ? systemMessage : "",
             token: apiToken,
             messages: messages,
-            maxTokens: 4096
+            maxTokens: 4096,
+            includeSearch: includeSearch
         )
     }
 

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -100,6 +100,7 @@ extension Defaults.Keys {
     static let webSearchEnabled = Key<Bool>("webSearchEnabled", default: false)
     static let tavilyAPIToken = Key<String>("tavilyAPIToken", default: "")
     static let isTavilyAPITokenValidated = Key<Bool>("tavilyAPITokenValidated", default: false)
+    static let tavilyCostSavingMode = Key<Bool>("tavilyCostSavingMode", default: false)
 
     // Window state
     static let panelWidth = Key<Double>("panelWidth", default: 400)

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -101,6 +101,7 @@ extension Defaults.Keys {
     static let tavilyAPIToken = Key<String>("tavilyAPIToken", default: "")
     static let isTavilyAPITokenValidated = Key<Bool>("tavilyAPITokenValidated", default: false)
     static let tavilyCostSavingMode = Key<Bool>("tavilyCostSavingMode", default: false)
+    static let allowWebSearchInLocalMode = Key<Bool>("allowWebSearchInLocalMode", default: false)
 
     // Window state
     static let panelWidth = Key<Double>("panelWidth", default: 400)

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -211,7 +211,8 @@ extension OnitPanelState {
                             webSearchContexts: webSearchContextsHistory,
                             responses: responsesHistory,
                             model: model,
-                            apiToken: apiToken)
+                            apiToken: apiToken,
+                            includeSearch: shouldUseServerSideWebSearch ? true : nil)
                     }
                 
                 case .local:

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -144,20 +144,22 @@ extension OnitPanelState {
 
                 // Determine web search strategy
                 let webSearchEnabled = Defaults[.webSearchEnabled]
-                let useWebSearch = webSearchEnabled && isNewInstruction
+                let localWebSearchAllowed = Defaults[.mode] != .local || Defaults[.allowWebSearchInLocalMode]
+                let useWebSearch = webSearchEnabled && localWebSearchAllowed && isNewInstruction
 
                 var hasValidProviderSearchToken = false
+                var onitSupportsSearchProvider = false
                 if Defaults[.mode] == .remote, let model = Defaults[.remoteModel] {
                     let apiToken = TokenValidationManager.getTokenForModel(model)
                     let hasValidToken = apiToken != nil && !apiToken!.isEmpty
                     hasValidProviderSearchToken = hasValidToken && (model.provider == .openAI || model.provider == .anthropic)
-                }
 
-                let providers = try? await FetchingClient().getChatSearchProviders()
+                    let providers = try? await FetchingClient().getChatSearchProviders()
 
-                var onitSupportsSearchProvider = false
-                if let providers = providers, let provider = Defaults[.remoteModel]?.provider.rawValue {
-                    onitSupportsSearchProvider = providers.contains(where: { $0.lowercased() == provider })
+                    if let providers = providers {
+                        let provider = model.provider.rawValue
+                        onitSupportsSearchProvider = providers.contains(where: { $0.lowercased() == provider })
+                    }
                 }
 
                 let tavilyCostSavingMode = Defaults[.tavilyCostSavingMode]

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -151,7 +151,7 @@ extension OnitPanelState {
                 var onitSupportsSearchProvider = false
                 if Defaults[.mode] == .remote, let model = Defaults[.remoteModel] {
                     let apiToken = TokenValidationManager.getTokenForModel(model)
-                    let hasValidToken = apiToken != nil && !apiToken!.isEmpty
+                    let hasValidToken = apiToken?.isEmpty == false
                     hasValidProviderSearchToken = hasValidToken && (model.provider == .openAI || model.provider == .anthropic)
 
                     let providers = try? await FetchingClient().getChatSearchProviders()

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -160,7 +160,8 @@ extension OnitPanelState {
                     onitSupportsSearchProvider = providers.contains(where: { $0.lowercased() == provider })
                 }
 
-                let useTavilySearch = useWebSearch && !hasValidProviderSearchToken && !onitSupportsSearchProvider
+                let tavilyCostSavingMode = Defaults[.tavilyCostSavingMode]
+                let useTavilySearch = useWebSearch && !hasValidProviderSearchToken && (tavilyCostSavingMode || !onitSupportsSearchProvider)
 
                 // Perform client-side web search with Tavily if available
                 if useTavilySearch {

--- a/macos/Onit/UI/Prompt/PromptCoreFooter.swift
+++ b/macos/Onit/UI/Prompt/PromptCoreFooter.swift
@@ -6,9 +6,12 @@
 //
 
 import SwiftUI
+import Defaults
 
 struct PromptCoreFooter: View {
     @Environment(\.windowState) private var windowState
+    @Default(.mode) private var mode
+    @Default(.allowWebSearchInLocalMode) private var allowWebSearchInLocalMode
     
     private let audioRecorder: AudioRecorder
     private let disableSend: Bool
@@ -28,7 +31,9 @@ struct PromptCoreFooter: View {
         HStack(alignment: .center, spacing: 0) {
             HStack(spacing: 4) {
                 ModelSelectionButton()
-                WebSearchButton()
+                if mode != .local || allowWebSearchInLocalMode {
+                    WebSearchButton()
+                }
             }
             
             Spacer()

--- a/macos/Onit/UI/Settings/WebSearchTab.swift
+++ b/macos/Onit/UI/Settings/WebSearchTab.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Defaults
 
 struct WebSearchTab: View {
-    @Default(.webSearchEnabled) var webSearchEnabled
     @Default(.tavilyAPIToken) var tavilyAPIToken
     @Default(.isTavilyAPITokenValidated) var isTavilyAPITokenValidated
     
@@ -108,14 +107,12 @@ struct WebSearchTab: View {
                     
                     if !validated {
                         validationError = "Invalid API key. Please check and try again."
-                        webSearchEnabled = false
                     }
                 }
             } catch {
                 await MainActor.run {
                     isValidating = false
                     isTavilyAPITokenValidated = false
-                    webSearchEnabled = false
                     validationError = "Error validating API key: \(error.localizedDescription)"
                 }
             }

--- a/macos/Onit/UI/Settings/WebSearchTab.swift
+++ b/macos/Onit/UI/Settings/WebSearchTab.swift
@@ -4,6 +4,7 @@ import Defaults
 struct WebSearchTab: View {
     @Default(.tavilyAPIToken) var tavilyAPIToken
     @Default(.isTavilyAPITokenValidated) var isTavilyAPITokenValidated
+    @Default(.tavilyCostSavingMode) var tavilyCostSavingMode
     
     @State private var isValidating = false
     @State private var validationError: String? = nil
@@ -47,14 +48,6 @@ struct WebSearchTab: View {
                         .padding(.vertical, 4)
                         .background(Color.green.opacity(0.2))
                         .cornerRadius(4)
-                } else {
-                    Text("Using Onit Server")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.blue)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.blue.opacity(0.2))
-                        .cornerRadius(4)
                 }
             }
             
@@ -86,6 +79,22 @@ struct WebSearchTab: View {
                     Text(error)
                         .font(.system(size: 12))
                         .foregroundStyle(.red)
+                }
+            }
+
+            if isTavilyAPITokenValidated {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Toggle("Cost Saving Mode", isOn: $tavilyCostSavingMode)
+                            .font(.system(size: 13))
+                    }
+
+                    Text("When enabled, Onit will use your Tavily token to perform searches instead of Onit credits. By default, Onit uses model provider search tools when available for optimal quality.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.gray200)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }

--- a/macos/Onit/UI/Settings/WebSearchTab.swift
+++ b/macos/Onit/UI/Settings/WebSearchTab.swift
@@ -5,6 +5,7 @@ struct WebSearchTab: View {
     @Default(.tavilyAPIToken) var tavilyAPIToken
     @Default(.isTavilyAPITokenValidated) var isTavilyAPITokenValidated
     @Default(.tavilyCostSavingMode) var tavilyCostSavingMode
+    @Default(.allowWebSearchInLocalMode) var allowWebSearchInLocalMode
     
     @State private var isValidating = false
     @State private var validationError: String? = nil
@@ -27,11 +28,36 @@ struct WebSearchTab: View {
                     Text("Web Search Providers")
                 }
             }
+
+            Section {
+                VStack(alignment: .leading, spacing: 16) {
+                    localModeSection
+                }
+            } header: {
+                HStack {
+                    Image(systemName: "lock.shield")
+                    Text("Local Mode")
+                }
+            }
         }
         .formStyle(.grouped)
         .padding()
     }
     
+    var localModeSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Toggle("Enable Web Search in Local Mode", isOn: $allowWebSearchInLocalMode)
+                    .font(.system(size: 13))
+            }
+
+            Text("When enabled, web search will be available in local mode. Please note that your queries will be sent to the search provider's servers, and we cannot guarantee that your data won't be stored or logged by the provider.")
+                .font(.system(size: 12))
+                .foregroundStyle(.gray200)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     var tavilySection: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {


### PR DESCRIPTION
We just merged three outstanding PR's related to web search (#291, #290, #289). This PR puts these features and updates in a better user facing place.
- Added support for OpenAI and Anthropic's search tools for users with valid provider tokens
- Now Onit will dynamically query the search providers available on the server to better select a web search strategy
- Added a Tavily costing saving mode for when users prefer to use Tavily over our credit based system
- Added an option to enable/disable search when local mode is active to maintain privacy