### PR TITLE
Text Highlight: Auto-add To Context

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -603,13 +603,19 @@ class AccessibilityNotificationsManager: ObservableObject {
             
             screenResult.userInteraction.selectedText = nil
             PanelStateCoordinator.shared.state.pendingInput = nil
+            PanelStateCoordinator.shared.state.trackedPendingInput = nil
             return
         }
         
         screenResult.userInteraction.selectedText = selectedText
         
         let input = Input(selectedText: selectedText, application: currentSource ?? "")
-        PanelStateCoordinator.shared.state.pendingInput = input
+        
+        if Defaults[.autoAddHighlightedTextToContext] {
+            PanelStateCoordinator.shared.state.pendingInput = input
+        } else {
+            PanelStateCoordinator.shared.state.trackedPendingInput = input
+        }
     }
 
 	// MARK: Caret Position Handling

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -114,7 +114,9 @@ extension Defaults.Keys {
     static let lineHeight = Key<Double>("lineHeight", default: 1.5)
     static let voiceSilenceThreshold = Key<Float>("voiceSilenceThreshold", default: -40)
     static let voiceSpeechPassThreshold = Key<Double>("voiceSpeechPassThreshold", default: 0.7)
+        /// Highlighted Text
     static let showHighlightedTextInput = Key<Bool>("showHighlightedTextInput", default: true)
+    static let autoAddHighlightedTextToContext = Key<Bool>("autoAddHighlightedTextToContext", default: true)
 
     // Local model advanced options
     static let localKeepAlive = Key<String?>("localKeepAlive", default: nil)

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -130,6 +130,8 @@ class OnitPanelState: NSObject {
         }
     }
     
+    var trackedPendingInput: Input? = nil
+    
     var systemPromptId: String = SystemPrompt.outputOnly.id
     
     var imageUploads: [URL: UploadProgress] = [:]

