### PR TITLE
Fix scrolling for custom model providers

### DIFF
--- a/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
+++ b/macos/Onit/UI/Settings/Models/CustomProvider/CustomProviderRow.swift
@@ -83,7 +83,7 @@ struct CustomProviderRow: View {
                             .padding(.horizontal, 4)
 
                         ScrollView {
-                            VStack(alignment: .leading, spacing: 0) {
+                            LazyVStack(alignment: .leading, spacing: 0) {
                                 ForEach(filteredProviderModels, id: \.self) { model in
                                     ModelToggle(aiModel: model)
                                         .frame(height: 36)


### PR DESCRIPTION
I noticed this issue while reviewing #353: For custom model providers, like OpenRouter, there are often lots' of models (almost 200 in this case). That makes our 'models' list laggy and unusable (I'm scrolling the whole time, in this video): 

https://github.com/user-attachments/assets/58200bcb-bb07-4ffd-bc9a-6bf52845855a


We need to be using a LazyVStack instead, which makes scrolling snappy and responsive:

https://github.com/user-attachments/assets/c3962362-cd66-49fe-abc4-5fcfcdff9b07

