### PR TITLE
Resize all windows underneath panel

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -240,15 +240,15 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     override func resetFramesOnAppChange() {
         let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
         let screenFrame = self.attachedScreen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
-        let panelMaxX = screenFrame.maxX - panelWidth
+        let panelMinX = screenFrame.maxX - panelWidth
         let capturedForegroundWindow = state.foregroundWindow
         
         // Handle foreground window first.
         // This is the only one users can see, so we can handle it synchronously. This creates the desired visual experience.
         if let foregroundWindow = capturedForegroundWindow,
            let currentFrame = foregroundWindow.element.getFrame() {
-            let isNearPanel = abs((panelMaxX) - currentFrame.maxX) <= 2
-            if isNearPanel {
+            let isNearOrUnderPanel = currentFrame.maxX > (panelMinX - 2) && currentFrame.maxX <= screenFrame.maxX
+            if isNearOrUnderPanel {
                 let newWidth = currentFrame.width + panelWidth
                 let newFrame = NSRect(origin: currentFrame.origin,
                                       size: NSSize(width: newWidth, height: currentFrame.height))
@@ -265,8 +265,8 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
                 // Skip the foreground element, since we've already done it.
                 if let foregroundWindow = capturedForegroundWindow, window != foregroundWindow.element {
                     if let currentFrame = window.getFrame() {
-                        let isNearPanel = abs(panelMaxX - currentFrame.maxX) <= 2
-                        if isNearPanel {
+                        let isNearOrUnderPanel = currentFrame.maxX > (panelMinX - 2) && currentFrame.maxX <= screenFrame.maxX
+                        if isNearOrUnderPanel {
                             let newWidth = currentFrame.width + panelWidth
                             let newFrame = NSRect(origin: currentFrame.origin,
                                                   size: NSSize(width: newWidth, height: currentFrame.height))


### PR DESCRIPTION
This fixes yet another edge case with resizing other windows in Pinned mode. There’s an edge case for narrow windows. Many applications enforce a minimum width for their windows. So when a window is already narrow to begin with, Onit may try to resize the window more than it can be resized. In this case, the edge of the window ends up **under** the Onit panel.

Our logic for resizing windows on panel close looks for windows that are bordering the Onit Panel. In the case above, the window will not share a border with the Onit Panel, even though it should be resized.

An easy repro is to snap a window to the right half of your screen on a laptop. Then open and close Onit and you’ll see the issue:

https://github.com/user-attachments/assets/768a9497-2baa-4923-8c39-2c352102f7ab

This PR changes it to look for any windows that have a right edge anywhere under the Onit panel. All of those get resized, solving this edge case.

https://github.com/user-attachments/assets/aeb9a975-d780-4239-a5f3-3163332fdbff


