### PR TITLE
Pass fontSize and lineHeight to LLMStream and force refresh

### DIFF
--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -29,21 +29,27 @@ struct GeneratedContentView: View {
     }
     
     var configuration: LLMStreamConfiguration {
+        let font = FontConfiguration(size: fontSize, lineHeight: lineHeight)
         let color = ColorConfiguration(citationBackgroundColor: .gray600,
                                        citationHoverBackgroundColor: .gray400,
                                        citationTextColor: .gray100)
         let thought = ThoughtConfiguration(icon: Image(.lightBulb))
         
-        return LLMStreamConfiguration(colors: color, thought: thought)
+        return LLMStreamConfiguration(font: font, colors: color, thought: thought)
     }
     
+
     var body: some View {
+        // By reading fontSize and lineHeight here, we ensure SwiftUI observes them.
+        let _ = fontSize
+        let _ = lineHeight
 
         VStack(alignment: .leading, spacing: 8) {
             LLMStreamView(text: textToRead,
-                          configuration: configuration,
-                          onUrlClicked: onUrlClicked,
-                          onCodeAction: codeAction)
+                        configuration: configuration,
+                        onUrlClicked: onUrlClicked,
+                        onCodeAction: codeAction)
+                .id("\(fontSize)-\(lineHeight)") // Force recreation when font settings change
                 .padding(.horizontal, 12)
 
             if let response = prompt.currentResponse, response.hasToolCall {

--- a/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
+++ b/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
@@ -164,8 +164,6 @@ extension QuickEditResponseView {
     
     private var scrollView: some View {
         // By reading fontSize and lineHeight here, we ensure SwiftUI observes them.
-//        let _ = fontSize
-//        let _ = lineHeight
         
         ScrollViewReader { proxy in
             ScrollView {

--- a/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
+++ b/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
@@ -20,13 +20,16 @@ struct ViewOffsetKey: @preconcurrency PreferenceKey {
 struct QuickEditResponseView: View {
     @Environment(\.windowState) private var state
     @Environment(\.openURL) var openURL
-    
+        
     @State private var previousViewOffset: CGFloat = 0
     @State private var hasUserManuallyScrolled: Bool = false
     @State private var isAutoScrolling: Bool = false
     @State private var lastAutoScrollTime: Date = Date.distantPast
     @State private var scrollProxy: ScrollViewProxy?
     @State private var isButtonScrolling: Bool = false
+    
+    @Default(.fontSize) var fontSize
+    @Default(.lineHeight) var lineHeight
     
     private let minimumOffset: CGFloat = 16
     private let autoScrollThrottleInterval: TimeInterval = 0.03
@@ -54,12 +57,13 @@ struct QuickEditResponseView: View {
     }
     
     private var configuration: LLMStreamConfiguration {
+        let font = FontConfiguration(size: fontSize, lineHeight: lineHeight)
         let color = ColorConfiguration(citationBackgroundColor: .gray600,
                                        citationHoverBackgroundColor: .gray400,
                                        citationTextColor: .gray100)
         let thought = ThoughtConfiguration(icon: Image(.lightBulb))
         
-        return LLMStreamConfiguration(colors: color, thought: thought)
+        return LLMStreamConfiguration(font: font, colors: color, thought: thought)
     }
     
     var body: some View {
@@ -159,6 +163,10 @@ extension QuickEditResponseView {
     }
     
     private var scrollView: some View {
+        // By reading fontSize and lineHeight here, we ensure SwiftUI observes them.
+//        let _ = fontSize
+//        let _ = lineHeight
+        
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 0) {
@@ -167,6 +175,7 @@ extension QuickEditResponseView {
                         configuration: configuration,
                         onUrlClicked: onUrlClicked,
                         onCodeAction: codeAction)
+                    .id("\(fontSize)-\(lineHeight)") // Force recreation when font settings change
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 8)
                     .id("content")


### PR DESCRIPTION
I noticed that changing the fontSize in the settings didn’t affect the response text size in Onit. After checking the code, I discovered that although we have a FontConfiguration object set up to handle fontSize and lineHeight, we aren’t passing those values into LLMStreamView. This pull request updates the implementation to utilize the FontConfiguration and ensures the view refreshes whenever the fontSize or lineHeight properties change.

Users can now slide the options in settings and see their responses update in real-time, giving a feel for how it will look:

https://github.com/user-attachments/assets/8408f1fd-38f5-4325-b4fe-3e15c34aa2a4

Notes: 
1.  I acknowledge that this isn't the smoothest transition. I tried a simple animation, but it didn't work. @lk340 @Niduank if you have any tricks up your sleeves to make this look better, let me know! It's not a common use case, though, so I'm okay with it being a little wonky. 
2. Many of the other components (like PromptCore, FinalContextView) aren't responsive to changes in the font. We should make them update too! We can handle this in a different PR. 

