### PR TITLE
Text Highlight: Update Highlighted Text Behavior

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -598,10 +598,7 @@ class AccessibilityNotificationsManager: ObservableObject {
 
     private func processSelectedText(_ text: String?) {
         guard Defaults[.autoContextFromHighlights],
-              let selectedText = text?
-                                    .replacingOccurrences(of: "\\r?\\n", with: " ", options: .regularExpression)
-                                    .replacingOccurrences(of: " +", with: " ", options: .regularExpression)
-                                    .trimmingCharacters(in: .whitespacesAndNewlines),
+              let selectedText = text,
               HighlightedTextValidator.isValid(text: selectedText) else {
             
             screenResult.userInteraction.selectedText = nil

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -606,13 +606,19 @@ class AccessibilityNotificationsManager: ObservableObject {
             
             screenResult.userInteraction.selectedText = nil
             PanelStateCoordinator.shared.state.pendingInput = nil
+            PanelStateCoordinator.shared.state.trackedPendingInput = nil
             return
         }
         
         screenResult.userInteraction.selectedText = selectedText
         
         let input = Input(selectedText: selectedText, application: currentSource ?? "")
-        PanelStateCoordinator.shared.state.pendingInput = input
+        
+        if Defaults[.autoAddHighlightedTextToContext] {
+            PanelStateCoordinator.shared.state.pendingInput = input
+        } else {
+            PanelStateCoordinator.shared.state.trackedPendingInput = input
+        }
     }
 
 	// MARK: Caret Position Handling

--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -598,7 +598,10 @@ class AccessibilityNotificationsManager: ObservableObject {
 
     private func processSelectedText(_ text: String?) {
         guard Defaults[.autoContextFromHighlights],
-              let selectedText = text,
+              let selectedText = text?
+                                    .replacingOccurrences(of: "\\r?\\n", with: " ", options: .regularExpression)
+                                    .replacingOccurrences(of: " +", with: " ", options: .regularExpression)
+                                    .trimmingCharacters(in: .whitespacesAndNewlines),
               HighlightedTextValidator.isValid(text: selectedText) else {
             
             screenResult.userInteraction.selectedText = nil

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -114,6 +114,7 @@ extension Defaults.Keys {
     static let lineHeight = Key<Double>("lineHeight", default: 1.5)
     static let voiceSilenceThreshold = Key<Float>("voiceSilenceThreshold", default: -40)
     static let voiceSpeechPassThreshold = Key<Double>("voiceSpeechPassThreshold", default: 0.7)
+    static let showHighlightedTextInput = Key<Bool>("showHighlightedTextInput", default: true)
 
     // Local model advanced options
     static let localKeepAlive = Key<String?>("localKeepAlive", default: nil)

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -114,7 +114,9 @@ extension Defaults.Keys {
     static let lineHeight = Key<Double>("lineHeight", default: 1.5)
     static let voiceSilenceThreshold = Key<Float>("voiceSilenceThreshold", default: -40)
     static let voiceSpeechPassThreshold = Key<Double>("voiceSpeechPassThreshold", default: 0.7)
+        /// Highlighted Text
     static let showHighlightedTextInput = Key<Bool>("showHighlightedTextInput", default: true)
+    static let autoAddHighlightedTextToContext = Key<Bool>("autoAddHighlightedTextToContext", default: true)
 
     // Local model advanced options
     static let localKeepAlive = Key<String?>("localKeepAlive", default: nil)

--- a/macos/Onit/Helpers/StringHelpers.swift
+++ b/macos/Onit/Helpers/StringHelpers.swift
@@ -1,0 +1,14 @@
+//
+//  StringHelpers.swift
+//  Onit
+//
+//  Created by Loyd Kim on 7/18/25.
+//
+
+struct StringHelpers {
+    static func removeWhiteSpaceAndNewLines(_ str: String) -> String {
+        return str.replacingOccurrences(of: "\\r?\\n", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: " +", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/macos/Onit/UI/Components/ContextTag.swift
+++ b/macos/Onit/UI/Components/ContextTag.swift
@@ -14,9 +14,11 @@ struct ContextTag: View {
     private let background: Color
     private let hoverBackground: Color
     private let hasHoverBorder: Bool
+    private let hasDottedBorder: Bool
     private let maxWidth: CGFloat
     private let isLoading: Bool
     private let shouldFadeIn: Bool
+    private let borderColor: Color?
     private let iconBundleURL: URL?
     private let iconView: (any View)?
     private let caption: String?
@@ -32,9 +34,11 @@ struct ContextTag: View {
         background: Color = .gray500,
         hoverBackground: Color = .gray400,
         hasHoverBorder: Bool = false,
+        hasDottedBorder: Bool = false,
         maxWidth: CGFloat = 155,
         isLoading: Bool = false,
         shouldFadeIn: Bool = false,
+        borderColor: Color? = nil,
         iconBundleURL: URL? = nil,
         iconView: (any View)? = nil,
         caption: String? = nil,
@@ -49,9 +53,11 @@ struct ContextTag: View {
         self.background = background
         self.hoverBackground = hoverBackground
         self.hasHoverBorder = hasHoverBorder
+        self.hasDottedBorder = hasDottedBorder
         self.maxWidth = maxWidth
         self.isLoading = isLoading
         self.shouldFadeIn = shouldFadeIn
+        self.borderColor = borderColor
         self.iconBundleURL = iconBundleURL
         self.iconView = iconView
         self.caption = caption
@@ -151,8 +157,8 @@ struct ContextTag: View {
         .addAnimation(dependency: isHoveredBody)
         .addBorder(
             cornerRadius: 4,
-            stroke: hasHoverBorder && isHoveredBody ? .T_4 : .clear,
-            dotted: true
+            stroke: hasHoverBorder && isHoveredBody ? .T_4 : borderColor ?? .clear,
+            dotted: hasDottedBorder
         )
         .addButtonEffects(
             background: background,

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -130,6 +130,8 @@ class OnitPanelState: NSObject {
         }
     }
     
+    var trackedPendingInput: Input? = nil
+    
     var systemPromptId: String = SystemPrompt.outputOnly.id
     
     var imageUploads: [URL: UploadProgress] = [:]

--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -120,11 +120,11 @@ struct FileRow: View {
             FlowLayout(spacing: 6) {
                 PaperclipButton()
                 
-                addHighlightedTextToContextButton
                 addWindowToContextButton
+                addHighlightedTextToContextButton
                 pendingWindowContextItems
-                highlightedTextContext
                 addedWindowContextItems
+                highlightedTextContext
             }
             
             ocrDetailsLink
@@ -183,7 +183,7 @@ extension FileRow {
            let trackedPendingInput = windowState.trackedPendingInput
         {
             ghostContextTag(
-                text: trackedPendingInput.selectedText,
+                text: StringHelpers.removeWhiteSpaceAndNewLines(trackedPendingInput.selectedText),
                 iconView: Image(.text).addIconStyles(iconSize: 14),
                 tooltip: "Add Highlighted Text To Context"
             ) {
@@ -251,7 +251,7 @@ extension FileRow {
     private var highlightedTextContext: some View {
         if let pendingInput = windowState?.pendingInput {
             ContextTag(
-                text: pendingInput.selectedText,
+                text: StringHelpers.removeWhiteSpaceAndNewLines(pendingInput.selectedText),
                 iconView: Image(.text).addIconStyles(iconSize: 14)
             ) {
                 Defaults[.showHighlightedTextInput] = true

--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -121,6 +121,7 @@ struct FileRow: View {
                 
                 addForegroundWindowToContextButton
                 pendingWindowContextItems
+                highlightedTextContext
                 addedWindowContextItems
             }
             
@@ -198,6 +199,18 @@ extension FileRow {
                         )
                     }
                 }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var highlightedTextContext: some View {
+        if let pendingInput = windowState?.pendingInput {
+            ContextTag(
+                text: pendingInput.selectedText,
+                iconView: Image(.text).addIconStyles(iconSize: 14)
+            ) {
+                Defaults[.showHighlightedTextInput] = true
             }
         }
     }

--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -15,6 +15,8 @@ struct FileRow: View {
     
     @Default(.autoContextFromCurrentWindow) var autoContextFromCurrentWindow
     @Default(.autoAddHighlightedTextToContext) var autoAddHighlightedTextToContext
+    @Default(.autoContextFromHighlights) var autoContextFromHighlights
+    @Default(.showHighlightedTextInput) var showHighlightedTextInput
     
     @State private var ocrComparisonResult: OCRComparisonResult? = nil
     @State private var showOCRDetails = false
@@ -166,6 +168,7 @@ extension FileRow {
             background: contextTagBackground,
             hoverBackground: contextTagHoverBackground,
             hasHoverBorder: true,
+            hasDottedBorder: true,
             shouldFadeIn: true,
             iconBundleURL: iconBundleURL,
             iconView: iconView,
@@ -178,7 +181,7 @@ extension FileRow {
     @ViewBuilder
     private var addHighlightedTextToContextButton: some View {
         if accessibilityEnabled,
-           Defaults[.autoContextFromHighlights],
+           autoContextFromHighlights,
            let windowState = windowState,
            let trackedPendingInput = windowState.trackedPendingInput
         {
@@ -252,9 +255,10 @@ extension FileRow {
         if let pendingInput = windowState?.pendingInput {
             ContextTag(
                 text: StringHelpers.removeWhiteSpaceAndNewLines(pendingInput.selectedText),
+                borderColor: showHighlightedTextInput ? .gray400 : .clear,
                 iconView: Image(.text).addIconStyles(iconSize: 14)
             ) {
-                Defaults[.showHighlightedTextInput] = true
+                showHighlightedTextInput = true
             } removeAction: {
                 windowState?.pendingInput = nil
             }

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -22,7 +22,7 @@ struct InputBody: View {
     }
 
     var height: CGFloat {
-        min(textHeight, 73)
+        min(textHeight, 222)
     }
 
     var body: some View {

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -9,14 +9,12 @@ import HighlightSwift
 import SwiftUI
 
 struct InputBody: View {
-    @Binding var inputExpanded: Bool
     @State var text: String?
     @State var textHeight: CGFloat = 0
 
     var input: Input
 
-    init(inputExpanded: Binding<Bool>, input: Input) {
-        _inputExpanded = inputExpanded
+    init(input: Input) {
         text = input.selectedText.count <= 500 ? input.selectedText : nil
         self.input = input
     }
@@ -41,7 +39,7 @@ struct InputBody: View {
                     }
             }
         }
-        .frame(height: inputExpanded ? height : 0)
+        .frame(height: height)
         .onChange(of: input.selectedText, initial: true) {
             DispatchQueue.main.async {
                 text = input.selectedText
@@ -74,6 +72,6 @@ struct InputBody: View {
 
 #if DEBUG
     #Preview {
-        InputBody(inputExpanded: .constant(true), input: .sample)
+        InputBody(input: .sample)
     }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputBody.swift
+++ b/macos/Onit/UI/Prompt/Input/InputBody.swift
@@ -9,12 +9,14 @@ import HighlightSwift
 import SwiftUI
 
 struct InputBody: View {
+    @Binding var inputExpanded: Bool
     @State var text: String?
     @State var textHeight: CGFloat = 0
 
     var input: Input
 
-    init(input: Input) {
+    init(inputExpanded: Binding<Bool>, input: Input) {
+        _inputExpanded = inputExpanded
         text = input.selectedText.count <= 500 ? input.selectedText : nil
         self.input = input
     }
@@ -39,7 +41,7 @@ struct InputBody: View {
                     }
             }
         }
-        .frame(height: height)
+        .frame(height: inputExpanded ? height : 0)
         .onChange(of: input.selectedText, initial: true) {
             DispatchQueue.main.async {
                 text = input.selectedText
@@ -72,6 +74,6 @@ struct InputBody: View {
 
 #if DEBUG
     #Preview {
-        InputBody(input: .sample)
+        InputBody(inputExpanded: .constant(true), input: .sample)
     }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -40,7 +40,7 @@ struct InputButtons: View {
                     .overlay {
                         Image(.smallChevRight)
                             .renderingMode(.template)
-                            .rotationEffect(isEditing ? .degrees(90) : inputExpanded ? .degrees(90) : .zero)
+                            .rotationEffect(isEditing ? .degrees(90) : inputExpanded ? .degrees(-90) : .degrees(90))
                     }
             }
         }

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -10,8 +10,6 @@ import SwiftUI
 
 struct InputButtons: View {
     @Environment(\.windowState) private var state
-    
-    @Binding var inputExpanded: Bool
 
     var input: Input
 
@@ -27,40 +25,24 @@ struct InputButtons: View {
                 .buttonStyle(DarkerButtonStyle())
             }
 
-            CopyButton(text: input.selectedText)
-                .frame(width: 20, height: 20)
-
             Button {
-                inputExpanded.toggle()
+                Defaults[.showHighlightedTextInput] = false
             } label: {
                 Color.clear
                     .frame(width: 20, height: 20)
                     .overlay {
                         Image(.smallChevRight)
                             .renderingMode(.template)
-                            .rotationEffect(inputExpanded ? .degrees(90) : .zero)
+                            .rotationEffect(.degrees(90))
                     }
             }
-            
-            closeButton
         }
         .foregroundStyle(.gray200)
-    }
-    
-    // MARK: - Child Components
-    
-    private var closeButton: some View {
-        IconButton(
-            icon: .cross,
-            iconSize: 9
-        ) {
-            Defaults[.showHighlightedTextInput] = false
-        }
     }
 }
 
 #if DEBUG
     #Preview {
-        InputButtons(inputExpanded: .constant(true), input: .sample)
+        InputButtons(input: .sample)
     }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -5,6 +5,7 @@
 //  Created by Benjamin Sage on 10/8/24.
 //
 
+import Defaults
 import SwiftUI
 
 struct InputButtons: View {
@@ -40,8 +41,21 @@ struct InputButtons: View {
                             .rotationEffect(inputExpanded ? .degrees(90) : .zero)
                     }
             }
+            
+            closeButton
         }
         .foregroundStyle(.gray200)
+    }
+    
+    // MARK: - Child Components
+    
+    private var closeButton: some View {
+        IconButton(
+            icon: .cross,
+            iconSize: 9
+        ) {
+            Defaults[.showHighlightedTextInput] = false
+        }
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputButtons.swift
+++ b/macos/Onit/UI/Prompt/Input/InputButtons.swift
@@ -10,8 +10,11 @@ import SwiftUI
 
 struct InputButtons: View {
     @Environment(\.windowState) private var state
+    
+    @Binding var inputExpanded: Bool
 
     var input: Input
+    var isEditing: Bool
 
     var body: some View {
         Group {
@@ -26,14 +29,18 @@ struct InputButtons: View {
             }
 
             Button {
-                Defaults[.showHighlightedTextInput] = false
+                if isEditing {
+                    Defaults[.showHighlightedTextInput] = false
+                } else {
+                    inputExpanded.toggle()
+                }
             } label: {
                 Color.clear
                     .frame(width: 20, height: 20)
                     .overlay {
                         Image(.smallChevRight)
                             .renderingMode(.template)
-                            .rotationEffect(.degrees(90))
+                            .rotationEffect(isEditing ? .degrees(90) : inputExpanded ? .degrees(90) : .zero)
                     }
             }
         }
@@ -43,6 +50,6 @@ struct InputButtons: View {
 
 #if DEBUG
     #Preview {
-        InputButtons(input: .sample)
+        InputButtons(inputExpanded: .constant(true), input: .sample, isEditing: true)
     }
 #endif

--- a/macos/Onit/UI/Prompt/Input/InputTitle.swift
+++ b/macos/Onit/UI/Prompt/Input/InputTitle.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct InputTitle: View {
-    @Binding var inputExpanded: Bool
     var input: Input
 
     var sourceString: String {
@@ -26,7 +25,7 @@ struct InputTitle: View {
                 .appFont(.medium13)
                 .textSelection(.enabled)
             Spacer()
-            InputButtons(inputExpanded: $inputExpanded, input: input)
+            InputButtons(input: input)
         }
         .foregroundStyle(.gray100)
         .padding(.horizontal, 12)
@@ -35,5 +34,5 @@ struct InputTitle: View {
 }
 
 #Preview {
-    InputTitle(inputExpanded: .constant(true), input: .sample)
+    InputTitle(input: .sample)
 }

--- a/macos/Onit/UI/Prompt/Input/InputTitle.swift
+++ b/macos/Onit/UI/Prompt/Input/InputTitle.swift
@@ -14,24 +14,24 @@ struct InputTitle: View {
 
     var sourceString: String {
         guard let sourceText = input.application else { return "" }
-        return " - \(sourceText)"
+        return " [\(sourceText)]"
     }
 
     var inputString: String {
-        "Input\(sourceString)"
+        "From\(sourceString)"
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(alignment: .center, spacing: 8) {
             Text(inputString)
-                .appFont(.medium13)
+                .appFont(.medium12)
                 .textSelection(.enabled)
             Spacer()
             InputButtons(inputExpanded: $inputExpanded, input: input, isEditing: isEditing)
         }
         .foregroundStyle(.gray100)
         .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.vertical, 4)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputTitle.swift
+++ b/macos/Onit/UI/Prompt/Input/InputTitle.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct InputTitle: View {
+    @Binding var inputExpanded: Bool
     var input: Input
+    var isEditing: Bool
 
     var sourceString: String {
         guard let sourceText = input.application else { return "" }
@@ -25,7 +27,7 @@ struct InputTitle: View {
                 .appFont(.medium13)
                 .textSelection(.enabled)
             Spacer()
-            InputButtons(input: input)
+            InputButtons(inputExpanded: $inputExpanded, input: input, isEditing: isEditing)
         }
         .foregroundStyle(.gray100)
         .padding(.horizontal, 12)
@@ -34,5 +36,5 @@ struct InputTitle: View {
 }
 
 #Preview {
-    InputTitle(input: .sample)
+    InputTitle(inputExpanded: .constant(true), input: .sample, isEditing: true)
 }

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -11,17 +11,15 @@ import SwiftUI
 struct InputView: View {
     @Default(.showHighlightedTextInput) var showHighlightedTextInput
 
-    @State var inputExpanded: Bool = true
-
     var input: Input
     var isEditing: Bool = true
 
     var body: some View {
         if showHighlightedTextInput {
             VStack(spacing: 0) {
-                InputTitle(inputExpanded: $inputExpanded, input: input)
+                InputTitle(input: input)
                 divider
-                InputBody(inputExpanded: $inputExpanded, input: input)
+                InputBody(input: input)
             }
             .background {
                 RoundedRectangle(cornerRadius: 10)
@@ -35,7 +33,6 @@ struct InputView: View {
     var divider: some View {
         Color.gray600
             .frame(height: 1)
-            .opacity(inputExpanded ? 1 : 0)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -9,30 +9,29 @@ import Defaults
 import SwiftUI
 
 struct InputView: View {
-    @Default(.showHighlightedTextInput) var showHighlightedTextInput
-
     var input: Input
     var isEditing: Bool = true
+    
+    @State var inputExpanded: Bool = false
 
     var body: some View {
-        if showHighlightedTextInput {
-            VStack(spacing: 0) {
-                InputTitle(input: input)
-                divider
-                InputBody(input: input)
-            }
-            .background {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(.gray800)
-                    .strokeBorder(.gray600)
-            }
-            .padding([.horizontal, .top], isEditing ? 12 : 0)
+        VStack(spacing: 0) {
+            InputTitle(inputExpanded: $inputExpanded, input: input, isEditing: isEditing)
+            divider
+            InputBody(inputExpanded: $inputExpanded, input: input)
         }
+        .background {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.gray800)
+                .strokeBorder(.gray600)
+        }
+        .padding([.horizontal, .top], isEditing ? 12 : 0)
     }
 
     var divider: some View {
         Color.gray600
             .frame(height: 1)
+            .opacity(inputExpanded ? 1 : 0)
     }
 }
 

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -21,15 +21,16 @@ struct InputView: View {
             InputBody(inputExpanded: $inputExpanded, input: input)
         }
         .background {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(.gray800)
-                .strokeBorder(.gray600)
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.gray500)
+                .strokeBorder(.gray400)
         }
-        .padding([.horizontal, .top], isEditing ? 12 : 0)
+        .padding(.top, isEditing ? 6 : 0)
+        .padding([.horizontal], isEditing ? 8 : 0)
     }
 
     var divider: some View {
-        Color.gray600
+        Color.gray400
             .frame(height: 1)
             .opacity(inputExpanded ? 1 : 0)
     }

--- a/macos/Onit/UI/Prompt/Input/InputView.swift
+++ b/macos/Onit/UI/Prompt/Input/InputView.swift
@@ -5,9 +5,11 @@
 //  Created by Benjamin Sage on 10/3/24.
 //
 
+import Defaults
 import SwiftUI
 
 struct InputView: View {
+    @Default(.showHighlightedTextInput) var showHighlightedTextInput
 
     @State var inputExpanded: Bool = true
 
@@ -15,17 +17,19 @@ struct InputView: View {
     var isEditing: Bool = true
 
     var body: some View {
-        VStack(spacing: 0) {
-            InputTitle(inputExpanded: $inputExpanded, input: input)
-            divider
-            InputBody(inputExpanded: $inputExpanded, input: input)
+        if showHighlightedTextInput {
+            VStack(spacing: 0) {
+                InputTitle(inputExpanded: $inputExpanded, input: input)
+                divider
+                InputBody(inputExpanded: $inputExpanded, input: input)
+            }
+            .background {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(.gray800)
+                    .strokeBorder(.gray600)
+            }
+            .padding([.horizontal, .top], isEditing ? 12 : 0)
         }
-        .background {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(.gray800)
-                .strokeBorder(.gray600)
-        }
-        .padding([.horizontal, .top], isEditing ? 12 : 0)
     }
 
     var divider: some View {

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -17,6 +17,7 @@ struct PromptCore: View {
     
     @Default(.mode) var mode
     @Default(.showTwoWeekProTrialEndedAlert) var showTwoWeekProTrialEndedAlert
+    @Default(.showHighlightedTextInput) var showHighlightedTextInput
     
     private var chats: [Chat] {
         let chatsFilteredByAccount = allChats
@@ -70,8 +71,8 @@ struct PromptCore: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            if let windowState = windowState, let pendingInput = windowState.pendingInput {
-                InputView(input: pendingInput)
+            if showHighlightedTextInput, let windowState = windowState, let pendingInput = windowState.pendingInput {
+                InputView(input: pendingInput, inputExpanded: true)
             }
             
             VStack(spacing: 6) {

--- a/macos/Onit/UI/Prompt/PromptCore.swift
+++ b/macos/Onit/UI/Prompt/PromptCore.swift
@@ -71,10 +71,6 @@ struct PromptCore: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            if showHighlightedTextInput, let windowState = windowState, let pendingInput = windowState.pendingInput {
-                InputView(input: pendingInput, inputExpanded: true)
-            }
-            
             VStack(spacing: 6) {
                 contextAndInput
                 PromptCoreFooter(
@@ -177,7 +173,11 @@ extension PromptCore {
     }
     
     private var contextAndInput: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
+            if showHighlightedTextInput, let windowState = windowState, let pendingInput = windowState.pendingInput {
+                InputView(input: pendingInput, inputExpanded: true)
+            }
+            
             if !appState.subscriptionPlanError.isEmpty {
                 Text(appState.subscriptionPlanError)
                     .styleText(
@@ -187,10 +187,15 @@ extension PromptCore {
                     )
             }
             
-            FileRow(contextList: windowState?.pendingContextList ?? [])
-            textField
+            VStack(alignment: .leading, spacing: 8) {
+                FileRow(contextList: windowState?.pendingContextList ?? [])
+                textField
+            }
+            .padding(.top, 6)
+            .padding([.horizontal, .bottom], 12)
         }
-        .padding(12)
+        .padding(.top, 2)
+        .padding([.horizontal, .bottom], 0)
         .background(.gray800)
         .addGradientBorder(
             cornerRadius: 8,

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -424,7 +424,7 @@ struct GeneralTab: View {
         ) {
             VStack(alignment: .leading, spacing: 20) {
                 HStack {
-                    Text("Show highlighted text input.")
+                    Text("Show highlighted text input")
                         .font(.system(size: 13))
                     
                     Spacer()

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -18,6 +18,7 @@ struct GeneralTab: View {
     @Default(.tetheredButtonHiddenApps) var tetheredButtonHiddenApps
     @Default(.tetheredButtonHideAllApps) var tetheredButtonHideAllApps
     @Default(.tetheredButtonHideAllAppsTimerDate) var tetheredButtonHideAllAppsTimerDate
+    @Default(.showHighlightedTextInput) var showHighlightedTextInput
     
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
     @State var isAnalyticsEnabled: Bool = PostHogSDK.shared.isOptOut() == false
@@ -73,6 +74,8 @@ struct GeneralTab: View {
             appearanceSection
             
             GeneralTabVoice()
+            
+            showHighlightedTextInputSection
                         
             hiddenAppsSection
             
@@ -410,6 +413,26 @@ struct GeneralTab: View {
                 //                        }
                 //                    }
                 //                }
+            }
+        }
+    }
+    
+    var showHighlightedTextInputSection: some View {
+        SettingsSection(
+            iconImage: .text,
+            title: "Highlighted Text"
+        ) {
+            VStack(alignment: .leading, spacing: 20) {
+                HStack {
+                    Text("Show highlighted text input.")
+                        .font(.system(size: 13))
+                    
+                    Spacer()
+                    
+                    Toggle("", isOn: $showHighlightedTextInput)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
             }
         }
     }

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -19,6 +19,7 @@ struct GeneralTab: View {
     @Default(.tetheredButtonHideAllApps) var tetheredButtonHideAllApps
     @Default(.tetheredButtonHideAllAppsTimerDate) var tetheredButtonHideAllAppsTimerDate
     @Default(.showHighlightedTextInput) var showHighlightedTextInput
+    @Default(.autoAddHighlightedTextToContext) var autoAddHighlightedTextToContext
     
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
     @State var isAnalyticsEnabled: Bool = PostHogSDK.shared.isOptOut() == false
@@ -430,6 +431,19 @@ struct GeneralTab: View {
                     Spacer()
                     
                     Toggle("", isOn: $showHighlightedTextInput)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
+            }
+            
+            VStack(alignment: .leading, spacing: 20) {
+                HStack {
+                    Text("Auto-add highlighted text to context.")
+                        .font(.system(size: 13))
+                    
+                    Spacer()
+                    
+                    Toggle("", isOn: $autoAddHighlightedTextToContext)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }


### PR DESCRIPTION
This is part 1 in a series of mini-PRs that tackle various aspects of the overarching text highlight context experience. 
Please review this first before reviewing all other text highlight PRs.

Part 2: https://github.com/synth-inc/onit/pull/340

### Summary

* The `inputView` can now be permanently shown or hidden.
* `inputView` is permanently hidden when closing it through the newly-added cross ("x") button in the `inputView` title section.
* Highlighted text now appears as a context tag in `FileRow`.
* Clicking on the highlighted text context item reveals the `inputView`.
* `inputView` showing/hiding can also be toggled in the settings "General" tab, under the "Highlighted Text" section.

### Parts (Pin 1 and Pin 2 have been closed)

1. `YOU ARE HERE`
2. https://github.com/synth-inc/onit/pull/340
3. https://github.com/synth-inc/onit/pull/342 (Pin 1)
4. https://github.com/synth-inc/onit/pull/343 (Pin 2)
5. https://github.com/synth-inc/onit/pull/341 (Pin 3)