### PR TITLE
Use a stored partial response

### DIFF
--- a/macos/Onit/UI/Chat/ChatScrollView.swift
+++ b/macos/Onit/UI/Chat/ChatScrollView.swift
@@ -245,18 +245,18 @@ class ChatScrollView: NSScrollView {
 struct ChatScrollViewRepresentable: NSViewRepresentable {
     @Binding var hasUserManuallyScrolled: Bool
     
-    let streamedResponse: String
+    let shouldStartAutoScroll: Bool
     let currentChat: Any?
     let content: AnyView
     
     init<Content: View>(
         hasUserManuallyScrolled: Binding<Bool>,
-        streamedResponse: String,
+        shouldStartAutoScroll: Bool,
         currentChat: Any?,
         @ViewBuilder content: () -> Content
     ) {
         self._hasUserManuallyScrolled = hasUserManuallyScrolled
-        self.streamedResponse = streamedResponse
+        self.shouldStartAutoScroll = shouldStartAutoScroll
         self.currentChat = currentChat
         self.content = AnyView(content())
     }
@@ -287,8 +287,6 @@ struct ChatScrollViewRepresentable: NSViewRepresentable {
     }
     
     func updateNSView(_ nsView: ChatScrollView, context: Self.Context) {
-        let shouldStartAutoScroll = !streamedResponse.isEmpty
-        
         if hasUserManuallyScrolled {
             nsView.stopAutoScrolling()
         } else if shouldStartAutoScroll {

--- a/macos/Onit/UI/Chat/ChatView.swift
+++ b/macos/Onit/UI/Chat/ChatView.swift
@@ -35,7 +35,13 @@ struct ChatView: View {
                 ZStack(alignment: .bottom) {
                     ChatScrollViewRepresentable(
                         hasUserManuallyScrolled: $hasUserManuallyScrolled,
-                        streamedResponse: state?.streamedResponse ?? "",
+                        shouldStartAutoScroll: {
+                            if let prompt = state?.generatingPrompt,
+                               let response = prompt.currentResponse {
+                                return response.isPartial && !response.text.isEmpty
+                            }
+                            return false
+                        }(),
                         currentChat: state?.currentChat
                     ) {
                         VStack(alignment: .leading, spacing: 0) {

--- a/macos/Onit/UI/Panels/State/OnitPanelState.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState.swift
@@ -150,9 +150,6 @@ class OnitPanelState: NSObject {
     var generatingPromptPriorState: GenerationState?
     var generationStopped: Bool = false
     
-    /// Don't leave this text empty to ensure the first scroll works.
-    var streamedResponse: String = " "
-    
     // Web search states
     var webSearchError: Error? = nil
     var isSearchingWeb: [PersistentIdentifier: Bool] = [:]

--- a/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
+++ b/macos/Onit/UI/Prompt/Generated/GeneratedContentView.swift
@@ -19,13 +19,10 @@ struct GeneratedContentView: View {
 
     var prompt: Prompt
     
-    var textToRead: String {
-        let safeIndex = prompt.safeGenerationIndex
-        guard safeIndex >= 0 && safeIndex < prompt.sortedResponses.count else {
-            return ""
-        }
-        let response = prompt.sortedResponses[safeIndex]
-        return response.isPartial ? (state?.streamedResponse ?? "") : response.text
+    private var textToRead: String {
+        guard let response = prompt.currentResponse else { return "" }
+        
+        return response.text
     }
     
     var configuration: LLMStreamConfiguration {

--- a/macos/Onit/UI/Prompt/PromptView.swift
+++ b/macos/Onit/UI/Prompt/PromptView.swift
@@ -26,7 +26,7 @@ struct PromptView: View {
             switch prompt.generationState {
             case .generating:
                 GeneratingView(prompt: prompt)
-            case .streaming,.done:
+            case .streaming, .done:
                 GeneratedView(prompt: prompt)
             default:
                 EmptyView()

--- a/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
+++ b/macos/Onit/UI/QuickEdit/QuickEditResponseView.swift
@@ -46,14 +46,10 @@ struct QuickEditResponseView: View {
         self.isEditableElement = isEditableElement
     }
     
-    private var textToDisplay: String {
-        guard let state = state else { return "" }
-        guard !prompt.responses.isEmpty else {
-            return state.streamedResponse
-        }
+    private var displayText: String {
+        guard let response = prompt.currentResponse else { return "" }
         
-        let response = prompt.sortedResponses[prompt.generationIndex]
-        return response.isPartial ? state.streamedResponse : response.text
+        return response.text
     }
     
     private var configuration: LLMStreamConfiguration {
@@ -110,7 +106,7 @@ extension QuickEditResponseView {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
             case .streaming, .done:
-                if textToDisplay.isEmpty && !(state?.isSearchingWeb[prompt.id] ?? false) {
+                if displayText.isEmpty && !(state?.isSearchingWeb[prompt.id] ?? false) {
                     HStack {
                         Spacer()
                         QLImage("loader_rotated-200")
@@ -169,7 +165,7 @@ extension QuickEditResponseView {
             ScrollView {
                 VStack(spacing: 0) {
                     LLMStreamView(
-                        text: textToDisplay,
+                        text: displayText,
                         configuration: configuration,
                         onUrlClicked: onUrlClicked,
                         onCodeAction: codeAction)
@@ -212,7 +208,7 @@ extension QuickEditResponseView {
             .onAppear {
                 scrollProxy = proxy
             }
-            .onChange(of: textToDisplay) { oldValue, newValue in
+            .onChange(of: displayText) { oldValue, newValue in
                 if newValue.count > oldValue.count &&
                     prompt.generationState == .streaming &&
                     !hasUserManuallyScrolled {


### PR DESCRIPTION
### Context 
Our old system wasn’t optimized for handling tools during streaming.
We were using a partial response object that remained empty and was never saved to the database, alongside a separate streamedResponse property used only for streaming management.
At the end of generation, the partial response was replaced by the final one, which was then persisted to the database.

### This PR aims to fix that

1. We now create a real partial response, which is incrementally filled as streaming progresses.
2. The partial response is saved to the database upon creation. While it’s being filled, updates happen in memory, and we persist the changes once generation completes.
3. The streamedResponse variable is no longer needed.
4. We'll now be able to modify the Response model during generation in the DiffView since it already exists in the database.

### Affected features
- Chat Generation
- Stop generation
- Streaming in Chat and QuickEdit
- Chat auto-scroll