### PR TITLE
Only resize windows that overlap with the panel

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -37,7 +37,7 @@ extension PanelStatePinnedManager {
         windowFrameChanged: Bool = false,
         isPanelResized: Bool = false
     ) {
-        if !windowFrameChanged, !isPanelResized { guard !targetInitialFrames.keys.contains(window) else { return } }
+        // We pass when the panel is in the process of closing.
         if !shouldResizeWindows { return }
         
         if let windowFrameConverted = window.getFrame(convertedToGlobalCoordinateSpace: true),
@@ -47,10 +47,15 @@ extension PanelStatePinnedManager {
             
             let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
             let screenFrame = screen.visibleFrame
+            let availableSpace = screenFrame.maxX - windowFrame.maxX
             
-            let newWidth = (screenFrame.maxX - windowFrame.origin.x) - panelWidth
-            let newFrame = CGRect(x: windowFrame.origin.x, y:windowFrame.origin.y, width: newWidth, height: windowFrame.height)
-            _ = window.setFrame(newFrame)
+            // Only resize when the window occupies the same space as the panel. 
+            if availableSpace < panelWidth {
+                let overlapAmount = panelWidth - availableSpace
+                let newWidth = windowFrame.width - overlapAmount
+                let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                _ = window.setFrame(newFrame)
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes a regression I introduced in #324 . In an attempt to clean up some old, dead code, I significantly reduced the logic in the Pinned Manager's implementation of resizeWindows. With my new code, every other window gets resized, regardless of whether it touches Onit. It can be a annoying effect, particularly if you're using a screen manager like Rectangles or Spectacle: 

https://github.com/user-attachments/assets/7c487c60-1428-4158-8a64-ac1eb8750b57

The fix is to re-introduce our 'availableSpace' calculation and then check for it before resizing. We should only resize windows that occupy the same space as the Onit panel. If they're elsewhere on the screen, leave them alone!

https://github.com/user-attachments/assets/3baa5ca3-5d9d-4d39-9ff2-e8641f94da2e


