### PR TITLE
Fix menu icon color

### DIFF
--- a/macos/Onit/Menu Bar/MenuIcon.swift
+++ b/macos/Onit/Menu Bar/MenuIcon.swift
@@ -51,8 +51,8 @@ struct MenuIcon: View {
     
     var body: some View {
         Image(iconImage)
-            .renderingMode(.original)
-//            .animation(.default, value: isOnitDisabled)
+            .renderingMode(.template) // Make sure to use template rendering
+            .foregroundColor(.primary) // Adapts to menu bar color
             .onAppear {
                 startTimerUpdateTaskIfNeeded()
             }


### PR DESCRIPTION
We had reports from a user of the Onit icon being too light against the MenuBar: 

<img width="198" height="41" alt="Screenshot 2025-07-16 at 9 49 03 AM" src="https://github.com/user-attachments/assets/53ccc401-af14-4730-9733-a3eb5b58b006" />

It turns out, in MacOS, the color of the MenuBar is responsive to the wallpaper. On dark wallpaper, the menu bar is dark. On a light wallpaper, the menu bar is light. This is changed between MacOS Sonoma, which had a light default wallpaper and menu bar, and MacOS Sequoia, which has a dark default wallpaper and menu bar. 

To fix this, we need to use a primary foreground color and .template rendering mode. After this change, our icon correctly adapts to the color of the MenuBar.

Light (Sonoma Background):
<img width="166" height="38" alt="Screenshot 2025-07-16 at 9 47 35 AM" src="https://github.com/user-attachments/assets/1ecfc19d-aed2-4f54-8f45-8bad160176e5" />

Dark (Sequoia background): 
<img width="204" height="44" alt="Screenshot 2025-07-16 at 9 42 44 AM" src="https://github.com/user-attachments/assets/5e3e092d-2dbb-44ce-ac21-3b85b113a4ef" />


