### PR TITLE
Google search support

### DIFF
--- a/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
@@ -162,7 +162,7 @@ struct ChatEndpointBuilder {
             userMessages: userMessages)
 
         return GoogleAIChatEndpoint(
-            messages: messages, model: model.id, token: apiToken, includeSearch: includeSearch)
+            messages: messages, model: model.id, queryToken: apiToken, includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
@@ -53,7 +53,8 @@ struct ChatEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .deepSeek:
             return ChatEndpointBuilder.deepSeek(
                 model: model,
@@ -150,7 +151,8 @@ struct ChatEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> GoogleAIChatEndpoint {
         let messages = ChatEndpointMessagesBuilder.googleAI(
             model: model,
@@ -160,7 +162,7 @@ struct ChatEndpointBuilder {
             userMessages: userMessages)
 
         return GoogleAIChatEndpoint(
-            messages: messages, model: model.id, token: apiToken)
+            messages: messages, model: model.id, token: apiToken, includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/ChatEndpointBuilder.swift
@@ -158,11 +158,14 @@ struct ChatEndpointBuilder {
             model: model,
             images: images,
             responses: responses,
-            systemMessage: systemMessage,
             userMessages: userMessages)
 
         return GoogleAIChatEndpoint(
-            messages: messages, model: model.id, queryToken: apiToken, includeSearch: includeSearch)
+            messages: messages,
+            system: model.supportsSystemPrompts ? systemMessage : nil,
+            model: model.id,
+            queryToken: apiToken,
+            includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -14,13 +14,14 @@ struct GoogleAIChatEndpoint: Endpoint {
 
     let messages: [GoogleAIChatMessage]
     let model: String
-    let token: String?
+    var token: String? { nil }
+    let queryToken: String?
     let includeSearch: Bool?
 
     var path: String { "/v1beta/models/\(model):generateContent" }
     var getParams: [String: String]? {
         [
-            "key": token ?? ""
+            "key": queryToken ?? ""
         ]
     }
 

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -14,6 +14,7 @@ struct GoogleAIChatEndpoint: Endpoint {
 
     let messages: [GoogleAIChatMessage]
     let model: String
+    // Doing this so the token doesn't get added as a header
     var token: String? { nil }
     let queryToken: String?
     let includeSearch: Bool?

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -15,13 +15,18 @@ struct GoogleAIChatEndpoint: Endpoint {
     let messages: [GoogleAIChatMessage]
     let model: String
     let token: String?
+    let includeSearch: Bool?
 
-    var path: String { "/v1beta:chatCompletions" }
+    var path: String { "/v1beta/models/\(model):generateContent" }
     var getParams: [String: String]? { nil }
 
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {
-        GoogleAIChatRequest(model:model, messages: messages, stream: false, n: 1)
+        var tools: [GoogleAIChatSearchTool] = []
+        if includeSearch == true {
+            tools.append(GoogleAIChatSearchTool())
+        }
+        return GoogleAIChatRequest(model: model, messages: messages, tools: tools, stream: false, n: 1)
     }
 
     var additionalHeaders: [String: String]? {
@@ -79,6 +84,7 @@ struct GoogleAIChatContentPart: Codable {
 struct GoogleAIChatRequest: Codable {
     let model: String
     let messages: [GoogleAIChatMessage]
+    let tools: [GoogleAIChatSearchTool]
     let stream: Bool
     let n : Int
 }
@@ -117,5 +123,15 @@ struct GoogleAIChatResponse: Codable {
             case promptTokens = "prompt_tokens"
             case totalTokens = "total_tokens"
         }
+    }
+}
+
+struct GoogleAIChatSearchTool: Codable {
+    let googleSearch = GoogleSearch()
+
+    struct GoogleSearch: Codable {}
+
+    enum CodingKeys: String, CodingKey {
+        case googleSearch = "google_search"
     }
 }

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -17,8 +17,12 @@ struct GoogleAIChatEndpoint: Endpoint {
     let token: String?
     let includeSearch: Bool?
 
-    var path: String { "/v1beta/models/\(model):generateContent?key=\(token ?? "")" }
-    var getParams: [String: String]? { nil }
+    var path: String { "/v1beta/models/\(model):generateContent" }
+    var getParams: [String: String]? {
+        [
+            "key": token ?? ""
+        ]
+    }
 
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -17,7 +17,7 @@ struct GoogleAIChatEndpoint: Endpoint {
     let token: String?
     let includeSearch: Bool?
 
-    var path: String { "/v1beta/models/\(model):generateContent" }
+    var path: String { "/v1beta/models/\(model):generateContent?key=\(token ?? "")" }
     var getParams: [String: String]? { nil }
 
     var method: HTTPMethod { .post }
@@ -29,9 +29,7 @@ struct GoogleAIChatEndpoint: Endpoint {
         return GoogleAIChatRequest(model: model, messages: messages, tools: tools, stream: false, n: 1)
     }
 
-    var additionalHeaders: [String: String]? {
-        ["Authorization": "Bearer \(token ?? "")"]
-    }
+    var additionalHeaders: [String: String]? { [:] }
     var timeout: TimeInterval? { nil }
     
     func getContent(response: Response) -> String? {

--- a/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/Chat/GoogleAIChatEndpoint.swift
@@ -13,6 +13,7 @@ struct GoogleAIChatEndpoint: Endpoint {
     typealias Response = GoogleAIChatResponse
 
     let messages: [GoogleAIChatMessage]
+    let system: String?
     let model: String
     // Doing this so the token doesn't get added as a header
     var token: String? { nil }
@@ -28,105 +29,56 @@ struct GoogleAIChatEndpoint: Endpoint {
 
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {
+        var systemInstruction: GoogleAIChatSystemInstruction?
+        if let system = system {
+            systemInstruction = GoogleAIChatSystemInstruction(parts: [GoogleAIChatPart(text: system, inlineData: nil)])
+        }
         var tools: [GoogleAIChatSearchTool] = []
         if includeSearch == true {
             tools.append(GoogleAIChatSearchTool())
         }
-        return GoogleAIChatRequest(model: model, messages: messages, tools: tools, stream: false, n: 1)
+        return GoogleAIChatRequest(systemInstruction: systemInstruction, contents: messages, tools: tools)
     }
 
     var additionalHeaders: [String: String]? { [:] }
     var timeout: TimeInterval? { nil }
     
     func getContent(response: Response) -> String? {
-        return response.choices.first?.message.content
+        let part = response.candidates.first?.content.parts.first { $0.text != nil }
+        return part?.text
     }
+}
+
+struct GoogleAIChatSystemInstruction: Codable {
+    let parts: [GoogleAIChatPart]
 }
 
 struct GoogleAIChatMessage: Codable {
     let role: String
-    let content: GoogleAIChatContent
+    let parts: [GoogleAIChatPart]
 }
 
-enum GoogleAIChatContent: Codable {
-    case text(String)
-    case multiContent([GoogleAIChatContentPart])
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch self {
-        case .text(let str):
-            try container.encode(str)
-        case .multiContent(let parts):
-            try container.encode(parts)
-        }
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if let str = try? container.decode(String.self) {
-            self = .text(str)
-        } else if let parts = try? container.decode([GoogleAIChatContentPart].self) {
-            self = .multiContent(parts)
-        } else {
-            throw DecodingError.dataCorruptedError(
-                in: container, debugDescription: "Invalid content format")
-        }
-    }
-}
-
-struct GoogleAIChatContentPart: Codable {
-    let type: String
+struct GoogleAIChatPart: Codable {
     let text: String?
-    let image_url: ImageURL?
+    let inlineData: InlineData?
 
-    struct ImageURL: Codable {
-        let url: String
+    struct InlineData: Codable {
+        let mimeType: String
+        let data: String
     }
 }
 
 struct GoogleAIChatRequest: Codable {
-    let model: String
-    let messages: [GoogleAIChatMessage]
-    let tools: [GoogleAIChatSearchTool]
-    let stream: Bool
-    let n : Int
+    let systemInstruction: GoogleAIChatSystemInstruction?
+    let contents: [GoogleAIChatMessage]
+    let tools: [GoogleAIChatSearchTool]?
 }
 
 struct GoogleAIChatResponse: Codable {
-    let choices: [Choice]
-    let created: Int
-    let model: String
-    let object: String
-    let usage: Usage
+    let candidates: [GoogleAIChatCandidate]
 
-    struct Choice: Codable {
-        let finishReason: String
-        let index: Int
-        let message: Message
-
-        enum CodingKeys: String, CodingKey {
-            case finishReason = "finish_reason"
-            case index
-            case message
-        }
-    }
-
-    struct Message: Codable {
-        let content: String
-        let role: String
-    }
-
-    struct Usage: Codable {
-        let completionTokens: Int
-        let promptTokens: Int
-        let totalTokens: Int
-
-        enum CodingKeys: String, CodingKey {
-            case completionTokens = "completion_tokens"
-            case promptTokens = "prompt_tokens"
-            case totalTokens = "total_tokens"
-        }
+    struct GoogleAIChatCandidate: Codable {
+        let content: GoogleAIChatMessage
     }
 }
 

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -17,8 +17,13 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     let token: String?
     let includeSearch: Bool?
     
-    var path: String { "/v1beta/models/\(model):generateContent?key=\(token ?? "")" }
-    var getParams: [String: String]? { nil }
+    var path: String { "/v1beta/models/\(model):streamGenerateContent" }
+    var getParams: [String: String]? {
+        [
+            "key": token ?? "",
+            "alt": "sse"
+        ]
+    }
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {
         var tools: [GoogleAIChatSearchTool] = []

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -14,6 +14,7 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     
     let messages: [GoogleAIChatMessage]
     let model: String
+    // Doing this so the token doesn't get added as a header
     var token: String? { nil }
     let queryToken: String?
     let includeSearch: Bool?

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -17,7 +17,7 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     let token: String?
     let includeSearch: Bool?
     
-    var path: String { "/v1beta/models/\(model):generateContent" }
+    var path: String { "/v1beta/models/\(model):generateContent?key=\(token ?? "")" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {
@@ -28,9 +28,7 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
         return GoogleAIChatRequest(model: model, messages: messages, tools: tools, stream: true, n: 1)
     }
     
-    var additionalHeaders: [String: String]? {
-        ["Authorization": "Bearer \(token ?? "")"]
-    }
+    var additionalHeaders: [String: String]? { [:] }
     
     var timeout: TimeInterval? { nil }
     
@@ -45,6 +43,7 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     }
     
     func getStreamingErrorMessage(data: Data) -> String? {
+        print(String(data: data, encoding: .utf8) ?? "")
         let response = try? JSONDecoder().decode(GoogleAIChatStreamingError.self, from: data)
         
         return response?.error.message

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -14,13 +14,14 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     
     let messages: [GoogleAIChatMessage]
     let model: String
-    let token: String?
+    var token: String? { nil }
+    let queryToken: String?
     let includeSearch: Bool?
     
     var path: String { "/v1beta/models/\(model):streamGenerateContent" }
     var getParams: [String: String]? {
         [
-            "key": token ?? "",
+            "key": queryToken ?? "",
             "alt": "sse"
         ]
     }

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -45,7 +45,6 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     }
     
     func getStreamingErrorMessage(data: Data) -> String? {
-        print(String(data: data, encoding: .utf8) ?? "")
         let response = try? JSONDecoder().decode(GoogleAIChatStreamingError.self, from: data)
         
         return response?.error.message

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -15,12 +15,17 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     let messages: [GoogleAIChatMessage]
     let model: String
     let token: String?
+    let includeSearch: Bool?
     
-    var path: String { "/v1beta:chatCompletions" } 
+    var path: String { "/v1beta/models/\(model):generateContent" }
     var getParams: [String: String]? { nil }
     var method: HTTPMethod { .post }
     var requestBody: GoogleAIChatRequest? {
-        GoogleAIChatRequest(model:model, messages: messages, stream: true, n: 1)
+        var tools: [GoogleAIChatSearchTool] = []
+        if includeSearch == true {
+            tools.append(GoogleAIChatSearchTool())
+        }
+        return GoogleAIChatRequest(model: model, messages: messages, tools: tools, stream: true, n: 1)
     }
     
     var additionalHeaders: [String: String]? {
@@ -40,6 +45,7 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     }
     
     func getStreamingErrorMessage(data: Data) -> String? {
+        print(String(data: data, encoding: .utf8) ?? "")
         let response = try? JSONDecoder().decode(GoogleAIChatStreamingError.self, from: data)
         
         return response?.error.message

--- a/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
+++ b/macos/Onit/Data/Fetching/Endpoints/ChatStreaming/GoogleAIChatStreamingEndpoint.swift
@@ -43,7 +43,6 @@ struct GoogleAIChatStreamingEndpoint: StreamingEndpoint {
     }
     
     func getStreamingErrorMessage(data: Data) -> String? {
-        print(String(data: data, encoding: .utf8) ?? "")
         let response = try? JSONDecoder().decode(GoogleAIChatStreamingError.self, from: data)
         
         return response?.error.message

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -188,11 +188,14 @@ struct ChatStreamingEndpointBuilder {
             model: model,
             images: images,
             responses: responses,
-            systemMessage: systemMessage,
             userMessages: userMessages)
 
         return GoogleAIChatStreamingEndpoint(
-            messages: messages, model: model.id, queryToken: apiToken, includeSearch: includeSearch)
+            messages: messages,
+            system: model.supportsSystemPrompts ? systemMessage : nil,
+            model: model.id,
+            queryToken: apiToken,
+            includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -64,7 +64,8 @@ struct ChatStreamingEndpointBuilder {
                 responses: responses,
                 apiToken: apiToken,
                 systemMessage: systemMessage,
-                userMessages: userMessages)
+                userMessages: userMessages,
+                includeSearch: includeSearch)
         case .deepSeek:
             return ChatStreamingEndpointBuilder.deepSeek(
                 model: model,
@@ -180,7 +181,8 @@ struct ChatStreamingEndpointBuilder {
         responses: [String],
         apiToken: String?,
         systemMessage: String,
-        userMessages: [String]
+        userMessages: [String],
+        includeSearch: Bool? = nil
     ) -> GoogleAIChatStreamingEndpoint {
         let messages = ChatEndpointMessagesBuilder.googleAI(
             model: model,
@@ -190,7 +192,7 @@ struct ChatStreamingEndpointBuilder {
             userMessages: userMessages)
 
         return GoogleAIChatStreamingEndpoint(
-            messages: messages, model: model.id, token: apiToken)
+            messages: messages, model: model.id, token: apiToken, includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
+++ b/macos/Onit/Data/Fetching/Streaming/ChatStreamingEndpointBuilder.swift
@@ -192,7 +192,7 @@ struct ChatStreamingEndpointBuilder {
             userMessages: userMessages)
 
         return GoogleAIChatStreamingEndpoint(
-            messages: messages, model: model.id, token: apiToken, includeSearch: includeSearch)
+            messages: messages, model: model.id, queryToken: apiToken, includeSearch: includeSearch)
     }
 
     private static func deepSeek(

--- a/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
+++ b/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
@@ -40,6 +40,10 @@ actor StreamingClient {
             includeSearch: includeSearch)
         var eventParser: EventParser?
         
+        if !useOnitServer && model.provider == .googleAI {
+            eventParser = PerplexityEventParser()
+        }
+
         if !useOnitServer && model.provider == .perplexity {
             eventParser = PerplexityEventParser()
         }

--- a/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
+++ b/macos/Onit/Data/Fetching/Streaming/StreamingClient.swift
@@ -41,6 +41,7 @@ actor StreamingClient {
         var eventParser: EventParser?
         
         if !useOnitServer && model.provider == .googleAI {
+            // Reusing this event parser because it also fix the same bug with GoogleAI
             eventParser = PerplexityEventParser()
         }
 

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Chat.swift
@@ -152,7 +152,7 @@ extension OnitPanelState {
                 if Defaults[.mode] == .remote, let model = Defaults[.remoteModel] {
                     let apiToken = TokenValidationManager.getTokenForModel(model)
                     let hasValidToken = apiToken?.isEmpty == false
-                    hasValidProviderSearchToken = hasValidToken && (model.provider == .openAI || model.provider == .anthropic)
+                    hasValidProviderSearchToken = hasValidToken && (model.provider == .openAI || model.provider == .anthropic || model.provider == .googleAI)
 
                     let providers = try? await FetchingClient().getChatSearchProviders()
 


### PR DESCRIPTION
- We're already supporting OpenAI and Anthropic native web search
- GoogleAI supports this, but requires us to use their native API format rather than OpenAI compatible Messages
- Migrated to the new format for both streaming and non-streaming endpoints
- Reused the `PerplexityEventParser` because it appeared to fix a similar bug with server event separators