### PR TITLE
Show tether window immediately when close completes

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Display.swift
@@ -115,6 +115,8 @@ extension PanelStatePinnedManager {
 
         resetFramesOnAppChange()
         
+        
+        
         NSAnimationContext.runAnimationGroup { context in
             context.duration = animationDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
@@ -122,7 +124,6 @@ extension PanelStatePinnedManager {
         } completionHandler: {
             // Disable rasterization after animation
             panel.contentView?.layer?.shouldRasterize = false
-
             panel.hide()
             panel.isAnimating = false
             panel.alphaValue = 0
@@ -131,7 +132,7 @@ extension PanelStatePinnedManager {
             // Once the panel is hidden, we should show the hint
             if let screen = self.attachedScreen {
                 self.attachedScreen = nil
-                self.debouncedShowTetherWindow(activeScreen: screen)
+                self.showTetherWindow(activeScreen: screen)
             }
         }
     }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -25,8 +25,9 @@ extension PanelStatePinnedManager {
         }
     }
 
-    private func showTetherWindow(activeScreen: NSScreen) {
-        let tetherView = ExternalTetheredButton(
+    func showTetherWindow(activeScreen: NSScreen) {
+         let tetherView = ExternalTetheredButton(
+
             onClick: { [weak self] in
                 self?.tetherHintClicked(screen: activeScreen)
             },


### PR DESCRIPTION
Another small Quality of Life fix: the tether window is currently delayed when you close the app. We’re calling a debounced method, but we don’t actually need to. In this case, since we’re calling it from the panel close animation and not from accessibility events, we can be sure it won’t get called multiple times in sequence. So, there’s no need to debounce and use the debouncing timer (which delays its appearance).

Here's what it looks like now:

https://github.com/user-attachments/assets/efe46a6c-13ce-40d1-b08c-c22a3d4f2d43

And here's what it looks like after this change: 

https://github.com/user-attachments/assets/be8c5318-5ac1-4f94-b893-e337ad8a1bf1


