### PR TITLE
Refresh button for remote models

### DIFF
--- a/macos/Onit/UI/Settings/Models/ModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/ModelsSection.swift
@@ -9,12 +9,34 @@ import SwiftUI
 
 struct ModelsSection<Content: View>: View {
     var title: String
+    @Environment(\.appState) var appState
+    @State private var fetching: Bool = false
+    
     @ViewBuilder var content: () -> Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text(title)
-                .font(.system(size: 14))
+            HStack {
+                Text(title)
+                    .font(.system(size: 14))
+                Spacer()
+                Button(action: {
+                    fetching = true
+                    Task {
+                        await appState.fetchRemoteModels()
+                        fetching = false
+                    }
+                }) {
+                    if fetching {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Refresh")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(fetching)
+            }
             content()
         }
         .fontWeight(.medium)


### PR DESCRIPTION
As part of the v2.8 release, I've added Grok 4 model. I was creating a demo video for the release notes and realized that there is no way to refresh the models list without restarting the app. I don't want to tell people to quit the app, so I added this simple refresh button, and was able to make a demo video using it: 

![grok-4](https://github.com/user-attachments/assets/2b8a11ab-006d-4c15-8b8a-e51d1fddae95)
