### PR TITLE
Make the whole TetheredButton tappable

### DIFF
--- a/macos/Onit/UI/Content/TetheredButton.swift
+++ b/macos/Onit/UI/Content/TetheredButton.swift
@@ -63,11 +63,17 @@ struct TetheredButton: View {
             Button(action: {
                 PanelStateCoordinator.shared.closePanel(for: state)
             }) {
-                Image(.smallChevRight)
-                    .renderingMode(.template)
-                    .foregroundColor(.white)
-                    .rotationEffect(arrowRotation)
-                    .frame(width: Self.width, height: Self.height, alignment: .center)
+                // Transparent rectangle that fills the entire button area
+                RoundedRectangle(cornerRadius: Self.width / 2)
+                    .fill(isHovering ? .gray800 : .black)
+                    .frame(width: Self.width, height: Self.height)
+                    .animation(.easeInOut(duration: 0.15), value: isHovering)
+                    .overlay {
+                        Image(.smallChevRight)
+                            .renderingMode(.template)
+                            .foregroundColor(.white)
+                            .rotationEffect(arrowRotation)
+                    }
             }
             .buttonStyle(.plain)
             .background {


### PR DESCRIPTION
There had been some user reports about the close button not being clickable, and I think this is why!

Currently, it only works if you click directly on the chevron icon:

https://github.com/user-attachments/assets/b52871bc-2e99-44d0-a18f-7ca9b7a389ad

With this change, it works if you click anywhere on it: 

https://github.com/user-attachments/assets/4b906213-e063-46a6-a849-c1e45c038f33

Greptile is going to complain about two rectangles (there's one for the main object, and another in the background modifier). I've noticed this issue, but when I remove the .background, the icon becomes mysteriously transparent when clicked. So, rather than debug whatever SwiftUI magic is happening, I left the background in. The code is a little more verbose, but it saved me potentially hours of SwiftUI debugging hell, so that's where we landed 🤷‍♂️

