### PR TITLE
Add setting that allows users to hide/show dock icon

### DIFF
--- a/macos/Onit/AppDelegate.swift
+++ b/macos/Onit/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by Kévin Naudin on 21/01/2025.
 //
 
+import Defaults
 import FirebaseCore
 import PostHog
 import SwiftUI
@@ -18,6 +19,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.appearance = darkAppearance
         }
         GIDSignIn.sharedInstance.restorePreviousSignIn()
+        
+        // Configure dock icon visibility based on user preference
+        configureDockIconVisibility()
+        
         // This is helpful for debugging the new user experience, but should never be committed!
         //        if let appDomain = Bundle.main.bundleIdentifier {
         //            UserDefaults.standard.removePersistentDomain(forName: appDomain)
@@ -36,5 +41,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         return true
+    }
+    
+    private func configureDockIconVisibility() {
+        let hideDockIcon = Defaults[.hideDockIcon]
+        
+        Task { @MainActor in
+            if hideDockIcon {
+                // Hide the dock icon - app becomes an accessory (background app)
+                NSApp.setActivationPolicy(.accessory)
+            } else {
+                // Show the dock icon - app becomes a regular app
+                NSApp.setActivationPolicy(.regular)
+            }
+        }
     }
 }

--- a/macos/Onit/AppDelegate.swift
+++ b/macos/Onit/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         GIDSignIn.sharedInstance.restorePreviousSignIn()
         
         // Configure dock icon visibility based on user preference
-        configureDockIconVisibility()
+        AppDelegate.configureDockIconVisibility()
         
         // This is helpful for debugging the new user experience, but should never be committed!
         //        if let appDomain = Bundle.main.bundleIdentifier {
@@ -43,7 +43,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
     
-    private func configureDockIconVisibility() {
+    static func configureDockIconVisibility() {
         let hideDockIcon = Defaults[.hideDockIcon]
         
         Task { @MainActor in

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -110,6 +110,7 @@ extension Defaults.Keys {
 
     // General settings
     static let launchOnStartupRequested = Key<Bool>("launchOnStartupRequested", default: false)
+    static let hideDockIcon = Key<Bool>("hideDockIcon", default: false)
     static let fontSize = Key<Double>("fontSize", default: 14.0)
     static let lineHeight = Key<Double>("lineHeight", default: 1.5)
     static let voiceSilenceThreshold = Key<Float>("voiceSilenceThreshold", default: -40)

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -15,6 +15,7 @@ struct GeneralTab: View {
     @Default(.usePinnedMode) var usePinnedMode
     @Default(.autoContextOnLaunchTethered) var autoContextOnLaunchTethered
     @Default(.stopMode) var stopMode
+    @Default(.hideDockIcon) var hideDockIcon
     @Default(.tetheredButtonHiddenApps) var tetheredButtonHiddenApps
     @Default(.tetheredButtonHideAllApps) var tetheredButtonHideAllApps
     @Default(.tetheredButtonHideAllAppsTimerDate) var tetheredButtonHideAllAppsTimerDate
@@ -114,9 +115,28 @@ struct GeneralTab: View {
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }
+                
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Hide dock icon")
+                            .font(.system(size: 13))
+                        Text("Show only the menu bar icon")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.gray200)
+                    }
+                    
+                    Spacer()
+                    
+                    Toggle("", isOn: $hideDockIcon)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
             }
             .onChange(of: isLaunchAtStartupEnabled, initial: false) { _, _ in
                 toggleLaunchAtStartup()
+            }
+            .onChange(of: hideDockIcon, initial: false) { _, _ in
+                toggleDockIconVisibility()
             }
         }
     }
@@ -666,6 +686,20 @@ struct GeneralTab: View {
     private func stopTimerUpdateTask() {
         timerUpdateTask?.cancel()
         timerUpdateTask = nil
+    }
+    
+    private func toggleDockIconVisibility() {
+        let hideDockIcon = Defaults[.hideDockIcon]
+        
+        Task { @MainActor in
+            if hideDockIcon {
+                // Hide the dock icon - app becomes an accessory (background app)
+                NSApp.setActivationPolicy(.accessory)
+            } else {
+                // Show the dock icon - app becomes a regular app
+                NSApp.setActivationPolicy(.regular)
+            }
+        }
     }
 }
 

--- a/macos/Onit/UI/Settings/GeneralTab.swift
+++ b/macos/Onit/UI/Settings/GeneralTab.swift
@@ -115,28 +115,9 @@ struct GeneralTab: View {
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }
-                
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Hide dock icon")
-                            .font(.system(size: 13))
-                        Text("Show only the menu bar icon")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.gray200)
-                    }
-                    
-                    Spacer()
-                    
-                    Toggle("", isOn: $hideDockIcon)
-                        .toggleStyle(.switch)
-                        .controlSize(.small)
-                }
             }
             .onChange(of: isLaunchAtStartupEnabled, initial: false) { _, _ in
                 toggleLaunchAtStartup()
-            }
-            .onChange(of: hideDockIcon, initial: false) { _, _ in
-                toggleDockIconVisibility()
             }
         }
     }
@@ -253,11 +234,33 @@ struct GeneralTab: View {
                         }
                     }
                 }
+                
+                // Hide dock icon section
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Hide dock icon")
+                                .font(.system(size: 13))
+                            Text("Show only the menu bar icon")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.gray200)
+                        }
+                        
+                        Spacer()
+                        
+                        Toggle("", isOn: $hideDockIcon)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                }
+                .onChange(of: hideDockIcon, initial: false) { _, _ in
+                    toggleDockIconVisibility()
+                }
             }
         } header: {
             HStack {
                 Image(systemName: "rectangle.on.rectangle")
-                Text("Display Mode")
+                Text("Display")
             }
         }
     }
@@ -689,17 +692,7 @@ struct GeneralTab: View {
     }
     
     private func toggleDockIconVisibility() {
-        let hideDockIcon = Defaults[.hideDockIcon]
-        
-        Task { @MainActor in
-            if hideDockIcon {
-                // Hide the dock icon - app becomes an accessory (background app)
-                NSApp.setActivationPolicy(.accessory)
-            } else {
-                // Show the dock icon - app becomes a regular app
-                NSApp.setActivationPolicy(.regular)
-            }
-        }
+        AppDelegate.configureDockIconVisibility()
     }
 }
 


### PR DESCRIPTION
Requested in #316  - this PR allows users to hide/show the dock icon: 

https://github.com/user-attachments/assets/893f0c9d-d130-43fc-b0a4-7701b3e7058d

Under the hood, this toggles whether the app's 'ActivationPolicy' is in .accessory or .regular mode. 

I am concerned that switching it to .accessory will have some unforeseen consequences. @Niduank - you handled switching us from .accessory to .regular before. Did you have to change anything to make it work? 

 We should all use the app in accessory mode for a while to ensure everything is working correctly before releasing it.