### PR TITLE
Add shortcut for adding current window to context

### DIFF
--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
@@ -17,6 +17,8 @@ extension KeyboardShortcuts.Name {
     static let newChat = Self("newChat", default: .init(.nine, modifiers: [.command]))
     static let toggleLocalMode = Self(
         "toggleLocalMode", default: .init(.seven, modifiers: [.shift, .command]))
+    static let addForegroundWindowToContext = Self(
+        "addForegroundWindowToContext", default: .init(.nine, modifiers: [.command]))
 }
 
 extension KeyboardShortcuts.Name: @retroactive CaseIterable {
@@ -25,6 +27,7 @@ extension KeyboardShortcuts.Name: @retroactive CaseIterable {
         .launchWithAutoContext,
         .escape,
         .newChat,
-        .toggleLocalMode
+        .toggleLocalMode,
+        .addForegroundWindowToContext
     ]
 }

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcuts+Name.swift
@@ -18,7 +18,7 @@ extension KeyboardShortcuts.Name {
     static let toggleLocalMode = Self(
         "toggleLocalMode", default: .init(.seven, modifiers: [.shift, .command]))
     static let addForegroundWindowToContext = Self(
-        "addForegroundWindowToContext", default: .init(.nine, modifiers: [.command]))
+        "addForegroundWindowToContext", default: .init(.w, modifiers: [.shift, .command]))
 }
 
 extension KeyboardShortcuts.Name: @retroactive CaseIterable {

--- a/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
+++ b/macos/Onit/KeyboardShortcuts/KeyboardShortcutsManager.swift
@@ -110,6 +110,10 @@ struct KeyboardShortcutsManager {
                     state.newChat()
                 case .toggleLocalMode:
                     Defaults[.mode] = Defaults[.mode] == .local ? .remote : .local
+                case .addForegroundWindowToContext:
+                    if let foregroundWindow = state.foregroundWindow {
+                        state.addWindowToContext(window: foregroundWindow.element)
+                    }
                 default:
                     print("KeyboardShortcut not handled: \(name)")
                 }

--- a/macos/Onit/UI/Settings/ShortcutsTab.swift
+++ b/macos/Onit/UI/Settings/ShortcutsTab.swift
@@ -37,6 +37,11 @@ struct ShortcutsTab: View {
                 )
                 .padding()
                 
+                KeyboardShortcuts.Recorder(
+                    "Add Current Window to Context", name: .addForegroundWindowToContext
+                )
+                .padding()
+                
                 Toggle("Disable 'ESC' shortcut", isOn: $escapeShortcutDisabled)
                 .padding()
             }

--- a/macos/Onit/UI/Settings/ShortcutsTab.swift
+++ b/macos/Onit/UI/Settings/ShortcutsTab.swift
@@ -37,10 +37,12 @@ struct ShortcutsTab: View {
                 )
                 .padding()
                 
-                KeyboardShortcuts.Recorder(
-                    "Add Current Window to Context", name: .addForegroundWindowToContext
-                )
-                .padding()
+                if accessibilityPermissionManager.accessibilityPermissionStatus == .authorized && autoContextFromCurrentWindow {
+                    KeyboardShortcuts.Recorder(
+                        "Add Current Window to Context", name: .addForegroundWindowToContext
+                    )
+                    .padding()
+                }
                 
                 Toggle("Disable 'ESC' shortcut", isOn: $escapeShortcutDisabled)
                 .padding()


### PR DESCRIPTION
Requested in #307 - this adds a shortcut that adds the current window to context. We'll need to consider how this integrates with @lk340's experimental new context behaviors, but I figured it'd be easy enough to get a PR up for this now. 