### PR TITLE
Fix/limit debug manager init

### DIFF
--- a/macos/Onit/Accessibility/AppCoordinator.swift
+++ b/macos/Onit/Accessibility/AppCoordinator.swift
@@ -21,8 +21,11 @@ class AppCoordinator {
     private let notificationsManager: AccessibilityNotificationsManager
     private let panelStateCoordinator: PanelStateCoordinator
     private let featureFlagManager: FeatureFlagManager
+
+    #if DEBUG || BETA
     private let debugManager : DebugManager
-    
+    #endif
+
     private var stateChangesCancellable: AnyCancellable?
     
     // MARK: - Initializer

--- a/macos/Onit/UI/Debug/DebugManager.swift
+++ b/macos/Onit/UI/Debug/DebugManager.swift
@@ -39,6 +39,7 @@ class DebugManager: ObservableObject {
     // MARK: - Initialization
     
     private init() {
+        #if DEBUG || BETA
         // Load persisted OCR comparison results
         loadOCRComparisonResults()
         
@@ -48,6 +49,7 @@ class DebugManager: ObservableObject {
         if enableAutoOCRComparison {
             startAutoOCRComparison()
         }
+        #endif
     }
     
     // MARK: - Functions


### PR DESCRIPTION
Before releasing a production build that includes the debug OCR code, I wanted to make sure we weren't accidentally running any of it in production. 

While reviewing, I discovered that DebugManager is initialized by a number of views. The init() function calls some clean-up code related to the debug screenshots, which all happens on the main thread. I wanted to make sure this doesn't happen on release builds, so I wrapped the code in a debug/beta if. 