### PR TITLE
Reset frames when panel jumps between monitors

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -45,6 +45,9 @@ extension PanelStatePinnedManager {
     }
     
     private func tetherHintClicked(screen: NSScreen) {
+        if state.panelOpened {
+            resetFramesOnAppChange()
+        }
         state.trackedScreen = screen
         launchPanel(for: state, createNewChat: true)
     }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Hint.swift
@@ -45,6 +45,8 @@ extension PanelStatePinnedManager {
     }
     
     private func tetherHintClicked(screen: NSScreen) {
+        // Reset frames when panel jumps between monitors to ensure windows on initial frame are properly reset
+        // Only call when panel is already open to avoid expensive UI work during initial launch
         if state.panelOpened {
             resetFramesOnAppChange()
         }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -183,7 +183,7 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     
     @objc private func spaceChangedReceived(notification: Notification) {
         guard state.panelOpened, let panel = state.panel, let screen = panel.screen else { return }
-        
+
         panel.orderFrontRegardless()
         
         resizeWindows(for: screen)


### PR DESCRIPTION
This fix addresses an edge case where the panel jumps from one monitor to another. In #324, I removed the call to ‘resetFramesOnAppChange’ from launchPanel() because it was generally unnecessary. This caused an issue when the panel jumped: the windows on the initial frame weren't getting reset. 

This change reintroduces the call to resetFramesOnAppChange, but only when the panel is already open. Since resetting the frames is expensive UI work, we want to avoid calling it whenever we can. 

With this change, the issue is resolved:

https://github.com/user-attachments/assets/6ba3f1c0-50a2-4b04-ba41-9ed43b5b6733

