### PR TITLE
Don't set selectedText from Accessibility scrape

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -525,8 +525,6 @@ class AccessibilityNotificationsManager: ObservableObject {
         results?.removeValue(forKey: AccessibilityParsedElements.applicationTitle)
         results?.removeValue(forKey: AccessibilityParsedElements.highlightedText)
         
-        self.processSelectedText(highlightedText, elementFrame: nil)
-        
         self.screenResult.elapsedTime = elapsedTime
         self.screenResult.applicationName = appName
         self.screenResult.applicationTitle = appTitle


### PR DESCRIPTION
This solves a small bug that was bothering me. Currently, if you add a window to context, it will remove any selected text that you have highlighted: 

https://github.com/user-attachments/assets/e4054625-c85d-4cd2-a6e4-5cbcf7f09fc9

This was a bad user experience. Often, I want to ask a question about a specific block of code (highlighted), while also providing the whole file as context. 

After investigating, I found that this is caused by a line of code that @Niduank introduced in[ here](https://github.com/synth-inc/onit/commit/57ee8d91f76381a2d4e2d46996175b5f98e9d3fc). We are calling 'processSelectedText' every time a new window is scraped. We are passing in any highlighted text that comes from the AXScrape, which seems always to be nil now. 

This doesn't make sense anymore, now that we can add windows from apps that aren't foregrounded. Also, if we aren't using it, we can get rid of the logic in the accessibility parsers that looks for highlighted text. 

@Niduank, what do you think? Is this okay with you? 

Here's the experience after removing this line. Much better!

https://github.com/user-attachments/assets/75fddd53-1a74-45ef-9b44-a051b1479cf1
