### PR TITLE
Fixed Window Resizing Bug in Pinned Mode

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -27,6 +27,7 @@ extension PanelStatePinnedManager {
         isPanelResized: Bool = false
     ) {
         if !windowFrameChanged, !isPanelResized { guard !targetInitialFrames.keys.contains(window) else { return } }
+        if !shouldResizeWindows { return }
         
         if let windowFrameConverted = window.getFrame(convertedToGlobalCoordinateSpace: true),
            let windowScreen = windowFrameConverted.findScreen(),

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -21,6 +21,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     // MARK: - Properties
     
     var isResizingWindows: Bool = false
+    var shouldResizeWindows : Bool = false
     var hintYRelativePosition: CGFloat?
     
     private var lastScreenFrame = CGRect.zero
@@ -135,6 +136,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     
     override func launchPanel(for state: OnitPanelState) {
         AnalyticsManager.Panel.opened(displayMode: "pinned")
+        shouldResizeWindows = true
         
         hideTetherWindow()
         resetFramesOnAppChange()
@@ -147,6 +149,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     
     override func closePanel(for state: OnitPanelState) {
         AnalyticsManager.Panel.closed(displayMode: "pinned")
+        shouldResizeWindows = false
         
         hidePanel(for: state)
         


### PR DESCRIPTION
This resolves a bug that occurs when the Onit panel is closing and causes windows to resize incorrectly.

The Problem: When users follow this sequence:

1. Click the tethered button to close Onit
2. Immediately click on another application while Onit is still closing

The system triggers resizeWindows whenever an application becomes active. So when you click the new application, it automatically resizes the window to make room for Onit—even though Onit is actually closing. This leaves you with a shrunken window and no Onit panel.

This happens frequently because users naturally click on other applications right after closing Onit.

The Solution: I added a shouldResizeWindows flag to the Pinned manager:
• Set to true when the panel opens
• Set to false when the panel closes

This prevents unnecessary window resizing when Onit is closing. Problem solved!