--- a/macos/Onit/UI/Prompt/Files/FileRow.swift
+++ b/macos/Onit/UI/Prompt/Files/FileRow.swift
@@ -120,7 +120,8 @@ struct FileRow: View {
             FlowLayout(spacing: 6) {
                 PaperclipButton()
                 
-                addToContextButton
+                addHighlightedTextToContextButton
+                addWindowToContextButton
                 pendingWindowContextItems
                 highlightedTextContext
                 addedWindowContextItems
@@ -175,39 +176,46 @@ extension FileRow {
     }
     
     @ViewBuilder
-    private var addToContextButton: some View {
-        if accessibilityEnabled {
-            if let windowState = windowState,
-               let trackedPendingInput = windowState.trackedPendingInput
-            {
-                ghostContextTag(
-                    text: trackedPendingInput.selectedText,
-                    iconView: Image(.text).addIconStyles(iconSize: 14),
-                    tooltip: "Add Highlighted Text To Context"
-                ) {
+    private var addHighlightedTextToContextButton: some View {
+        if accessibilityEnabled,
+           Defaults[.autoContextFromHighlights],
+           let windowState = windowState,
+           let trackedPendingInput = windowState.trackedPendingInput
+        {
+            ghostContextTag(
+                text: trackedPendingInput.selectedText,
+                iconView: Image(.text).addIconStyles(iconSize: 14),
+                tooltip: "Add Highlighted Text To Context"
+            ) {
+                windowState.pendingInput = trackedPendingInput
+                windowState.trackedPendingInput = nil
+            }
+            .onChange(of: autoAddHighlightedTextToContext) { _, autoAddHighlightedText in
+                if autoAddHighlightedText {
                     windowState.pendingInput = trackedPendingInput
                     windowState.trackedPendingInput = nil
                 }
-                .onChange(of: autoAddHighlightedTextToContext) { _, autoAddHighlightedText in
-                    if autoAddHighlightedText {
-                        windowState.pendingInput = trackedPendingInput
-                        windowState.trackedPendingInput = nil
-                    }
-                }
-            } else if autoContextFromCurrentWindow,
-                      !(windowBeingAddedToContext || windowAlreadyInContext),
-                      let foregroundWindow = windowState?.foregroundWindow
-            {
-                let foregroundWindowName = WindowHelpers.getWindowName(window: foregroundWindow.element)
-                let iconBundleURL = WindowHelpers.getWindowAppBundleUrl(window: foregroundWindow.element)
-                
-                ghostContextTag(
-                    text: contextTagText,
-                    iconBundleURL: iconBundleURL,
-                    tooltip: "Add \(foregroundWindowName) Context"
-                ) {
-                    windowState?.addWindowToContext(window: foregroundWindow.element)
-                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var addWindowToContextButton: some View {
+        if accessibilityEnabled,
+           autoContextFromCurrentWindow,
+           !(windowBeingAddedToContext || windowAlreadyInContext),
+           let windowState = windowState,
+           let foregroundWindow = windowState.foregroundWindow
+        {
+            let foregroundWindowName = WindowHelpers.getWindowName(window: foregroundWindow.element)
+            let iconBundleURL = WindowHelpers.getWindowAppBundleUrl(window: foregroundWindow.element)
+            
+            ghostContextTag(
+                text: contextTagText,
+                iconBundleURL: iconBundleURL,
+                tooltip: "Add \(foregroundWindowName) Context"
+            ) {
+                windowState.addWindowToContext(window: foregroundWindow.element)
             }
         }
     }

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -19,6 +19,7 @@ struct GeneralTab: View {
     @Default(.tetheredButtonHideAllApps) var tetheredButtonHideAllApps
     @Default(.tetheredButtonHideAllAppsTimerDate) var tetheredButtonHideAllAppsTimerDate
     @Default(.showHighlightedTextInput) var showHighlightedTextInput
+    @Default(.autoAddHighlightedTextToContext) var autoAddHighlightedTextToContext
     
     @State var isLaunchAtStartupEnabled: Bool = SMAppService.mainApp.status == .enabled
     @State var isAnalyticsEnabled: Bool = PostHogSDK.shared.isOptOut() == false
@@ -430,6 +431,19 @@ struct GeneralTab: View {
                     Spacer()
                     
                     Toggle("", isOn: $showHighlightedTextInput)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
+            }
+            
+            VStack(alignment: .leading, spacing: 20) {
+                HStack {
+                    Text("Auto-add highlighted text to context.")
+                        .font(.system(size: 13))
+                    
+                    Spacer()
+                    
+                    Toggle("", isOn: $autoAddHighlightedTextToContext)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }


### PR DESCRIPTION
This is part 2 in a series of mini-PRs that tackle various aspects of the overarching text highlight context experience. 
Please review this after reviewing the [first PR](https://github.com/synth-inc/onit/pull/339).

### Summary

* This PR tackles the auto-adding nature of text highlights, namely togging the auto-adding of highlighted text into context on/off.
* Auto-adding behavior is set by the `autoAddHighlightedTextToContext` boolean property in the Defaults store (initialized to `true`).
* When `autoAddHighlightedTextToContext` is `true`, the app defaults to the original text highlight behavior.
* When `autoAddHighlightedTextToContext` is `false`, the highlighted text appears as the "ghost" button in `FileRow`, rather than automatically being added into context, and it takes precedence over the foreground window "ghost" button.
  * The "ghost" button tracks the highlighted text through the new `trackedPendingInput` state in `OnitPanelState`.
  * Clicking on the text highlight "ghost" button adds the highlighted text into context.
* The `autoAddHighlightedTextToContext` property can be toggled in the settings "General" tab, under the "Highlighted Text" section.
* Add a remove action to the highlighted text context tag, which sets `pendingInput` to `nil`.

### Parts

1. https://github.com/synth-inc/onit/pull/339
2. `YOU ARE HERE`
3. https://github.com/synth-inc/onit/pull/342 (Pin 1)
4. https://github.com/synth-inc/onit/pull/343 (Pin 2)
5. https://github.com/synth-inc/onit/pull/341 (Pin 3)