### PR TITLE
Dont show system prompt on hover

### DIFF
--- a/macos/Onit/UI/Content/ToolbarLeft.swift
+++ b/macos/Onit/UI/Content/ToolbarLeft.swift
@@ -59,11 +59,6 @@ struct ToolbarLeft: View {
             state?.systemPromptState.shouldShowSelection = true
             state?.systemPromptState.shouldShowSystemPrompt = true
         }
-        .onHover(perform: { isHovered in
-            if isHovered && state?.currentChat?.systemPrompt == nil && state?.systemPromptState.shouldShowSystemPrompt != true {
-                state?.systemPromptState.shouldShowSystemPrompt = true
-            }
-        })
     }
 }
 


### PR DESCRIPTION
Elise requested that we only display the system prompt view when the user clicks the icon, rather than when they hover over it. This avoids accidental activation due to unintended hover.