### PR TITLE
Fix/add border on tether button

### DIFF
--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -13,6 +13,8 @@ struct TetheredButton: View {
     @Environment(\.openSettings) var openSettings
     @Environment(\.windowState) private var state
     
+    @State private var isHovering: Bool = false
+    
     static let width: CGFloat = 19
     static let height: CGFloat = 53
     
@@ -67,10 +69,23 @@ struct TetheredButton: View {
                     .rotationEffect(arrowRotation)
                     .frame(width: Self.width, height: Self.height, alignment: .center)
             }
+            .buttonStyle(.plain)
             .background {
                 RoundedRectangle(cornerRadius: Self.width / 2)
-                    .fill(.black)
+                    .fill(isHovering ? .gray800 : .black)
+                    .animation(.easeInOut(duration: 0.15), value: isHovering)
             }
+             .onHover { hovering in
+                 isHovering = hovering
+                
+                 if hovering {
+                     TooltipManager.shared.setTooltip(
+                         Tooltip(prompt: fitActiveWindowPrompt)
+                     )
+                 } else {
+                     TooltipManager.shared.setTooltip(nil)
+                 }
+             }
             .overlay {
                 TetheredButtonBorder(cornerRadius: Self.width / 2)
                     .stroke(
@@ -78,7 +93,6 @@ struct TetheredButton: View {
                         lineWidth: 1.5
                     )
             }
-            .tooltip(prompt: fitActiveWindowPrompt)
             Spacer()
         }
         .edgesIgnoringSafeArea(.top)

--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -71,12 +71,60 @@ struct TetheredButton: View {
                 RoundedRectangle(cornerRadius: Self.width / 2)
                     .fill(.black)
             }
+            .overlay {
+                TetheredButtonBorder(cornerRadius: Self.width / 2)
+                    .stroke(
+                        .gray500,
+                        lineWidth: 1.5
+                    )
+            }
             .tooltip(prompt: fitActiveWindowPrompt)
             Spacer()
         }
         .edgesIgnoringSafeArea(.top)
         .frame(maxHeight: .infinity, alignment: .top)
         .zIndex(1)
+    }
+}
+
+struct TetheredButtonBorder: Shape {
+    let cornerRadius: CGFloat
+    
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        
+        let inset: CGFloat = 0.75 // Half the line width to draw inside
+        let midX = rect.midX
+        let adjustedCornerRadius = cornerRadius - inset
+        let extensionPastHalf: CGFloat = 1.5 // Extra pixels past center for clean connection
+        
+        // Start from middle of top edge + extension (inset)
+        path.move(to: CGPoint(x: midX + extensionPastHalf, y: rect.minY + inset))
+        
+        // Draw left half of top edge to start of curve
+        path.addLine(to: CGPoint(x: rect.minX + cornerRadius, y: rect.minY + inset))
+        
+        // Draw top-left curve
+        path.addArc(center: CGPoint(x: rect.minX + cornerRadius, y: rect.minY + cornerRadius),
+                   radius: adjustedCornerRadius,
+                   startAngle: .degrees(270),
+                   endAngle: .degrees(180),
+                   clockwise: true)
+        
+        // Draw full left edge
+        path.addLine(to: CGPoint(x: rect.minX + inset, y: rect.maxY - cornerRadius))
+        
+        // Draw bottom-left curve
+        path.addArc(center: CGPoint(x: rect.minX + cornerRadius, y: rect.maxY - cornerRadius),
+                   radius: adjustedCornerRadius,
+                   startAngle: .degrees(180),
+                   endAngle: .degrees(90),
+                   clockwise: true)
+        
+        // Draw left half of bottom edge to middle + extension
+        path.addLine(to: CGPoint(x: midX + extensionPastHalf, y: rect.maxY - inset))
+        
+        return path
     }
 }
 


### PR DESCRIPTION
This is a small one: with the updated Hint design, it was driving me nuts that the close button didn't have a matching border. So, I added it here. 

To achieve this, I created a custom shape for the border. Since I don’t expect it to be reused, I named it specifically for the TetheredButton and kept it in the TetheredButton file. If we decide to use it elsewhere in the future, we can refactor it then, but I doubt that will be necessary!

Before: 
<img width="144" height="180" alt="Screenshot 2025-07-10 at 7 52 03 PM" src="https://github.com/user-attachments/assets/1a18023a-2a7f-4398-ad83-492336a29001" />

After
<img width="123" height="131" alt="Screenshot 2025-07-10 at 7 49 08 PM" src="https://github.com/user-attachments/assets/ddb1ba4e-ed80-42a1-a088-709830d5ae65" />
