### PR TITLE
Fix cursor position issue in TextViewWrapper

### DIFF
--- a/macos/Onit/UI/Components/TextViewWrapper.swift
+++ b/macos/Onit/UI/Components/TextViewWrapper.swift
@@ -267,6 +267,9 @@ private class CustomTextView: NSTextView {
         autoresizingMask = [.width]
         maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         
+        // Set consistent text container inset to align cursor and placeholder
+        textContainerInset = NSSize(width: 0, height: 2)
+        
         typingAttributes = [
             .font: customFont,
             .foregroundColor: textColor
@@ -288,9 +291,11 @@ private class CustomTextView: NSTextView {
                 .foregroundColor: placeholderColor
             ]
             
-            let rect = NSRect(x: textContainerInset.width,
+            // Use the same positioning logic as the actual text to ensure cursor alignment
+            let lineFragmentPadding = textContainer?.lineFragmentPadding ?? 0
+            let rect = NSRect(x: textContainerInset.width + lineFragmentPadding,
                             y: textContainerInset.height,
-                            width: bounds.width - textContainerInset.width * 2,
+                            width: bounds.width - (textContainerInset.width + lineFragmentPadding) * 2,
                             height: bounds.height)
             
             placeholder.draw(in: rect, withAttributes: attributes)


### PR DESCRIPTION
Fixing the annoying issue where the cursor showed up in the middle of the 'N': 

Before:
<img width="243" height="142" alt="Screenshot 2025-07-18 at 1 44 49 PM" src="https://github.com/user-attachments/assets/6ee83398-ddf4-42c2-8796-27524cb29f46" />

After: 
<img width="460" height="155" alt="Screenshot 2025-07-18 at 1 43 22 PM" src="https://github.com/user-attachments/assets/5614147c-6b92-476f-9e74-71f0c8e77fc4" />
