### PR TITLE
Local-First Support ("offline mode")

### DIFF
--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -110,9 +110,7 @@ class AppState: NSObject, SPUUpdaterDelegate {
         settingsTab = tab
     }
     
-    func openModelSettingsTab() {
-        @Environment(\.openSettings) var openSettings
-        
+    func openModelSettingsTab(_ openSettings: OpenSettingsAction) {
         NSApp.activate()
         if NSApp.isActive {
             self.setSettingsTab(tab: .models)

--- a/macos/Onit/Constants/ModelConstants.swift
+++ b/macos/Onit/Constants/ModelConstants.swift
@@ -1,0 +1,10 @@
+//
+//  ModelConstants.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+struct ModelConstants {
+    static let ollamaUrl: String = "http://localhost:11434"
+}

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -57,6 +57,8 @@ extension Defaults.Keys {
     static let useLocal = Key<Bool>("useLocalModel", default: true)
     
     static let streamResponse = Key<StreamResponseConfig>("streamResponse", default: StreamResponseConfig.default)
+    
+    static let modelModeToggleShortcutDisabled = Key<Bool>("modelModeToggleShortcutDisabled", default: true)
 
     // Dialogs closed
     static let closedLocal = Key<Bool>("closedLocal", default: false)

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -109,7 +109,9 @@ struct KeyboardShortcutsManager {
                 case .newChat:
                     state.newChat()
                 case .toggleLocalMode:
-                    Defaults[.mode] = Defaults[.mode] == .local ? .remote : .local
+                    if !Defaults[.modelModeToggleShortcutDisabled] {
+                        Defaults[.mode] = Defaults[.mode] == .local ? .remote : .local
+                    }
                 default:
                     print("KeyboardShortcut not handled: \(name)")
                 }

--- a/macos/Onit/Network/NetworkMonitor.swift
+++ b/macos/Onit/Network/NetworkMonitor.swift
@@ -1,0 +1,74 @@
+//
+//  NetworkMonitor.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+import Foundation
+import Network
+
+@MainActor
+final class NetworkMonitor: ObservableObject {
+    // MARK: - Singleton Instance
+    
+    static let shared = NetworkMonitor()
+    
+    // MARK: - Properties
+    
+    private let networkMonitor: NWPathMonitor = NWPathMonitor()
+    private let networkMonitorQueue = DispatchQueue(label: "com.onitapp.networkMonitorQueue")
+    
+    /// Wi-Fi, Cellular, Wired Ethernet, Loopback, Other
+    @Published private(set) var networkInterface: NWInterface.InterfaceType? = nil
+    @Published private(set) var isOnline = true
+    
+    private init() {
+        self.networkMonitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self else { return }
+            
+            DispatchQueue.main.async {
+                /// Wi-Fi, Cellular, Wired Ethernet, Loopback, Other
+                self.updateNetworkInterface(path)
+                self.updateIsOnline(path)
+            }
+        }
+        
+        /// Initializing real-time network monitoring.
+        /// Queue allows monitoring to occur off the main thread, preventing hits on UI performance.
+        self.networkMonitor.start(queue: networkMonitorQueue)
+        
+        /// This is required to accurately synchronize set network properties ON START.
+        /// Every moment after is then updated in real time by `monitor.pathUpdateHandler` above.
+        initializeNetworkProperties()
+    }
+    
+    /// This technically never fires, but it never hurts to set this up, *just in case*.
+    deinit {
+        self.networkMonitor.cancel()
+    }
+    
+    // MARK: - Private Functions
+    
+    private func initializeNetworkProperties() {
+        let currentPath: NWPath = self.networkMonitor.currentPath
+        
+        updateNetworkInterface(currentPath)
+        updateIsOnline(currentPath)
+    }
+    
+    private func updateNetworkInterface(_ path: NWPath) {
+        self.networkInterface = path
+            .availableInterfaces
+            .first { path.usesInterfaceType($0.type) }?
+            .type
+    }
+    
+    private func updateIsOnline(_ path: NWPath) {
+        let isValidInternetPath = path.usesInterfaceType(.wifi) ||
+                                  path.usesInterfaceType(.wiredEthernet) ||
+                                  path.usesInterfaceType(.cellular)
+        
+        self.isOnline = path.status == .satisfied && isValidInternetPath
+    }
+}

--- a/macos/Onit/TokenValidation/TokenValidationManager.swift
+++ b/macos/Onit/TokenValidation/TokenValidationManager.swift
@@ -62,7 +62,8 @@ class TokenValidationManager {
             case .custom:
                 throw FetchingError.invalidRequest(message: "Custom provider token validation is not supported")   
             }
-            Self.setTokenIsValid(true)
+            
+            Self.setTokenIsValid(true, provider: provider)
         } catch let error as FetchingError {
             print("Error: \(error.localizedDescription)")
             state.setInvalid(provider: provider, error: error)
@@ -80,7 +81,6 @@ class TokenValidationManager {
     }
 
     static func setTokenIsValid(_ isValid: Bool, provider: AIModel.ModelProvider) {
-        if Defaults[.mode] == .local { return }
         switch provider {
         case .openAI:
             Defaults[.isOpenAITokenValidated] = isValid

--- a/macos/Onit/UI/Auth/AuthAddModelSection.swift
+++ b/macos/Onit/UI/Auth/AuthAddModelSection.swift
@@ -1,0 +1,129 @@
+//
+//  AuthAddModelSection.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+import Defaults
+import SwiftUI
+
+struct AuthAddModelSection: View {
+    @Environment(\.appState) var appState
+    @Environment(\.openSettings) var openSettings
+    
+    // MARK: - States
+    
+    @State private var isHoveredAddLocalModelButton: Bool = false
+    @State private var isHoveredAddModelButton: Bool = false
+    
+    @State private var isFetchingLocalModels: Bool = false
+    
+    @State private var errorMessageFetchingLocalModels: String = ""
+    
+    // MARK: - Private Variables
+    
+    private var isOffline: Bool {
+        !appState.isOnline
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 4) {
+            Text("Have local models\(!isOffline ? " or API key" : "")?")
+                .styleText(
+                    size: 13,
+                    weight: .regular,
+                    color: .gray100,
+                    align: .center
+                )
+            
+            loadLocalModelsButton
+            
+            fetchingLocalModelsError
+            
+            if !isOffline {
+                openModelSettingsTabButton
+            } else {
+                if !errorMessageFetchingLocalModels.isEmpty {
+                    openModelSettingsTabButton
+                }
+            }
+        }
+    }
+    
+    // MARK: - Child Components
+    
+    @ViewBuilder
+    private var loadLocalModelsButton: some View {
+        if isOffline {
+            Button {
+                isFetchingLocalModels = true
+                errorMessageFetchingLocalModels = ""
+                
+                Task {
+                    Defaults[.localEndpointURL] = URL(string: ModelConstants.ollamaUrl)!
+                    
+                    await appState.fetchLocalModels()
+                    
+                    if appState.localFetchFailed {
+                        errorMessageFetchingLocalModels = "Failed to load Ollama.\nMake sure it is running and try again. Or manually add it with the link below."
+                    } else {
+                        errorMessageFetchingLocalModels = ""
+                    }
+                    
+                    isFetchingLocalModels = false
+                }
+            } label: {
+                HStack(alignment: .center, spacing: 8) {
+                    if isFetchingLocalModels {
+                        Loader()
+                    }
+                    
+                    Text("Load Ollama")
+                        .styleText(
+                            size: 13,
+                            weight: .regular,
+                            align: .center,
+                            underline: isHoveredAddLocalModelButton
+                        )
+                        .onHover { isHovering in
+                            isHoveredAddLocalModelButton = isHovering
+                        }
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var fetchingLocalModelsError: some View {
+        if !errorMessageFetchingLocalModels.isEmpty {
+            Text(errorMessageFetchingLocalModels)
+                .styleText(
+                    size: 13,
+                    weight: .regular,
+                    color: .red,
+                    align: .center
+                )
+                .frame(maxWidth: 220)
+        }
+    }
+    
+    private var openModelSettingsTabButton: some View {
+        Button {
+            appState.openModelSettingsTab(openSettings)
+        } label: {
+            Text("Add \(isOffline ? "local model" : "models") here to access Onit")
+                .styleText(
+                    size: 13,
+                    weight: .regular,
+                    align: .center,
+                    underline: isHoveredAddModelButton
+                )
+                .onHover { isHovering in
+                    isHoveredAddModelButton = isHovering
+                }
+        }
+    }
+}

--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -188,7 +188,7 @@ extension AuthFlow {
                 )
             
             Button {
-                appState.openModelSettingsTab()
+                appState.openModelSettingsTab(openSettings)
             } label: {
                 Text("Add it here to access Onit.")
                     .styleText(

--- a/macos/Onit/UI/Auth/AuthFlow.swift
+++ b/macos/Onit/UI/Auth/AuthFlow.swift
@@ -5,47 +5,19 @@
 //  Created by Loyd Kim on 4/30/25.
 //
 
-import AuthenticationServices
 import Defaults
-import GoogleSignIn
-import GoogleSignInSwift
 import SwiftUI
 
 struct AuthFlow: View {
     @Environment(\.appState) var appState
-    @Environment(\.openSettings) var openSettings
     
     @Default(.availableLocalModels) var availableLocalModels
     @Default(.authFlowStatus) var authFlowStatus
-    
-    @Default(.useOpenAI) var useOpenAI
-    @Default(.useAnthropic) var useAnthropic
-    @Default(.useXAI) var useXAI
-    @Default(.useGoogleAI) var useGoogleAI
-    @Default(.useDeepSeek) var useDeepSeek
-    @Default(.usePerplexity) var usePerplexity
-
-    @State private var isHoveredContinueWithEmailButton: Bool = false
-    @State private var isPressedContinueWithEmailButton: Bool = false
-    
-    @State private var isHoveredRedirectButton: Bool = false
-    @State private var isHoveredSkipButton: Bool = false
-
-    @State private var isHoveredResendLinkButton: Bool = false
-    @State private var isHoveredBackButton: Bool = false
-    @State private var isPressedBackButton: Bool = false
-    
-    @State private var isHoveredAddModelButton: Bool = false
     
     @State private var email: String = ""
     @State private var requestedEmailLogin: Bool = false
     
     @State private var errorMessageEmail: String = ""
-    @State private var errorMessageAuth: String = ""
-    
-    private var isSignUp: Bool {
-        return authFlowStatus == .showSignUp
-    }
     
     private var userProvidedOwnModel: Bool {
         let hasLocalModel: Bool = !availableLocalModels.isEmpty
@@ -59,14 +31,22 @@ struct AuthFlow: View {
     var body: some View {
         VStack(alignment: .center, spacing: 42) {
             if requestedEmailLogin {
-                emailAuthTokenForm
+                AuthVerifyEmailForm(
+                    email: $email,
+                    requestedEmailLogin: $requestedEmailLogin,
+                    requestEmailLoginLink: requestEmailLoginLink
+                )
             } else {
-                form
+                AuthForm(
+                    email: $email,
+                    errorMessageEmail: $errorMessageEmail,
+                    requestEmailLoginLink: requestEmailLoginLink
+                )
                 
-                redirectSection
+                AuthRedirectSection()
                 
                 if !userProvidedOwnModel {
-                    addModelSection
+                    AuthAddModelSection()
                 }
                 
                 Spacer()
@@ -82,194 +62,8 @@ struct AuthFlow: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.top, 134)
     }
-}
-
-// MARK: - Child Components
-
-extension AuthFlow {
-    private var formAuthButtons: some View {
-        VStack(spacing: 4) {
-            OnboardingAuthButton(
-                icon: .logoGoogle,
-                action: handleGoogleSignInButton
-            )
-            
-            if !errorMessageAuth.isEmpty {
-                Text(errorMessageAuth)
-                    .styleText(size: 12, weight: .medium, color: .red, align: .center)
-            }
-        }
-    }
     
-    private var emailAddressInput: some View {
-        InputField(
-            placeholder: "Email Address",
-            text: $email,
-            errorMessage: errorMessageEmail,
-            onSubmit: requestEmailLoginLink
-        )
-    }
-    
-    private var continueWithEmailButton: some View {
-        Text("Continue with email")
-            .frame(maxWidth: .infinity)
-            .frame(height: 40)
-            .styleText(align: .center)
-            .addButtonEffects(
-                background: .blue400,
-                hoverBackground: .blue350,
-                cornerRadius: 9,
-                isHovered: $isHoveredContinueWithEmailButton,
-                isPressed: $isPressedContinueWithEmailButton,
-                action: requestEmailLoginLink
-            )
-    }
-    
-    private var form: some View {
-        VStack(alignment: .center, spacing: 0) {
-            Image("Logo").padding(.bottom, 19)
-            
-            Text(isSignUp ? "Create your account" : "Sign in to Onit")
-                .styleText(size: 23)
-                .padding(.bottom, 28)
-            
-            VStack(alignment: .center, spacing: 12) {
-                formAuthButtons
-                
-                Text("OR").styleText(size: 12, color: .gray300)
-                
-                VStack(spacing: 20) {
-                    VStack(spacing: 12) {
-                        emailAddressInput
-                        continueWithEmailButton
-                    }
-//                    agreement
-                }
-            }
-        }
-        .padding(.horizontal, 40)
-    }
-    
-    private var agreement: some View {
-        Text(generateAgreementText())
-            .styleText(size: 12, align: .center)
-    }
-    
-    private var redirectSection: some View {
-        HStack(spacing: 6) {
-            Text(isSignUp ? "Already have an account?" : "Don't have an account?")
-                .styleText(size: 13, weight: .regular, color: .gray100)
-            
-            Button {
-                if isSignUp {
-                    authFlowStatus = .showSignIn
-                } else {
-                    authFlowStatus = .showSignUp
-                }
-            } label: {
-                Text(isSignUp ? "Sign In" : "Sign up")
-                    .styleText(size: 13, weight: .regular, underline: isHoveredRedirectButton)
-            }
-            .buttonStyle(PlainButtonStyle())
-            .onHover { isHovering in
-                isHoveredRedirectButton = isHovering
-            }
-        }
-    }
-    
-    private var addModelSection: some View {
-        VStack(alignment: .center, spacing: 4) {
-            Text("Have your own API key or local model?")
-                .styleText(
-                    size: 13,
-                    weight: .regular,
-                    color: .gray100,
-                    align: .center
-                )
-            
-            Button {
-                appState.openModelSettingsTab(openSettings)
-            } label: {
-                Text("Add it here to access Onit.")
-                    .styleText(
-                        size: 13,
-                        weight: .regular,
-                        align: .center,
-                        underline: isHoveredAddModelButton
-                    )
-                    .onHover { isHovering in
-                        isHoveredAddModelButton = isHovering
-                    }
-            }
-        }
-    }
-    
-    private var emailAuthTokenForm: some View {
-        VStack(alignment: .center, spacing: 0) {
-            Image("Mail").padding(.bottom, 16)
-            
-            Text("Check your email")
-                .styleText(size: 23)
-            
-            VStack(alignment: .center, spacing: 2) {
-                Text("Click the link we sent to:")
-                    .styleText(
-                        size: 13,
-                        weight: .regular,
-                        color: .gray100
-                    )
-                
-                Text(email).styleText(size: 15, weight: .regular)
-            }
-            .padding(.vertical, 16)
-            
-            Spacer()
-            
-            VStack(alignment: .center, spacing: 28) {
-                VStack(alignment: .center, spacing: 0) {
-                    Text("Didn't get it? Check your spam folder and the spelling")
-                        .styleText(size: 12, color: .gray200, align: .center)
-                        .frame(maxWidth: .infinity)
-                    
-                    HStack(spacing: 4) {
-                        Text("of your email address, or")
-                            .styleText(size: 12, color: .gray200)
-                        
-                        Button {
-                            requestEmailLoginLink()
-                        } label: {
-                            Text("Resend Link")
-                                .styleText(size: 12, underline: isHoveredResendLinkButton)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .onHover { isHovering in
-                            isHoveredResendLinkButton = isHovering
-                        }
-                    }
-                }
-                
-                Text("← Back")
-                    .frame(height: 40)
-                    .padding(.horizontal, 14)
-                    .background(isHoveredBackButton ? .gray900 : .clear)
-                    .addBorder(cornerRadius: 9, stroke: .gray700)
-                    .scaleEffect(isPressedBackButton ? 0.98 : 1)
-                    .opacity(isPressedBackButton ? 0.7 : 1)
-                    .addAnimation(dependency: isHoveredBackButton)
-                    .onHover{ isHovering in isHoveredBackButton = isHovering }
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged {_ in isPressedBackButton = true }
-                            .onEnded{ _ in
-                                AnalyticsManager.Auth.cancelled(provider: "email")
-                                isPressedBackButton = false
-                                requestedEmailLogin = false
-                            }
-                    )
-            }
-        }
-        .padding(.bottom, 53)
-    }
+    // MARK: - Child Components
     
     private var closeButton: some View {
         TextButton(
@@ -285,57 +79,9 @@ extension AuthFlow {
         .padding([.top, .horizontal], 40)
         .padding(.bottom, 53)
     }
-}
-
-
-// MARK: - Private Functions (UI)
-
-extension AuthFlow {
-    private func generateAgreementText() -> AttributedString {
-        var agreementText = AttributedString("By continuing with Google or email, you agree to our ")
-        agreementText.foregroundColor = .gray300
-        
-        var termsText = AttributedString("Terms of Service")
-        termsText.foregroundColor = .gray200
-        termsText.link = URL(string: "https://www.getonit.ai/")
-        agreementText.append(termsText)
-        
-        var andText = AttributedString(" and ")
-        andText.foregroundColor = .gray300
-        agreementText.append(andText)
-        
-        var privacyText = AttributedString("Privacy Policy")
-        privacyText.foregroundColor = .gray200
-        privacyText.link = URL(string: "https://www.getonit.ai/")
-        agreementText.append(privacyText)
-        
-        var periodText = AttributedString(".")
-        periodText.foregroundColor = .gray300
-        agreementText.append(periodText)
-        
-        return agreementText
-    }
     
-    @MainActor
-    private func handleLogin(loginResponse: LoginResponse) {
-        TokenManager.token = loginResponse.token
-        appState.account = loginResponse.account
-
-        if loginResponse.isNewAccount {
-            AnalyticsManager.Identity.identify(account: loginResponse.account)
-            useOpenAI = true
-            useAnthropic = true
-            useXAI = true
-            useGoogleAI = true
-            useDeepSeek = true
-            usePerplexity = true
-        }
-    }
-}
-
-// MARK: - Private Functions (email)
-
-extension AuthFlow {
+    // MARK: - Private Functions
+    
     private func validateEmail() -> Bool {
         let emailRegex = "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
@@ -351,102 +97,34 @@ extension AuthFlow {
         errorMessageEmail = ""
 
         if email.isEmpty {
-            let errorMsg = "Please enter your email"
+            let errorMessage = "Please enter your email"
             
-            AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
-            errorMessageEmail = errorMsg
+            AnalyticsManager.Auth.error(provider: provider, error: errorMessage)
+            
+            errorMessageEmail = errorMessage
         } else if !validateEmail() {
-            let errorMsg = "Invalid email format"
+            let errorMessage = "Invalid email format"
             
-            AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
-            errorMessageEmail = errorMsg
+            AnalyticsManager.Auth.error(provider: provider, error: errorMessage)
+            
+            errorMessageEmail = errorMessage
         } else {
             let client = FetchingClient()
             
             Task {
                 do {
                     AnalyticsManager.Auth.requested(provider: provider)
+                    
                     try await client.requestLoginLink(email: email)
                     requestedEmailLogin = true
                 } catch {
-                    let errorMsg = error.localizedDescription
+                    let errorMessage = error.localizedDescription
                     
-                    AnalyticsManager.Auth.failed(provider: provider, error: errorMsg)
-                    errorMessageEmail = errorMsg
+                    AnalyticsManager.Auth.failed(provider: provider, error: errorMessage)
+                    
+                    errorMessageEmail = errorMessage
                 }
             }
         }
-    }
-}
-
-// MARK: - Private Functions (Google, Apple)
-
-extension AuthFlow {
-    private func handleGoogleSignInButton() {
-        let provider = "google"
-        AnalyticsManager.Auth.pressed(provider: provider)
-        errorMessageAuth = ""
-        
-        guard let window = NSApp.keyWindow else { return }
-
-        AnalyticsManager.Auth.requested(provider: provider)
-        
-        GIDSignIn.sharedInstance.signIn(withPresenting: window) { result, error in
-            guard let result = result else {
-                if let error = error as? NSError, error.domain == "com.google.GIDSignIn", error.code == -5 {
-                    // The user canceled the sign-in flow
-                    AnalyticsManager.Auth.cancelled(provider: provider)
-                    return
-                } else if let error = error {
-                    let errorMsg = error.localizedDescription
-                    
-                    AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
-                    errorMessageAuth = errorMsg
-                } else {
-                    let errorMsg = "Unknown Google sign in error"
-                    
-                    AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
-                    errorMessageAuth = errorMsg
-                }
-                return
-            }
-
-            guard let idToken = result.user.idToken?.tokenString else {
-                let errorMsg = "Failed to get Google identity token"
-                
-                AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
-                errorMessageAuth = errorMsg
-                return
-            }
-
-            Task {
-                do {
-                    let client = FetchingClient()
-                    let loginResponse = try await client.loginGoogle(idToken: idToken)
-                    handleLogin(loginResponse: loginResponse)
-                    AnalyticsManager.Auth.success(provider: provider)
-                } catch {
-                    let errorMsg = error.localizedDescription
-                    
-                    AnalyticsManager.Auth.failed(provider: provider, error: errorMsg)
-                    errorMessageAuth = errorMsg
-                }
-            }
-        }
-    }
-    
-    private func handleAppleCredential(_ authResults: ASAuthorization) async throws {
-        guard
-            let credentials = authResults.credential as? ASAuthorizationAppleIDCredential,
-            let identityToken = credentials.identityToken,
-            let identityTokenString = String(data: identityToken, encoding: .utf8)
-        else {
-            errorMessageAuth = "Failed to get Apple identity token"
-            return
-        }
-        
-        let client = FetchingClient()
-        let loginResponse = try await client.loginApple(idToken: identityTokenString)
-        handleLogin(loginResponse: loginResponse)
     }
 }

--- a/macos/Onit/UI/Auth/AuthForm.swift
+++ b/macos/Onit/UI/Auth/AuthForm.swift
@@ -1,0 +1,253 @@
+//
+//  AuthForm.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+import AuthenticationServices
+import Defaults
+import GoogleSignIn
+import GoogleSignInSwift
+import SwiftUI
+
+struct AuthForm: View {
+    @Environment(\.appState) var appState
+    
+    @Default(.useOpenAI) var useOpenAI
+    @Default(.useAnthropic) var useAnthropic
+    @Default(.useXAI) var useXAI
+    @Default(.useGoogleAI) var useGoogleAI
+    @Default(.useDeepSeek) var useDeepSeek
+    @Default(.usePerplexity) var usePerplexity
+    
+    @Default(.authFlowStatus) var authFlowStatus
+    
+    // MARK: - Properties
+    
+    @Binding private var email: String
+    @Binding private var errorMessageEmail: String
+    
+    private var requestEmailLoginLink: () -> Void
+    
+    init(
+        email: Binding<String>,
+        errorMessageEmail: Binding<String>,
+        requestEmailLoginLink: @escaping () -> Void
+    ) {
+        self._email = email
+        self._errorMessageEmail = errorMessageEmail
+        self.requestEmailLoginLink = requestEmailLoginLink
+    }
+    
+    // MARK: - States
+    
+    @State private var isHoveredContinueWithEmailButton: Bool = false
+    
+    @State private var isPressedContinueWithEmailButton: Bool = false
+    
+    @State private var errorMessageAuth: String = ""
+    
+    // MARK: - Private Variables
+    
+    private var isSignUp: Bool {
+        return authFlowStatus == .showSignUp
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image("Logo").padding(.bottom, 19)
+            
+            Text(isSignUp ? "Create your account" : "Sign in to Onit")
+                .styleText(size: 23)
+                .padding(.bottom, 28)
+            
+            VStack(alignment: .center, spacing: 12) {
+                formAuthButtons
+                
+                Text("OR")
+                    .styleText(
+                        size: 12,
+                        color: .gray300
+                    )
+                
+                VStack(spacing: 20) {
+                    VStack(spacing: 12) {
+                        emailAddressInput
+                        continueWithEmailButton
+                    }
+//                    agreement
+                }
+            }
+        }
+        .padding(.horizontal, 40)
+    }
+    
+    // MARK: - Child Components
+    
+    private var formAuthButtons: some View {
+        VStack(spacing: 4) {
+            OnboardingAuthButton(
+                icon: .logoGoogle,
+                action: handleGoogleSignInButton
+            )
+            
+            if !errorMessageAuth.isEmpty {
+                Text(errorMessageAuth)
+                    .styleText(
+                        size: 12,
+                        weight: .medium,
+                        color: .red,
+                        align: .center
+                    )
+            }
+        }
+    }
+    
+    private var emailAddressInput: some View {
+        InputField(
+            placeholder: "Email Address",
+            text: $email,
+            errorMessage: errorMessageEmail
+        ) {
+            requestEmailLoginLink()
+        }
+    }
+    
+    private var continueWithEmailButton: some View {
+        Text("Continue with email")
+            .frame(maxWidth: .infinity)
+            .frame(height: 40)
+            .styleText(align: .center)
+            .addButtonEffects(
+                background: .blue400,
+                hoverBackground: .blue350,
+                cornerRadius: 9,
+                isHovered: $isHoveredContinueWithEmailButton,
+                isPressed: $isPressedContinueWithEmailButton
+            ) {
+                requestEmailLoginLink()
+            }
+    }
+    
+    private var agreement: some View {
+        Text(generateAgreementText())
+            .styleText(
+                size: 12,
+                align: .center
+            )
+    }
+    
+    // MARK: - Private Functions
+    
+    private func generateAgreementText() -> AttributedString {
+        var agreementText = AttributedString("By continuing with Google or email, you agree to our ")
+        agreementText.foregroundColor = .gray300
+        
+        var termsText = AttributedString("Terms of Service")
+        termsText.foregroundColor = .gray200
+        termsText.link = URL(string: "https://www.getonit.ai/")
+        agreementText.append(termsText)
+        
+        var andText = AttributedString(" and ")
+        andText.foregroundColor = .gray300
+        agreementText.append(andText)
+        
+        var privacyText = AttributedString("Privacy Policy")
+        privacyText.foregroundColor = .gray200
+        privacyText.link = URL(string: "https://www.getonit.ai/")
+        agreementText.append(privacyText)
+        
+        var periodText = AttributedString(".")
+        periodText.foregroundColor = .gray300
+        agreementText.append(periodText)
+        
+        return agreementText
+    }
+    
+    @MainActor
+    private func handleLogin(loginResponse: LoginResponse) {
+        TokenManager.token = loginResponse.token
+        appState.account = loginResponse.account
+
+        if loginResponse.isNewAccount {
+            AnalyticsManager.Identity.identify(account: loginResponse.account)
+            useOpenAI = true
+            useAnthropic = true
+            useXAI = true
+            useGoogleAI = true
+            useDeepSeek = true
+            usePerplexity = true
+        }
+    }
+    
+    private func handleGoogleSignInButton() {
+        let provider = "google"
+        AnalyticsManager.Auth.pressed(provider: provider)
+        errorMessageAuth = ""
+        
+        guard let window = NSApp.keyWindow else { return }
+
+        AnalyticsManager.Auth.requested(provider: provider)
+        
+        GIDSignIn.sharedInstance.signIn(withPresenting: window) { result, error in
+            guard let result = result else {
+                if let error = error as? NSError, error.domain == "com.google.GIDSignIn", error.code == -5 {
+                    // The user canceled the sign-in flow
+                    AnalyticsManager.Auth.cancelled(provider: provider)
+                    return
+                } else if let error = error {
+                    let errorMsg = error.localizedDescription
+                    
+                    AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
+                    errorMessageAuth = errorMsg
+                } else {
+                    let errorMsg = "Unknown Google sign in error"
+                    
+                    AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
+                    errorMessageAuth = errorMsg
+                }
+                return
+            }
+
+            guard let idToken = result.user.idToken?.tokenString else {
+                let errorMsg = "Failed to get Google identity token"
+                
+                AnalyticsManager.Auth.error(provider: provider, error: errorMsg)
+                errorMessageAuth = errorMsg
+                return
+            }
+
+            Task {
+                do {
+                    let client = FetchingClient()
+                    let loginResponse = try await client.loginGoogle(idToken: idToken)
+                    handleLogin(loginResponse: loginResponse)
+                    AnalyticsManager.Auth.success(provider: provider)
+                } catch {
+                    let errorMsg = error.localizedDescription
+                    
+                    AnalyticsManager.Auth.failed(provider: provider, error: errorMsg)
+                    errorMessageAuth = errorMsg
+                }
+            }
+        }
+    }
+    
+    private func handleAppleCredential(_ authResults: ASAuthorization) async throws {
+        guard
+            let credentials = authResults.credential as? ASAuthorizationAppleIDCredential,
+            let identityToken = credentials.identityToken,
+            let identityTokenString = String(data: identityToken, encoding: .utf8)
+        else {
+            errorMessageAuth = "Failed to get Apple identity token"
+            return
+        }
+        
+        let client = FetchingClient()
+        let loginResponse = try await client.loginApple(idToken: identityTokenString)
+        handleLogin(loginResponse: loginResponse)
+    }
+}

--- a/macos/Onit/UI/Auth/AuthRedirectSection.swift
+++ b/macos/Onit/UI/Auth/AuthRedirectSection.swift
@@ -1,0 +1,55 @@
+//
+//  AuthRedirectSection.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+import Defaults
+import SwiftUI
+
+struct AuthRedirectSection: View {
+    @Default(.authFlowStatus) var authFlowStatus
+    
+    // MARK: - States
+    
+    @State private var isHoveredRedirectButton: Bool = false
+    
+    // MARK: - Private Variables
+    
+    private var isSignUp: Bool {
+        authFlowStatus == .showSignUp
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(isSignUp ? "Already have an account?" : "Don't have an account?")
+                .styleText(
+                    size: 13,
+                    weight: .regular,
+                    color: .gray100
+                )
+            
+            Button {
+                if isSignUp {
+                    authFlowStatus = .showSignIn
+                } else {
+                    authFlowStatus = .showSignUp
+                }
+            } label: {
+                Text(isSignUp ? "Sign In" : "Sign up")
+                    .styleText(
+                        size: 13,
+                        weight: .regular,
+                        underline: isHoveredRedirectButton
+                    )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .onHover { isHovering in
+                isHoveredRedirectButton = isHovering
+            }
+        }
+    }
+}

--- a/macos/Onit/UI/Auth/AuthVerifyEmailForm.swift
+++ b/macos/Onit/UI/Auth/AuthVerifyEmailForm.swift
@@ -1,0 +1,114 @@
+//
+//  AuthVerifyEmailForm.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/7/25.
+//
+
+import SwiftUI
+
+struct AuthVerifyEmailForm: View {
+    // MARK: - Properties
+    
+    @Binding private var email: String
+    @Binding private var requestedEmailLogin: Bool
+    
+    private var requestEmailLoginLink: () -> Void
+    
+    init(
+        email: Binding<String>,
+        requestedEmailLogin: Binding<Bool>,
+        requestEmailLoginLink: @escaping () -> Void
+    ) {
+        self._email = email
+        self._requestedEmailLogin = requestedEmailLogin
+        self.requestEmailLoginLink = requestEmailLoginLink
+    }
+    
+    // MARK: - States
+    
+    @State private var isHoveredResendLinkButton: Bool = false
+    @State private var isHoveredBackButton: Bool = false
+    
+    @State private var isPressedBackButton: Bool = false
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image("Mail")
+                .padding(.bottom, 16)
+            
+            Text("Check your email")
+                .styleText(size: 23)
+            
+            VStack(alignment: .center, spacing: 2) {
+                Text("Click the link we sent to:")
+                    .styleText(
+                        size: 13,
+                        weight: .regular,
+                        color: .gray100
+                    )
+                
+                Text(email)
+                    .styleText(
+                        size: 15,
+                        weight: .regular
+                    )
+            }
+            .padding(.vertical, 16)
+            
+            Spacer()
+            
+            VStack(alignment: .center, spacing: 28) {
+                VStack(alignment: .center, spacing: 0) {
+                    Text("Didn't get it? Check your spam folder and the spelling")
+                        .styleText(
+                            size: 12,
+                            color: .gray200,
+                            align: .center
+                        )
+                        .frame(maxWidth: .infinity)
+                    
+                    HStack(spacing: 4) {
+                        Text("of your email address, or")
+                            .styleText(
+                                size: 12,
+                                color: .gray200
+                            )
+                        
+                        Button {
+                            requestEmailLoginLink()
+                        } label: {
+                            Text("Resend Link")
+                                .styleText(
+                                    size: 12,
+                                    underline: isHoveredResendLinkButton
+                                )
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .onHover { isHovering in
+                            isHoveredResendLinkButton = isHovering
+                        }
+                    }
+                }
+                
+                Text("← Back")
+                    .frame(height: 40)
+                    .padding(.horizontal, 14)
+                    .addBorder(cornerRadius: 9, stroke: .gray700)
+                    .addButtonEffects(
+                        hoverBackground: .gray900,
+                        cornerRadius: 9,
+                        isHovered: $isHoveredBackButton,
+                        isPressed: $isPressedBackButton
+                    ) {
+                        AnalyticsManager.Auth.cancelled(provider: "email")
+                        isPressedBackButton = false
+                        requestedEmailLogin = false
+                    }
+            }
+        }
+        .padding(.bottom, 53)
+    }
+}

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -106,12 +106,17 @@ struct ChatView: View {
             
             if currentPromptsCount <= 0 {
                 Spacer()
-                footerNotificationsList
+                
+                if appState.isOnline {
+                    footerNotificationsList
+                }
             }
         }
         .drag()
         .onAppear {
-            appState.checkForAvailableUpdate()
+            if appState.isOnline {
+                appState.checkForAvailableUpdate()
+            }
         }
     }
 }

--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -129,7 +129,7 @@ struct TextViewWrapper: NSViewRepresentable {
                 parent.cursorPosition = textView.selectedRange().location
             }
             
-            if parent.detectLinks {
+            if parent.detectLinks && NetworkMonitor.shared.isOnline {
                 handleUrlDetection(text: textView.string)
             }
             

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -151,8 +151,8 @@ struct ContentView: View {
         .onAppear {
             // Prevents edge cases where incorrect state may have been set.
             // While this isn't likely, having an extra layer of security makes sure to keep the UX in-line with expectations.
+            checkCanAccessRemoteModels(appState.canAccessRemoteModels)
             checkShouldHideOrShowAuthFlow()
-            checkCanAccessRemoteModels()
             
             if !hasClosedTrialEndedAlert {
                 if let subscriptionStatus = appState.subscription?.status {
@@ -172,6 +172,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: appState.userLoggedIn) { _, loggedIn in
+            // Handles showing AuthFlow when logging out.
             if loggedIn {
                 authFlowStatus = .hideAuth
             } else if !loggedIn && !userProvidedOwnModel {
@@ -179,6 +180,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: userProvidedOwnModel) { _, providedOwnModel in
+            // Handles showing AuthFlow when removing local models or provider API keys.
             if providedOwnModel {
                 authFlowStatus = .hideAuth
             } else if !providedOwnModel && !appState.userLoggedIn {
@@ -186,12 +188,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: appState.canAccessRemoteModels) { _, canAccessRemoteModels in
-            if !canAccessRemoteModels {
-                mode = .local
-                Defaults[.modelModeToggleShortcutDisabled] = true
-            } else {
-                Defaults[.modelModeToggleShortcutDisabled] = false
-            }
+            checkCanAccessRemoteModels(!canAccessRemoteModels)
         }
     }
     
@@ -205,8 +202,8 @@ struct ContentView: View {
         }
     }
     
-    private func checkCanAccessRemoteModels() {
-        if !appState.canAccessRemoteModels {
+    private func checkCanAccessRemoteModels(_ canAccessRemoteModels: Bool) {
+        if !canAccessRemoteModels {
             mode = .local
             Defaults[.modelModeToggleShortcutDisabled] = true
         } else {

--- a/macos/Onit/UI/Content/ContentView.swift
+++ b/macos/Onit/UI/Content/ContentView.swift
@@ -159,7 +159,7 @@ struct ContentView: View {
                     if subscriptionStatus == "active" {
                         hasClosedTrialEndedAlert = true
                     } else if subscriptionStatus == "canceled",
-                       let trialEndDate = appState.subscription?.trialEnd
+                              let trialEndDate = appState.subscription?.trialEnd
                     {
                         let today = getTodayAsEpochDate()
                         let trialExpired = today >= trialEndDate
@@ -173,22 +173,22 @@ struct ContentView: View {
         }
         .onChange(of: appState.userLoggedIn) { _, loggedIn in
             // Handles showing AuthFlow when logging out.
-            if loggedIn {
+            if !loggedIn && !userProvidedOwnModel {
+                authFlowStatus = .showSignIn
+            } else {
                 authFlowStatus = .hideAuth
-            } else if !loggedIn && !userProvidedOwnModel {
-                authFlowStatus = .showSignUp
             }
         }
         .onChange(of: userProvidedOwnModel) { _, providedOwnModel in
             // Handles showing AuthFlow when removing local models or provider API keys.
-            if providedOwnModel {
-                authFlowStatus = .hideAuth
-            } else if !providedOwnModel && !appState.userLoggedIn {
+            if !providedOwnModel && !appState.userLoggedIn {
                 authFlowStatus = .showSignUp
+            } else {
+                authFlowStatus = .hideAuth
             }
         }
         .onChange(of: appState.canAccessRemoteModels) { _, canAccessRemoteModels in
-            checkCanAccessRemoteModels(!canAccessRemoteModels)
+            checkCanAccessRemoteModels(canAccessRemoteModels)
         }
     }
     

--- a/macos/Onit/UI/Content/Toolbar.swift
+++ b/macos/Onit/UI/Content/Toolbar.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 struct Toolbar: View {
+    var mode: InferenceMode
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .center) {
                 ToolbarLeft()
                 Spacer()
-                ToolbarRight()
+                ToolbarRight(mode: mode)
             }
             .padding(.top, 1)
             .padding(.trailing, 8)

--- a/macos/Onit/UI/Content/ToolbarRight.swift
+++ b/macos/Onit/UI/Content/ToolbarRight.swift
@@ -60,6 +60,7 @@ struct ToolbarRight: View {
         ) {
             toggleMode()
         }
+        .disabled(!appState.canAccessRemoteModels)
     }
 
     var discord: some View {

--- a/macos/Onit/UI/Content/ToolbarRight.swift
+++ b/macos/Onit/UI/Content/ToolbarRight.swift
@@ -14,8 +14,9 @@ struct ToolbarRight: View {
     @Environment(\.openSettings) var openSettings
     @Environment(\.windowState) private var state
     
-    @Default(.mode) var mode
     @Default(.footerNotifications) var footerNotifications
+    
+    var mode: InferenceMode
 
     var body: some View {
         HStack(alignment: .center, spacing: 6) {
@@ -23,10 +24,7 @@ struct ToolbarRight: View {
             localMode
             history
             settings
-            
-            if footerNotifications.contains(.update) {
-                installUpdate
-            }
+            installUpdate
         }
         .padding(.trailing, 6)
         .foregroundStyle(.gray200)
@@ -42,7 +40,7 @@ struct ToolbarRight: View {
     func toggleMode() {
         let oldMode = mode
         
-        mode = mode == .local ? .remote : .local
+        Defaults[.mode] = oldMode == .local ? .remote : .local
         
         AnalyticsManager.Toolbar.llmModeToggled(oldValue: oldMode, newValue: mode)
     }
@@ -63,13 +61,16 @@ struct ToolbarRight: View {
         .disabled(!appState.canAccessRemoteModels)
     }
 
+    @ViewBuilder
     var discord: some View {
-        IconButton(
-            icon: .logoDiscord,
-            iconSize: 21,
-            tooltipPrompt: "Join Discord"
-        ) {
-            MenuJoinDiscord.openDiscord(appState)
+        if appState.isOnline {
+            IconButton(
+                icon: .logoDiscord,
+                iconSize: 21,
+                tooltipPrompt: "Join Discord"
+            ) {
+                MenuJoinDiscord.openDiscord(appState)
+            }
         }
     }
 
@@ -117,19 +118,22 @@ struct ToolbarRight: View {
         }
     }
     
+    @ViewBuilder
     var installUpdate: some View {
-        IconButton(
-            icon: .lightning,
-            iconSize: 21,
-            inactiveColor: .blue300,
-            hoverBackground: .blue300.opacity(0.2),
-            tooltipPrompt: "Install Update"
-        ) {
-            appState.checkForAvailableUpdateWithDownload()
+        if appState.isOnline && footerNotifications.contains(.update) {
+            IconButton(
+                icon: .lightning,
+                iconSize: 21,
+                inactiveColor: .blue300,
+                hoverBackground: .blue300.opacity(0.2),
+                tooltipPrompt: "Install Update"
+            ) {
+                appState.checkForAvailableUpdateWithDownload()
+            }
         }
     }
 }
 
 #Preview {
-    ToolbarRight()
+    ToolbarRight(mode: .remote)
 }

--- a/macos/Onit/UI/Prompt/MicrophoneButton.swift
+++ b/macos/Onit/UI/Prompt/MicrophoneButton.swift
@@ -9,6 +9,7 @@ import Defaults
 import SwiftUI
 
 struct MicrophoneButton: View {
+    @Environment(\.appState) var appState
     @Environment(\.windowState) private var windowState
     
     @Default(.openAIToken) var openAIToken
@@ -29,17 +30,22 @@ struct MicrophoneButton: View {
     
     private let recordingSpacesCount = 8
     
+    private var disabled: Bool {
+        !appState.isOnline || audioRecorder.isTranscribing
+    }
+    
     var body: some View {
         PromptCoreFooterButton(
             iconColor: audioRecorder.isRecording ? .red : .gray200,
             icon: .microphone,
             text: audioRecorder.isRecording ? "Stop" : "Voice",
+            disabled: disabled,
             action: { handleMicrophonePress() },
             background: audioRecorder.isRecording ? Color.red.opacity(0.15) : .clear,
             hoverBackground: audioRecorder.isRecording ? Color.red.opacity(0.3) : .gray600,
             fontColor: audioRecorder.isRecording ? .red : .gray200
         )
-        .disabled(audioRecorder.isTranscribing)
+        .disabled(disabled)
         .help(microphoneButtonHelpText)
         .onDisappear {
             if audioRecorder.isRecording { cancelRecording() }

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -192,10 +192,10 @@ extension PromptCore {
             lineWidth: 1.6,
             gradientBorder:
                 !isFocused ? unfocusedBorder :
-                isRemote ? remoteBorder :
+                mode == .remote ? remoteBorder :
                 localBorder
         )
-        .addAnimation(dependency: isRemote, duration: 0.3)
+        .addAnimation(dependency: mode, duration: 0.3)
         .addAnimation(dependency: isFocused, duration: 0.3)
         .padding(.top, 8)
         .padding(.horizontal, 12)
@@ -247,13 +247,6 @@ extension PromptCore {
     
     private var showingAlert: Bool {
         showTwoWeekProTrialEndedAlert || appState.showFreeLimitAlert || appState.showProLimitAlert
-    }
-    
-    private var isRemote: Bool {
-        switch mode {
-        case .remote: return true
-        default: return false
-        }
     }
     
     private var placeholderText: String {

--- a/macos/Onit/UI/Prompt/PromptCoreFooter.swift
+++ b/macos/Onit/UI/Prompt/PromptCoreFooter.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import Defaults
 
 struct PromptCoreFooter: View {
+    @Environment(\.appState) var appState
     @Environment(\.windowState) private var windowState
     @Default(.mode) private var mode
     @Default(.allowWebSearchInLocalMode) private var allowWebSearchInLocalMode
@@ -33,6 +34,9 @@ struct PromptCoreFooter: View {
                 ModelSelectionButton()
                 if mode != .local || allowWebSearchInLocalMode {
                     WebSearchButton()
+                        .disabled(!appState.isOnline)
+                        .allowsHitTesting(appState.isOnline)
+                        .opacity(appState.isOnline ? 1 : 0.3)
                 }
             }
             

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -119,10 +119,7 @@ struct ModelSelectionView: View {
                 .padding(.horizontal, 8)
                 .fixedSize(horizontal: false, vertical: true)
             
-            TextButton(
-                fillContainer: false,
-                background: .gray800
-            ) {
+            TextButton(fillContainer: false) {
                 HStack(alignment: .center, spacing: 10) {
                     Image(systemName: "cpu")
                     
@@ -131,7 +128,7 @@ struct ModelSelectionView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             } action: {
-                appState.openModelSettingsTab()
+                openModelSettings()
             }
         }
         .padding([.horizontal, .bottom], 8)
@@ -255,13 +252,8 @@ extension ModelSelectionView {
     }
     
     private func openModelSettings() {
-        NSApp.activate()
-        
-        if NSApp.isActive {
-            appState.setSettingsTab(tab: .models)
-            openSettings()
-            OverlayManager.shared.dismissOverlay()
-        }
+        appState.openModelSettingsTab(openSettings)
+        OverlayManager.shared.dismissOverlay()
     }
     
     private func isSelectedLocalModel(modelName: String) -> Bool {

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -92,15 +92,49 @@ struct ModelSelectionView: View {
         return MenuSection(
             title: "Remote",
             showTopBorder: true,
-            maxScrollHeight: setModelListHeight(
-                listCount: CGFloat(filteredRemoteModels.count)
-            ),
+            maxScrollHeight:
+                !appState.canAccessRemoteModels ? nil :
+                setModelListHeight(
+                    listCount: CGFloat(filteredRemoteModels.count)
+                ),
             contentRightPadding: 0,
             contentBottomPadding: 0,
             contentLeftPadding: 0
         ) {
-            remoteModelsView
+            if !appState.canAccessRemoteModels {
+                addApiKeyCTA
+            } else {
+                remoteModelsView
+            }
         }
+    }
+    
+    var addApiKeyCTA: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Sign up, log in, or add your own API key to access remote models.")
+                .styleText(
+                    weight: .regular,
+                    color: .gray200
+                )
+                .padding(.horizontal, 8)
+                .fixedSize(horizontal: false, vertical: true)
+            
+            TextButton(
+                fillContainer: false,
+                background: .gray800
+            ) {
+                HStack(alignment: .center, spacing: 10) {
+                    Image(systemName: "cpu")
+                    
+                    Text("Add Model API Key")
+                        .styleText()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } action: {
+                appState.openModelSettingsTab()
+            }
+        }
+        .padding([.horizontal, .bottom], 8)
     }
     
     var remoteModelsView: some View {
@@ -113,8 +147,7 @@ struct ModelSelectionView: View {
                 )
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.bottom, 8)
+        .padding([.horizontal, .bottom], 8)
     }
 
     var local: some View {

--- a/macos/Onit/UI/Prompt/Selection/RemoteModelButton.swift
+++ b/macos/Onit/UI/Prompt/Selection/RemoteModelButton.swift
@@ -95,9 +95,7 @@ extension RemoteModelButton {
     
     private func checkPlanLimitReached() async {
         do {
-            let userLoggedIn = appState.account != nil
-            
-            if userLoggedIn {
+            if appState.userLoggedIn {
                 let client = FetchingClient()
                 let chatUsageResponse = try await client.getChatUsage()
                 

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -31,26 +31,33 @@ struct GeneralTab: View {
     }
     
     var body: some View {
-        Form {
-            GeneralTabPlanAndBilling()
-            
-            GeneralTabAccount()
-            
-            launchOnStartupSection
-            
-            displayModeSection
-            
-            behaviorSection
-            
-            analyticsSection
-            
-            appearanceSection
-            
-            GeneralTabVoice()
-            
-            // experimentalSection
+        ScrollView {
+            VStack(alignment: .center, spacing: 0) {
+                OfflineText()
+                
+                Form {
+                    GeneralTabPlanAndBilling()
+                    
+                    GeneralTabAccount()
+                    
+                    launchOnStartupSection
+                    
+                    displayModeSection
+                    
+                    behaviorSection
+                    
+                    analyticsSection
+                    
+                    appearanceSection
+                    
+                    GeneralTabVoice()
+                    
+                    // experimentalSection
+                }
+                .formStyle(.grouped)
+            }
+            .padding()
         }
-        .formStyle(.grouped)
     }
     
     var launchOnStartupSection: some View {

--- a/macos/Onit/UI/Settings/GeneralTabAccount.swift
+++ b/macos/Onit/UI/Settings/GeneralTabAccount.swift
@@ -85,7 +85,7 @@ extension GeneralTabAccount {
             action: {
                 AnalyticsManager.AccountEvents.createAccountPressed()
                 authFlowStatus = .showSignUp
-                openPanel()
+                handlePanelOpen()
             },
             background: .blue
         )
@@ -97,7 +97,7 @@ extension GeneralTabAccount {
             action: {
                 AnalyticsManager.AccountEvents.signInPressed()
                 authFlowStatus = .showSignIn
-                openPanel()
+                handlePanelOpen()
             }
         )
     }
@@ -138,7 +138,6 @@ extension GeneralTabAccount {
     private func logout() {
         TokenManager.token = nil
         appState.account = nil
-        Defaults[.authFlowStatus] = .showSignIn
         GIDSignIn.sharedInstance.signOut()
         
         // Reset all chat state
@@ -147,7 +146,9 @@ extension GeneralTabAccount {
         }
     }
     
-    private func openPanel() {
-        PanelStateCoordinator.shared.launchPanel()
+    private func handlePanelOpen() {
+        if !PanelStateCoordinator.shared.state.panelOpened {
+            PanelStateCoordinator.shared.launchPanel()
+        }
     }
 }

--- a/macos/Onit/UI/Settings/GeneralTabPlanAndBilling.swift
+++ b/macos/Onit/UI/Settings/GeneralTabPlanAndBilling.swift
@@ -23,10 +23,6 @@ struct GeneralTabPlanAndBilling: View {
     @State private var fetchingSubscriptionData: Bool = false
     @State private var subscriptionDataErrorMessage: String = ""
     
-    private var userLoggedIn: Bool {
-        appState.account != nil
-    }
-    
     var body: some View {
         SettingsSection(
             iconText: "􀋃",
@@ -44,7 +40,7 @@ struct GeneralTabPlanAndBilling: View {
                 
                 if fetchingSubscriptionData {
                     shimmers
-                } else if userLoggedIn,
+                } else if appState.userLoggedIn,
                    let planType = planType,
                    let usage = chatGenerationsUsage,
                    let quota = chatGenerationsQuota,
@@ -58,7 +54,7 @@ struct GeneralTabPlanAndBilling: View {
                     )
                 }
                 
-                if !userLoggedIn {
+                if !appState.userLoggedIn {
                     upgradeToProButton
                 } else if appState.subscriptionStatus == SubscriptionStatus.free {
                     HStack(spacing: 11) {
@@ -86,7 +82,7 @@ struct GeneralTabPlanAndBilling: View {
                     }
                 }
                 
-                if !userLoggedIn ||
+                if !appState.userLoggedIn ||
                     appState.subscriptionCanceled ||
                     planType == SubscriptionStatus.free
                 {
@@ -97,8 +93,8 @@ struct GeneralTabPlanAndBilling: View {
         .task() {
             await fetchSubscriptionData()
         }
-        .onChange(of: userLoggedIn) {
-            if userLoggedIn {
+        .onChange(of: appState.userLoggedIn) { _, loggedIn in
+            if loggedIn {
                 Task {
                     await fetchSubscriptionData()
                 }
@@ -266,7 +262,7 @@ extension GeneralTabPlanAndBilling {
             subscriptionDataErrorMessage = ""
             fetchingSubscriptionData = true
             
-            if userLoggedIn {
+            if appState.userLoggedIn {
                 await refreshSubscriptionState()
                 
                 planType = appState.subscriptionStatus

--- a/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
+++ b/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
@@ -218,7 +218,7 @@ struct RemoteModelSection: View {
     @ViewBuilder
     var modelsView: some View {
         // If their logged in, we shoudl show these since they can always use them through the free plan.
-        if use && (appState.account != nil || validated) {
+        if use && (appState.userLoggedIn || validated) {
             GroupBox {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(models) { model in

--- a/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
+++ b/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
@@ -217,7 +217,7 @@ struct RemoteModelSection: View {
 
     @ViewBuilder
     var modelsView: some View {
-        // If their logged in, we shoudl show these since they can always use them through the free plan.
+        // If they're logged in, we should show these since they can always use them through the free plan.
         if use && (appState.userLoggedIn || validated) {
             GroupBox {
                 VStack(alignment: .leading, spacing: 0) {

--- a/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
+++ b/macos/Onit/UI/Settings/Models/RemoteModelSection.swift
@@ -124,6 +124,7 @@ struct RemoteModelSection: View {
                 .frame(height: 22)
                 .font(.system(size: 13, weight: .regular))
                 .foregroundColor(.primary)  // Ensure placeholder text is not dimmed
+                .disabled(!appState.isOnline)
 
             Button {
                 Task {

--- a/macos/Onit/UI/Settings/Models/RemoteModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/RemoteModelsSection.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct RemoteModelsSection: View {
+    @Environment(\.appState) var appState
 
     var body: some View {
         ScrollView {
@@ -20,6 +21,8 @@ struct RemoteModelsSection: View {
                 RemoteModelSection(provider: .perplexity)
                 CustomProvidersSection()
             }
+            .opacity(appState.isOnline ? 1 : 0.4)
+            .allowsHitTesting(appState.isOnline)
         }
     }
 }

--- a/macos/Onit/UI/Settings/ModelsTab.swift
+++ b/macos/Onit/UI/Settings/ModelsTab.swift
@@ -11,12 +11,16 @@ struct ModelsTab: View {
     
     var body: some View {
         ScrollView {
-            VStack(spacing: 25) {
-                RemoteModelsSection()
-                LocalModelsSection()
-                DefaultModelsSection()
+            VStack(spacing: 8) {
+                OfflineText()
+                
+                VStack(spacing: 25) {
+                    RemoteModelsSection()
+                    LocalModelsSection()
+                    DefaultModelsSection()
+                }
             }
-            .padding(.vertical, 20)
+            .padding()
             .padding(.horizontal, 86)
         }
     }

--- a/macos/Onit/UI/Settings/OfflineText.swift
+++ b/macos/Onit/UI/Settings/OfflineText.swift
@@ -1,0 +1,19 @@
+//
+//  OfflineText.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/10/25.
+//
+
+import SwiftUI
+
+struct OfflineText: View {
+    @Environment(\.appState) var appState
+    
+    var body: some View {
+        if !appState.isOnline {
+            Text("Offline")
+                .styleText(color: .limeGreen)
+        }
+    }
+}

--- a/macos/Onit/UI/Settings/WebSearchTab.swift
+++ b/macos/Onit/UI/Settings/WebSearchTab.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import Defaults
 
 struct WebSearchTab: View {
+    @Environment(\.appState) var appState
+    
     @Default(.tavilyAPIToken) var tavilyAPIToken
     @Default(.isTavilyAPITokenValidated) var isTavilyAPITokenValidated
     @Default(.tavilyCostSavingMode) var tavilyCostSavingMode
@@ -11,36 +13,42 @@ struct WebSearchTab: View {
     @State private var validationError: String? = nil
     
     var body: some View {
-        Form {
-            Section {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Configure web search providers to enhance your AI responses with real-time information from the internet.")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.gray200)
-                    
-                    Divider()
-                    
-                    tavilySection
+        VStack(alignment: .center, spacing: 8) {
+            OfflineText()
+            
+            Form {
+                Section {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Configure web search providers to enhance your AI responses with real-time information from the internet.")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.gray200)
+                        
+                        Divider()
+                        
+                        tavilySection
+                    }
+                } header: {
+                    HStack {
+                        Image(systemName: "magnifyingglass")
+                        Text("Web Search Providers")
+                    }
                 }
-            } header: {
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                    Text("Web Search Providers")
-                }
-            }
 
-            Section {
-                VStack(alignment: .leading, spacing: 16) {
-                    localModeSection
-                }
-            } header: {
-                HStack {
-                    Image(systemName: "lock.shield")
-                    Text("Local Mode")
+                Section {
+                    VStack(alignment: .leading, spacing: 16) {
+                        localModeSection
+                    }
+                } header: {
+                    HStack {
+                        Image(systemName: "lock.shield")
+                        Text("Local Mode")
+                    }
                 }
             }
+            .formStyle(.grouped)
+            .opacity(appState.isOnline ? 1 : 0.4)
+            .allowsHitTesting(appState.isOnline)
         }
-        .formStyle(.grouped)
         .padding()
     }
     


### PR DESCRIPTION
### Task

* This update addresses [recent user feedback](https://github.com/synth-inc/onit/issues/283), requesting there to be explicit local-first support.
* The implication behind local-first support is two-fold:
    1. User should not have to create an account to access the app if they have provided their own local model.
    2. User should not have to create an account to access the app if they have provided at least one provider API key.

### Notes

* Auth flow is now only fixed to the UI when the user is not logged in AND either hasn't provided their own local model or provider API key.
* After providing a local model or provider API key, the auth flow automatically disappears but is still accessible through the settings "General" tab.
* The auth flow has now been updated to show a CTA for when the user wants to provide their own models.  If they have provided their own local model or provider API key, this CTA disappears and a "close" button appears at the bottom of the auth flow to allow for continuous use of the app while logged out.
* If the user has provided a local model but NOT a provider API key, they will not have access to any remote models and will, instead, be shown a CTA in the model selection view to either log in or add their own provider API key to access remote models.
    * This means that, in this scenario, the model mode toggle shortcut is disabled, and local mode is strictly enforced.
* If the user is not logged in but but has added their own provider API keys, the local model restriction will be lifted, and they will only have access to remote models whose provider API keys were provided.