### PR TITLE
Add ability to show/hide local models

### DIFF
--- a/macos/Onit/AppState.swift
+++ b/macos/Onit/AppState.swift
@@ -115,10 +115,24 @@ class AppState: NSObject, SPUUpdaterDelegate {
             let localModel = Defaults[.localModel]
 
             Defaults[.availableLocalModels] = models
+            
+            // Initialize visible local models if empty (first time or after being cleared)
+            if Defaults[.visibleLocalModels].isEmpty && !models.isEmpty {
+                Defaults[.visibleLocalModels] = Set(models)
+            } else {
+                // Update visible models to only include currently available models
+                let currentVisible = Defaults[.visibleLocalModels]
+                Defaults[.visibleLocalModels] = currentVisible.intersection(Set(models))
+            }
+            
             if models.isEmpty {
                 Defaults[.localModel] = nil
             } else if localModel == nil || !models.contains(localModel!) {
-                Defaults[.localModel] = models[0]
+                // Choose from visible models if available
+                let visibleModels = Defaults[.visibleLocalModels]
+                if let firstVisibleModel = visibleModels.first {
+                    Defaults[.localModel] = firstVisibleModel
+                }
             }
             localFetchFailed = false
 

--- a/macos/Onit/Data/Persistence/Defaults.swift
+++ b/macos/Onit/Data/Persistence/Defaults.swift
@@ -79,6 +79,7 @@ extension Defaults.Keys {
 
     // Stores unique model identifiers in the format "provider-id" or "customProviderName-id" for custom providers
     static let visibleModelIds = Key<Set<String>>("visibleModelIds", default: Set([]))
+    static let visibleLocalModels = Key<Set<String>>("visibleLocalModels", default: Set([]))
     static let hasPerformedModelIdMigration = Key<Bool>(
         "hasPerformedModelIdMigration", default: false)
 

--- a/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
+++ b/macos/Onit/UI/Prompt/Selection/ModelSelectionView.swift
@@ -16,6 +16,7 @@ struct ModelSelectionView: View {
     @Default(.localModel) var localModel
     @Default(.remoteModel) var remoteModel
     @Default(.availableLocalModels) var availableLocalModels
+    @Default(.visibleLocalModels) var visibleLocalModels
     
     private var open: Binding<Bool>
     init(open: Binding<Bool>) { self.open = open }
@@ -33,10 +34,11 @@ struct ModelSelectionView: View {
     }
     
     private var filteredLocalModels: [String] {
+        let visibleModels = availableLocalModels.filter { visibleLocalModels.contains($0) }
         if searchQuery.isEmpty {
-            return availableLocalModels
+            return visibleModels
         } else {
-            return availableLocalModels.filter {
+            return visibleModels.filter {
                 $0.localizedCaseInsensitiveContains(searchQuery)
             }
         }

--- a/macos/Onit/UI/Settings/Models/LocalModelPicker.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelPicker.swift
@@ -10,11 +10,16 @@ import SwiftUI
 
 struct LocalModelPicker: View {
     @Default(.availableLocalModels) var availableLocalModels
+    @Default(.visibleLocalModels) var visibleLocalModels
     @Default(.localModel) var localModel
+    
+    private var visibleModels: [String] {
+        availableLocalModels.filter { visibleLocalModels.contains($0) }
+    }
 
     var body: some View {
         Picker("Model", selection: $localModel) {
-            ForEach(availableLocalModels, id: \.self) { localModel in
+            ForEach(visibleModels, id: \.self) { localModel in
                 Text(localModel)
                     .tag(localModel)
             }

--- a/macos/Onit/UI/Settings/Models/LocalModelToggle.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelToggle.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct LocalModelToggle: View {
     @Default(.visibleLocalModels) var visibleLocalModels
     @Default(.localModel) var localModel
-    @Default(.mode) var mode
+    @Default(.visibleLocalModels) var visibleLocalModels
+    @Default(.localModel) var localModel
 
     let modelName: String
 

--- a/macos/Onit/UI/Settings/Models/LocalModelToggle.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelToggle.swift
@@ -1,0 +1,49 @@
+//
+//  LocalModelToggle.swift
+//  Onit
+//
+//  Created by Assistant on 1/13/25.
+//
+
+import Defaults
+import SwiftUI
+
+struct LocalModelToggle: View {
+    @Default(.visibleLocalModels) var visibleLocalModels
+    @Default(.localModel) var localModel
+    @Default(.mode) var mode
+
+    let modelName: String
+
+    var isOn: Binding<Bool> {
+        Binding {
+            visibleLocalModels.contains(modelName)
+        } set: { isOn in
+            if isOn {
+                visibleLocalModels.insert(modelName)
+            } else {
+                visibleLocalModels.remove(modelName)
+                
+                // Handle edge case: if the currently selected local model is being deselected
+                if modelName == localModel {
+                    // Try to find another visible local model to select
+                    if let firstVisibleModel = visibleLocalModels.first {
+                        localModel = firstVisibleModel
+                    } else {
+                        // No visible local models left, clear the selection
+                        localModel = nil
+                    }
+                }
+            }
+        }
+    }
+
+    var body: some View {
+        Toggle(isOn: isOn) {
+            Text(modelName)
+                .font(.system(size: 13))
+                .fontWeight(.regular)
+                .opacity(0.85)
+        }
+    }
+} 

--- a/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
+++ b/macos/Onit/UI/Settings/Models/LocalModelsSection.swift
@@ -375,13 +375,8 @@ struct LocalModelsSection: View {
             GroupBox {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(availableLocalModels, id: \.self) { model in
-                        Toggle(isOn: .constant(true)) {
-                            Text(model)
-                                .font(.system(size: 13))
-                                .fontWeight(.regular)
-                                .opacity(0.85)
-                        }
-                        .frame(height: 36)
+                        LocalModelToggle(modelName: model)
+                            .frame(height: 36)
                     }
                 }
                 .padding(.vertical, -4)


### PR DESCRIPTION
Requested in #303

We currently don't support a way to show/hide local models. This PR introduces a "visibleLocalModels' default, to match our 'visibleModelIDs" that we use for remote models. Now, users can select and deselect models in settings, the same way they can for remote models 

Demo: 

https://github.com/user-attachments/assets/f6758363-b9ba-4f2d-8ddf-2d9262900dcb



