### PR TITLE
Correctly resize window when panel has been shrunk

### DIFF
--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Resize.swift
@@ -9,15 +9,15 @@ import AppKit
 
 extension PanelStatePinnedManager {
     
-    func resizeWindows(for screen: NSScreen, isPanelResized: Bool = false) {
+    func resizeWindows(for screen: NSScreen, panelResizedOriginalWidth: CGFloat? = nil) {
         guard !isResizingWindows else { return }
 
         isResizingWindows = true
 
         // First, handle the bordering windows if they exists
-        let borderingWindows = findBorderingWindows().compactMap { $0 }
+        let borderingWindows = findBorderingWindows(panelResizedOriginalWidth: panelResizedOriginalWidth).compactMap { $0 }
         for window in borderingWindows {
-            resizeWindow(for: screen, window: window, isPanelResized: isPanelResized)
+            resizeWindow(for: screen, window: window, panelResizedOriginalWidth: panelResizedOriginalWidth)
         }
 
         // Then, handle all other windows, skipping the foregroundWindow if present
@@ -27,7 +27,7 @@ extension PanelStatePinnedManager {
                 continue
             }
             DispatchQueue.main.async {
-                self.resizeWindow(for: screen, window: window, isPanelResized: isPanelResized)
+                self.resizeWindow(for: screen, window: window, panelResizedOriginalWidth: panelResizedOriginalWidth)
             }
         }
         isResizingWindows = false
@@ -36,7 +36,7 @@ extension PanelStatePinnedManager {
         for screen: NSScreen,
         window: AXUIElement,
         windowFrameChanged: Bool = false,
-        isPanelResized: Bool = false
+        panelResizedOriginalWidth: CGFloat? = nil
     ) {
         // We pass when the panel is in the process of closing.
         if !shouldResizeWindows { return }
@@ -47,11 +47,13 @@ extension PanelStatePinnedManager {
            let windowFrame = window.getFrame() {
             
             let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
+            let resizeRadiusWidth = panelResizedOriginalWidth != nil ?  panelResizedOriginalWidth! - (TetheredButton.width / 2) + 1 : panelWidth
+            
             let screenFrame = screen.visibleFrame
             let availableSpace = screenFrame.maxX - windowFrame.maxX
             
             // Only resize when the window occupies the same space as the panel. 
-            if availableSpace < panelWidth {
+            if availableSpace < resizeRadiusWidth {
                 let overlapAmount = panelWidth - availableSpace
                 let newWidth = windowFrame.width - overlapAmount
                 let newFrame = CGRect(x: windowFrame.origin.x, y: windowFrame.origin.y, width: newWidth, height: windowFrame.height)
@@ -60,9 +62,18 @@ extension PanelStatePinnedManager {
         }
     }
     
-    func findBorderingWindows() -> [AXUIElement?] {
+    func findBorderingWindows(panelResizedOriginalWidth: CGFloat? = nil) -> [AXUIElement?] {
+        
         guard let screenFrame = self.attachedScreen?.visibleFrame ?? NSScreen.main?.visibleFrame else { return [] }
-        let panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
+        
+        var panelWidth = state.panelWidth - (TetheredButton.width / 2) + 1
+
+        // If we've made the panel smaller, than we actually want to look for bordering windows on the prior width
+        if let panelResizedOriginalWidth = panelResizedOriginalWidth,
+           panelResizedOriginalWidth > panelWidth {
+            panelWidth = panelResizedOriginalWidth - (TetheredButton.width / 2) + 1
+        }
+        
         let panelMinX = screenFrame.maxX - panelWidth
         let panelYMin = screenFrame.minY
         let panelYMax = screenFrame.maxY

--- a/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
+++ b/macos/Onit/UI/Panels/OnitRegularPanel+Move.swift
@@ -62,7 +62,7 @@ extension OnitRegularPanel {
             // In pinned mode, we need to resize all windows that overlap with the panel
             if let screen = state.trackedScreen ?? NSScreen.mouse,
                let pinnedManager = PanelStateCoordinator.shared.currentManager as? PanelStatePinnedManager {
-                pinnedManager.resizeWindows(for: screen, isPanelResized: true)
+                pinnedManager.resizeWindows(for: screen, panelResizedOriginalWidth: originalPanelWidth)
             }
         } else {
             // Normal mode - adjust a single active window


### PR DESCRIPTION
This fixes another bug related to resizing other windows in Pinned mode: specifically, when the panel is reduced in size. 

Our resizing logic detects windows that are bordering or underneath the current panel. When the panel is shrunk, the windows are no longer bordering the OnitPanel, so they don't get resized. This creates an annoying problem where windows are left hanging. 

https://github.com/user-attachments/assets/dcd52203-1831-4323-8466-7020495ffd5a

The solution is to pass the original panel width to the resize function after resizing the panel. Then, use the larger value between the original and current panel widths to decide on window resizing. This step should be performed both in the bordering windows and again in all the windows. 

After this change, the issue is resolved: 

https://github.com/user-attachments/assets/b214a178-8cfc-442c-8297-2283d3e50f3b


