### PR TITLE
Resize bordering windows synchronously

### DIFF
--- a/macos/Onit/Accessibility/AXUIElement+Accessors.swift
+++ b/macos/Onit/Accessibility/AXUIElement+Accessors.swift
@@ -334,6 +334,29 @@ extension AXUIElement {
         
         return domain
     }
+
+    /// Returns the accessibility element at the given screen point.
+    func accessibilityHitTest(_ point: CGPoint) -> AXUIElement? {
+        var element: AXUIElement?
+        let result = AXUIElementCopyElementAtPosition(self, Float(point.x), Float(point.y), &element)
+        return result == .success ? element : nil
+    }
+
+    func findContainingTargetWindow() -> AXUIElement? {
+        var currentElement = self
+        if self.isTargetWindow() {
+            return self
+        }
+        
+        while let parent = currentElement.parent() {
+            if parent.isTargetWindow() {
+                return parent
+            }
+            currentElement = parent
+        }
+
+        return nil
+    }
 }
 
 //

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -37,7 +37,7 @@ extension PanelStatePinnedManager {
         windowFrameChanged: Bool = false,
         isPanelResized: Bool = false
     ) {
-        if !windowFrameChanged, !isPanelResized { guard !targetInitialFrames.keys.contains(window) else { return } }
+        // We pass when the panel is in the process of closing.
         if !shouldResizeWindows { return }
         
         if let windowFrameConverted = window.getFrame(convertedToGlobalCoordinateSpace: true),
@@ -47,10 +47,15 @@ extension PanelStatePinnedManager {
             
             let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
             let screenFrame = screen.visibleFrame
+            let availableSpace = screenFrame.maxX - windowFrame.maxX
             
-            let newWidth = (screenFrame.maxX - windowFrame.origin.x) - panelWidth
-            let newFrame = CGRect(x: windowFrame.origin.x, y:windowFrame.origin.y, width: newWidth, height: windowFrame.height)
-            _ = window.setFrame(newFrame)
+            // Only resize when the window occupies the same space as the panel. 
+            if availableSpace < panelWidth {
+                let overlapAmount = panelWidth - availableSpace
+                let newWidth = windowFrame.width - overlapAmount
+                let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
+                _ = window.setFrame(newFrame)
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes another edge-case that I introduced in #324. 

In 324, I added a concept of **resizing only the foregrounded window synchronously**. This makes our panel closing/opening animation much faster smoother, because we are not trying to resize every window at the same time. However, there's an edge case: the foregroundWindow is not always the correct window to resize. If, for example, the foreground window is on the left half of the screen, then it doesn't need to be resized. We _actually_ want to resize any windows that are bordering the panel. The bordering windows get resized after the panel animation completes, creating a weird visual: 

https://github.com/user-attachments/assets/fd82a7ea-5755-47c8-afad-31632cce8c00

Instead, we should be synchronously resizing any windows that border the OnitPanel. Here, I calculate that by doing 10 hit tests along the left edge of the Onit panel. The windows returned from the hit test get priority, sychronous resizing: 


https://github.com/user-attachments/assets/8c688dec-a1b6-44ef-9d99-ea02fa6acdc2

Notes* There's still an edge case if the user has more than 10, very short apps alongside the edge, or if the hit tests otherwise miss one. In all practicality, that's unlikely to occur, so I'm not handling it. If we observe issues, we can increase the number of hit tests. 

