### PR TITLE
Make input text copyable

### DIFF
--- a/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Onit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "13347d05bd34bc586e04f84a3e17cef4c2d0a14d592d46776334e85bca8c96f9",
+  "originHash" : "cfdf414613a08165a3414dddf1c77d8e4f8353dc29e19e3704fcca9c0fd059d5",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -55,6 +55,7 @@ struct InputBody: View {
             .foregroundColor(.FG)
             .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
             .padding(10)
             .background {
                 geometryReader

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -26,6 +26,9 @@ struct InputButtons: View {
                 .buttonStyle(DarkerButtonStyle())
             }
 
+            CopyButton(text: input.selectedText)
+                .frame(width: 20, height: 20)
+
             Button {
                 inputExpanded.toggle()
             } label: {

--- a/macos/Onit/UI/Prompt/Input/InputTitle.swift
+++ b/macos/Onit/UI/Prompt/Input/InputTitle.swift
@@ -24,6 +24,7 @@ struct InputTitle: View {
         HStack(spacing: 8) {
             Text(inputString)
                 .appFont(.medium13)
+                .textSelection(.enabled)
             Spacer()
             InputButtons(inputExpanded: $inputExpanded, input: input)
         }


### PR DESCRIPTION
This is a small change that was occasionally annoying: the text in the "Input" field (for highlighted text) was not previously copyable. Sometimes, you want to copy the input from a prior prompt and put it back into a new prompt. Very simple fix, which sets the text fields to allow selection. Now it works!

<img width="536" height="285" alt="Screenshot 2025-07-13 at 3 43 21 PM" src="https://github.com/user-attachments/assets/d82832ca-fd1e-48fa-a6fe-c7cb390fae6c" />
