### PR TITLE
Fix infinite loop on adding context

### DIFF
--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -40,9 +40,6 @@ struct FileRow: View {
             for contextItem in contextList {
                 if case .auto(let autoContext) = contextItem {
                     if windowName == autoContext.appTitle {
-                        windowState?.cleanupWindowContextTask(
-                            uniqueWindowIdentifier: foregroundWindow.hash
-                        )
                         return true
                     }
                 }


### PR DESCRIPTION
In FileRow, an infinite loop was occurring in the following loop: 

1. The main **FileView** is drawn, which creates the **addForegroundWindowToContextButton** subview. 
2. **addForegroundWindowToContextButton** calls **windowAlreadyInContext** while being drawn. 
3. **windowAlreadyInContext** calls **cleanupWindowContextTask**
4. **cleanupWindowContextTask** modifies the **windowContextTasks** array
5. Changing **windowContextTasks** causes **FileView** to be re-drawn, restarting process. 

I don't really understand why this caused a loop. I would think that in removing the task the first time that 'cleanupWindowContextTask' is called, it would prevent more iterations. But it appears not. Calling "windowContextTasks.removeValue", even if it's a no-op, triggers a view refresh. 

Note, there's an alternative solution, which is simply checking to see if the windowContextTask exists before removing it: 

```
func cleanupWindowContextTask(uniqueWindowIdentifier: UInt) {
   if let task = windowContextTasks[uniqueWindowIdentifier] {
      task.cancel()
      windowContextTasks.removeValue(forKey: uniqueWindowIdentifier)
    }
 }
```

From testing, this works as well. 
However, I prefer the solution in this PR: I don't really think we should be triggering the task cleanup, optionally, based on the appearance of a view particularly when the task cleanup influences the rendering of that view. 

Looking through "addAutoContext", which is the root function that triggers all of this, I see that we're already calling "cleanupWindowContextTask" in every possible return state, so I think we can skip doing it here. 