### PR TITLE
Return nil when off the main thread

### DIFF
--- a/macos/Onit/UI/Environment/Environment+Values.swift
+++ b/macos/Onit/UI/Environment/Environment+Values.swift
@@ -32,7 +32,12 @@ extension EnvironmentValues {
     }
     
     var windowState: OnitPanelState? {
-        get { self[OnitPanelStateKey.self] }
+        get {
+            guard Thread.isMainThread else {
+                return nil
+            }
+            return self[OnitPanelStateKey.self]
+        }
         set { self[OnitPanelStateKey.self] = newValue }
     }
 }


### PR DESCRIPTION
Despite making the OnitPanelState optional in #292, we are still seeing the crash in Environment+Values! 
I'm able to reproduce the crash in main by foregrounding another application, and then clicking the 'refresh' button on an Onit response while Onit is in the background. Do this repeatedly and you'll eventually get a crash. 

My solution here is to check if we're on the main thread before accessing 'self' in the windowState getter. 

I've tested this by adding a log statement and repeating the repro steps above. I can see in the console logs that the getting is being called off the main thread, but the app isn't crashing anymore. Visually, I don't observe any issues with the UI, confirming the suspicion that any UI rendered with a nil windowState is short-lived and quickly overwritten. 

<img width="751" height="445" alt="Screenshot 2025-07-16 at 10 40 02 AM" src="https://github.com/user-attachments/assets/e4525679-0149-4c51-9e05-597aa4e6f739" />
