### PR TITLE
Disable quickedit and gate entry point to beta and debug builds

### DIFF
--- a/macos/Onit/Data/Persistence/QuickEditConfig.swift
+++ b/macos/Onit/Data/Persistence/QuickEditConfig.swift
@@ -15,9 +15,9 @@ struct QuickEditConfig: Codable, Defaults.Serializable {
     var shouldCaptureTrainingData: Bool
     
     static let `default` = QuickEditConfig(
-        isEnabled: true,
+        isEnabled: false,
         excludedApps: [],
         pausedApps: [:],
-        shouldCaptureTrainingData: true
+        shouldCaptureTrainingData: false
     )
 }

--- a/macos/Onit/UI/Settings/SettingsView.swift
+++ b/macos/Onit/UI/Settings/SettingsView.swift
@@ -50,11 +50,13 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.accessibility)
 
+            #if DEBUG || BETA
             QuickEditTab()
                 .tabItem {
                     Label("Quick Edit", systemImage: "wand.and.sparkles")
                 }
                 .tag(SettingsTab.quickEdit)
+            #endif
                 
             WebSearchTab()
                 .tabItem {


### PR DESCRIPTION
Simple update: Since the feature isn't complete yet, we shouldn't make it externally available. This gates it so that we can use it in debug and beta builds, without shipping it externally!