### PR TITLE
Use medium14 font in TextViewWrapper

### DIFF
--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -25,7 +25,7 @@ struct TextViewWrapper: NSViewRepresentable {
     var audioRecorder: AudioRecorder
     var isDisabled: Bool = false
     
-    var font: NSFont = AppFont.medium16.nsFont
+    var font: NSFont = AppFont.medium14.nsFont
     var textColor: NSColor = .white
     var placeholderColor: NSColor = .gray300
     var detectLinks: Bool = true // TODO remove this once we use TextInputView for prompt editing

--- a/macos/Onit/UI/Prompt/FinalContextView.swift
+++ b/macos/Onit/UI/Prompt/FinalContextView.swift
@@ -63,7 +63,6 @@ struct FinalContextView: View {
                     audioRecorder: audioRecorder,
                     detectLinks: false
                 )
-                .appFont(.medium16)
                 .frame(height: min(textHeight, maxHeightLimit))
                 .allowsHitTesting(isEditing)
                 .textSelection(.enabled)

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -151,7 +151,6 @@ extension PromptCore {
                 detectLinks: true
             )
             .frame(height: min(textHeight, maxHeightLimit))
-            .appFont(.medium16)
             .foregroundStyle(.white)
             .opacity(shouldIndicateDisabled ? 0.5 : 1)
             .focused($isFocused)

--- a/macos/Onit/UI/QuickEdit/QuickEditView.swift
+++ b/macos/Onit/UI/QuickEdit/QuickEditView.swift
@@ -205,7 +205,6 @@ extension QuickEditView {
         .frame(height: min(textHeight, maxTextHeight))
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
-        .appFont(.medium16)
         .foregroundStyle(.white)
         .focused($isFocused)
         .onAppear { 


### PR DESCRIPTION
While working on #336, I noticed that the font used in PromptCore is different from that in LLMSteamView. Looking through the code, I see that we are using 'medium16', which is defined as `Default[.fontSize] + 2. ` I'm not sure how we landed here - the designs all use the default font at 14 points. 

Here's what it looks like currently: 

<img width="283" height="110" alt="Screenshot 2025-07-16 at 11 41 44 AM" src="https://github.com/user-attachments/assets/5c644a9f-4b54-480c-93a6-7372b531bc06" />

In this change, I changed TextViewWrapper to use medium14. I also removed the .appFont modifier on the TextViewWrappers, since it's ignored! 

After this change (and #336), the PromptCore and LLMStream are in sync: both use the user defined .fontSize default!