### PR TITLE
Only init timers when needed

### DIFF
--- a/macos/Onit/Menu Bar/Content Rows/MenuHideTimerStatus.swift
+++ b/macos/Onit/Menu Bar/Content Rows/MenuHideTimerStatus.swift
@@ -74,10 +74,17 @@ struct MenuHideTimerStatus: View {
                 .padding(.trailing, 10)
         }
         .onAppear {
-            startTimerUpdateTask()
+            startTimerUpdateTaskIfNeeded()
         }
         .onDisappear {
             stopTimerUpdateTask()
+        }
+        .onChange(of: tetheredButtonHideAllAppsTimerDate) { _, newValue in
+            if newValue != nil {
+                startTimerUpdateTaskIfNeeded()
+            } else {
+                stopTimerUpdateTask()
+            }
         }
     }
     
@@ -86,7 +93,10 @@ struct MenuHideTimerStatus: View {
         tetheredButtonHideAllApps = false
     }
     
-    private func startTimerUpdateTask() {
+    private func startTimerUpdateTaskIfNeeded() {
+        // Only start timer if there's a timer date set and no task is already running
+        guard tetheredButtonHideAllAppsTimerDate != nil, timerUpdateTask == nil else { return }
+        
         timerUpdateTask = Task {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))

--- a/macos/Onit/Menu Bar/MenuIcon.swift
+++ b/macos/Onit/Menu Bar/MenuIcon.swift
@@ -54,14 +54,24 @@ struct MenuIcon: View {
             .renderingMode(.original)
 //            .animation(.default, value: isOnitDisabled)
             .onAppear {
-                startTimerUpdateTask()
+                startTimerUpdateTaskIfNeeded()
             }
             .onDisappear {
                 stopTimerUpdateTask()
             }
+            .onChange(of: tetheredButtonHideAllAppsTimerDate) { _, newValue in
+                if newValue != nil {
+                    startTimerUpdateTaskIfNeeded()
+                } else {
+                    stopTimerUpdateTask()
+                }
+            }
     }
     
-    private func startTimerUpdateTask() {
+    private func startTimerUpdateTaskIfNeeded() {
+        // Only start timer if there's a timer date set and no task is already running
+        guard tetheredButtonHideAllAppsTimerDate != nil, timerUpdateTask == nil else { return }
+        
         timerUpdateTask = Task {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -80,10 +80,17 @@ struct GeneralTab: View {
         }
         .formStyle(.grouped)
         .onAppear {
-            startTimerUpdateTask()
+            startTimerUpdateTaskIfNeeded()
         }
         .onDisappear {
             stopTimerUpdateTask()
+        }
+        .onChange(of: tetheredButtonHideAllAppsTimerDate) { _, newValue in
+            if newValue != nil {
+                startTimerUpdateTaskIfNeeded()
+            } else {
+                stopTimerUpdateTask()
+            }
         }
     }
     
@@ -596,7 +603,10 @@ struct GeneralTab: View {
         tetheredButtonHideAllApps = false
     }
     
-    private func startTimerUpdateTask() {
+    private func startTimerUpdateTaskIfNeeded() {
+        // Only start timer if there's a timer date set and no task is already running
+        guard tetheredButtonHideAllAppsTimerDate != nil, timerUpdateTask == nil else { return }
+        
         timerUpdateTask = Task {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))


### PR DESCRIPTION
On our release candidate (the Beta build sent to Elise on Tuesday and running on Main locally), we’ve been experiencing freezing and stuttering issues. To isolate the problem, this morning I opened v2.7 (our latest stable release) and used it for about one hour without encountering any freezes. This leads me to believe the issue stems from changes introduced between v2.7 and the current build. 

**Initial Hypothesis: DebugManager/OCR Code**
My first suspected culprit was the DebugManager/OCR implementation. I created PR #320 to ensure OCR-related tasks aren’t inadvertently running in release builds. However, after testing this fix, the application continued to freeze.

Given the limited number of PRs between v2.7 and v2.8, I focused on the only other substantial change: the Revamped Hint PR.

In the revamped hint PR, I had written timer code that is supposed to update various UI elements when the user has chosen to "disable Onit for 1hr". The timers are initialized in each view's 'onAppear' method, resulting in three separate 1-second timers running continuously on the main thread—even when completely unnecessary. This seems like something that could cause freezing. 

This PR changes the code so that timers only run when necessary. Since making the change, I haven't seen the app freeze. I'm not 100% sure we've solved the issue, since I've only used the app for a few hours since the update. But, there's a good chance it's related, so I'm optimistic. Either way, we should make this change: my original code was sloppy and warrants cleanup.  