### PR TITLE
Reset foregroundWindow frames first

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
@@ -71,11 +71,19 @@ extension PanelStatePinnedManager {
         state.animateChatView = true
         state.showChatView = false
         
+        // Enable layer backing for smoother animation
+        panel.contentView?.wantsLayer = true
+        panel.contentView?.layer?.shouldRasterize = true
+        panel.contentView?.layer?.rasterizationScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        
         NSAnimationContext.runAnimationGroup { context in
             context.duration = animationDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().setFrame(toPanel, display: false)
         } completionHandler: {
+            // Disable rasterization after animation
+            panel.contentView?.layer?.shouldRasterize = false
+
             state.animateChatView = true
             state.showChatView = true
             panel.isAnimating = false
@@ -100,6 +108,11 @@ extension PanelStatePinnedManager {
         state.animateChatView = true
         state.showChatView = false
         
+        // Enable layer backing for smoother animation
+        panel.contentView?.wantsLayer = true
+        panel.contentView?.layer?.shouldRasterize = true
+        panel.contentView?.layer?.rasterizationScale = NSScreen.main?.backingScaleFactor ?? 2.0
+
         resetFramesOnAppChange()
         
         NSAnimationContext.runAnimationGroup { context in
@@ -107,11 +120,14 @@ extension PanelStatePinnedManager {
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().setFrame(toPanel, display: false)
         } completionHandler: {
+            // Disable rasterization after animation
+            panel.contentView?.layer?.shouldRasterize = false
+
             panel.hide()
             panel.isAnimating = false
             panel.alphaValue = 0
             state.panel = nil
-            
+
             // Once the panel is hidden, we should show the hint
             if let screen = self.attachedScreen {
                 self.attachedScreen = nil


### PR DESCRIPTION
This PR addresses a number of issues that were making our app open and close animation feel sluggish. 

First, I rasterize the contentViewLayer to make the animation cleaner.. This has a small effect, but something still seemed off. 

The issue was this: in Pinned mode, we resize _every_ other non-Onit application window simultaneously. All of this in a synchronous function on the main thread that competes with our animation. It's noticeably bad when closing the panel, because we were waiting for all the other windows to resize before starting our animation. I timed it at around 500-600ms to resize every other window, before starting our animation.

We only really need to resize the **foreground** window synchronously. This is the only one that users will see. Every other window is in the background. They can get dispatched and handled later: they shouldn't block our main animation. This PR does just that. For both the opening and closing, we handle the foreground window first. Then, we dispatch the other windows so that they are handled afterwards. 

Here's what it looked like before: 

https://github.com/user-attachments/assets/adad3033-883c-4db3-a04e-81f94c8dd1a8

And here's how it looks now: 

https://github.com/user-attachments/assets/513d39ac-b59b-49a7-82ab-61beff3626da

**Note** there is one edge case, when we call resetFramesOnAppChange in "applicationWillTerminate". In this case, we don't need to wait for the animation because there is no animation: the app is shutting down. However, it doesn't really hurt. I couldn't find an easy way to solve it without adding a parameter to the resetFramesOnAppChange, which is inherited from the base manager. I decided to ignore this issue and leave it as is. 

Finally, I took the opportunity to clean up a bunch of code in PinnedManager, regarding the 'targetInitialFrames'. This was an old concept that we used back when we were trying to restore frames to their exact initial locations when the panel closed. We don't do this anymore, so we can remove the code. It makes everything much cleaner. 



