### PR TITLE
make default tooltip display match new helper

### DIFF
--- a/macos/Onit/Helpers/TooltipHelpers.swift
+++ b/macos/Onit/Helpers/TooltipHelpers.swift
@@ -22,15 +22,10 @@ struct TooltipHelpers {
                         prompt: tooltipPrompt!,
                         shortcut: tooltipShortcut
                     ),
-                    tooltipConfig: tooltipConfig,
-                    delayStart: 0.4,
-                    delayEnd: 0
+                    tooltipConfig: tooltipConfig
                 )
             } else {
-                TooltipManager.shared.setTooltip(
-                    nil,
-                    delayEnd: 0
-                )
+                TooltipManager.shared.setTooltip(nil)
             }
         }
     }

--- a/macos/Onit/UI/Tooltip/TooltipManager.swift
+++ b/macos/Onit/UI/Tooltip/TooltipManager.swift
@@ -13,12 +13,15 @@ class TooltipManager {
     // MARK: - Singleton
     
     static let shared = TooltipManager()
-    
+    static let animationDuration: TimeInterval = 0.1
+
     // MARK: - Properties
     
     var tooltipWindow: NSWindow?
     var tooltipTask: Task<Void, Never>?
     var isTooltipActive = false
+    var animateOut = true
+    
     
     // MARK: - Functions
     
@@ -26,10 +29,11 @@ class TooltipManager {
         _ tooltip: Tooltip?,
         tooltipConfig: TooltipConfig? = nil,
         delayStart: Double = 0.4,
-        delayEnd: Double = 0.2
+        delayEnd: Double = 0.0,
+        animateOut: Bool = true
     ) {
         tooltipTask?.cancel()
-
+        self.animateOut = animateOut
         if let tooltip {
             if isTooltipActive {
                 resetTooltip(tooltip, tooltipConfig)
@@ -52,7 +56,7 @@ class TooltipManager {
                 try? await Task.sleep(for: .seconds(delayEnd))
                 if Task.isCancelled { return }
                 isTooltipActive = false
-                if delayEnd == 0 {
+                if self.animateOut {
                     hideWindowWithoutAnimation()
                 } else {
                     hideWindowWithAnimation()
@@ -123,7 +127,7 @@ class TooltipManager {
 
         NSAnimationContext.runAnimationGroup(
             { context in
-                context.duration = 0.3  // Adjust duration as needed
+                context.duration = TooltipManager.animationDuration 
                 context.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 tooltipWindow.animator().alphaValue = 0.0
             },

--- a/macos/Onit/UI/Tooltip/TooltipManager.swift
+++ b/macos/Onit/UI/Tooltip/TooltipManager.swift
@@ -25,7 +25,7 @@ class TooltipManager {
     func setTooltip(
         _ tooltip: Tooltip?,
         tooltipConfig: TooltipConfig? = nil,
-        delayStart: Double = 0,
+        delayStart: Double = 0.4,
         delayEnd: Double = 0.2
     ) {
         tooltipTask?.cancel()


### PR DESCRIPTION
I’ve noticed that some tooltips (such as on the ‘panel close’ button - aka TetheredButton.swift) appear immediately when you hover over them, which can be a bit irritating. Let's implement a standard delay across the app. We’re already using a delay in @lk340’s new tooltip helper, so let’s apply the same behavior to the .tooltip modifier. Unless a different delay is explicitly set, tooltips should appear with at least a 0.4-second delay.

@lk340, do you foresee any issues with this approach? Are there any elements where we’d want the tooltip to appear immediately instead?