### PR TITLE
Dont ignore xcode!

### DIFF
--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
@@ -21,7 +21,7 @@ class AccessibilityObserversManager {
     weak var delegate: AccessibilityObserversDelegate?
     
 #if DEBUG
-    private let ignoredAppNames : [String] = ["Xcode"]
+    private let ignoredAppNames : [String] = [] // "Xcode"]
 #else
     private let ignoredAppNames : [String] = []
 #endif


### PR DESCRIPTION
So we used to have a loop that occurred while handling Accessibility events in Xcode, specifically in the console. 

1. AXEvents would fire, triggering console logs. 
2. New console logs would create more AXEvents, which would create more console logs. 
3. This created an infinite loop of unhandleable AXEvents and console logs -> each begets more of the other. 

To solve this (and a few other issues), we made our app ignore Xcode in Debug builds. But that loop has been solved since I introduced a new Xcode debugger that ignores the console AXElements in #293. So, I've been enjoying having Onit enabled for Xcode. Since we're all mostly developing in Xcode all day, it's important it's enabled so we can dogfood our product. 

I left the commented-out string in because we'll still need to ignore it anytime we're using breakpoints. Having commented out "Xcode" is a bit sloppy, but it makes it easier to find in a pinch. 