### PR TITLE
Feature/mouse notification manager

### DIFF
--- a/macos/Onit/Keystrokes/KeycodeTranslator.swift
+++ b/macos/Onit/Keystrokes/KeycodeTranslator.swift
@@ -2,252 +2,214 @@
 //  KeycodeTranslator.swift
 //  Onit
 //
-//  Created by Timothy Lenardo on 7/24/25.
+//  Created by Timothy Lenardo on 7/25/25.
 //
 
-import Foundation
 import AppKit
+import CoreText
+import Foundation
+//import UIKit
 
-@MainActor
-final class KeyCodeTranslator {
-    static let shared = KeyCodeTranslator()
+// Job structure to hold event and callback
+private struct KeyEventJob {
+    let event: NSEvent
+    let callback: (String?) -> Void
+    let completion: (String?) -> Void
+}
 
-    private let keyCodeMap: [Int64: String] = [
-        // Letters
-        0: "a", 1: "s", 2: "d", 3: "f", 4: "h", 5: "g", 6: "z", 7: "x", 8: "c", 9: "v",
-        11: "b", 12: "q", 13: "w", 14: "e", 15: "r", 16: "y", 17: "t", 18: "1", 19: "2",
-        20: "3", 21: "4", 22: "6", 23: "5", 24: "=", 25: "9", 26: "7", 27: "-", 28: "8",
-        29: "0", 30: "]", 31: "o", 32: "u", 33: "[", 34: "i", 35: "p", 37: "l", 38: "j",
-        39: "'", 40: "k", 41: ";", 42: "\\", 43: ",", 44: "/", 45: "n", 46: "m", 47: ".",
-        50: "`",
+// Lookup table mapping special key keyCodes to human-readable names
+private let specialKeyLookup: [UInt16: String] = [
+    // Arrow keys
+    123: "left",
+    124: "right",
+    125: "down",
+    126: "up",
 
-        // Numbers
-        82: "0", 83: "1", 84: "2", 85: "3", 86: "4", 87: "5", 88: "6", 89: "7", 91: "8", 92: "9",
+    // Function keys (F1-F20)
+    122: "f1",
+    120: "f2",
+    99:  "f3",
+    118: "f4",
+    96:  "f5",
+    97:  "f6",
+    98:  "f7",
+    100: "f8",
+    101: "f9",
+    109: "f10",
+    103: "f11",
+    111: "f12",
+    105: "f13",
+    107: "f14",
+    113: "f15",
+    106: "f16",
+    64:  "f17",
+    79:  "f18",
+    80:  "f19",
+    90:  "f20",
 
-        // Function keys
-        122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5", 97: "F6", 98: "F7", 100: "F8",
-        101: "F9", 109: "F10", 103: "F11", 111: "F12", 105: "F13", 107: "F14", 113: "F15",
-        106: "F16", 64: "F17", 79: "F18", 80: "F19", 90: "F20",
+    // Keys above arrow keys
+    115: "home",
+    119: "end",
+    116: "pageup",
+    121: "pagedown",
+    114: "help",
+    117: "forward_delete",
 
-        // Special keys
-        36: "return", 48: "tab", 49: "space", 51: "delete", 53: "escape",
-        76: "enter", 117: "forward_delete", 119: "end", 115: "home",
-        116: "page_up", 121: "page_down", 123: "left", 124: "right", 125: "down", 126: "up",
+    // Other special keys
+    53:  "escape",
+    51:  "delete",
+    36:  "return",
+    48:  "tab",
+    76:  "enter", // Keypad enter
 
-        // Keypad
-        65: "keypad_.", 67: "keypad_*", 69: "keypad_+", 71: "keypad_clear", 75: "keypad_/",
-        78: "keypad_-", 81: "keypad_=",
+    // Miscellaneous
+    72:  "volume_up",
+    73:  "volume_down",
+    74:  "mute",
+    39:  "caps_lock",
+    63:  "fn"
+]
 
-        // Other
-        114: "help", 72: "volume_up", 73: "volume_down", 74: "mute"
-    ]
 
-    private let shiftedKeyMap: [Int64: String] = [
-        // Shifted letters become uppercase automatically
-        // Shifted numbers and symbols
-        18: "!", 19: "@", 20: "#", 21: "$", 23: "%", 22: "^", 26: "&", 28: "*", 25: "(", 29: ")",
-        27: "_", 24: "+", 33: "{", 30: "}", 42: "|", 41: ":", 39: "\"", 43: "<", 47: ">", 44: "?",
-        50: "~"
-    ]
-
-    private init() {}
-
-    func translateKeyCode(_ keyCode: Int64,
-                         isShiftPressed: Bool = false,
-                         isCommandPressed: Bool = false,
-                         isControlPressed: Bool = false,
-                         isOptionPressed: Bool = false) -> String {
-
-        var modifiers: [String] = []
-        if isControlPressed { modifiers.append("ctrl") }
-        if isOptionPressed { modifiers.append("opt") }
-        if isCommandPressed { modifiers.append("cmd") }
-
-        // Only add shift to modifiers if it doesn't naturally transform the character
-        // (we'll determine this after processing the key)
-
-        var keyString: String
-
-        // Handle shifted characters
-        let hasNaturalShiftTransformation: Bool
-        if isShiftPressed {
-            if let shiftedChar = shiftedKeyMap[keyCode] {
-                keyString = shiftedChar
-                hasNaturalShiftTransformation = true // shift produces a different character naturally
-            } else if let normalChar = keyCodeMap[keyCode] {
-                // For letters, make them uppercase when shift is pressed
-                if normalChar.count == 1 && normalChar.first!.isLetter {
-                    keyString = normalChar.uppercased()
-                    hasNaturalShiftTransformation = true // shift produces uppercase naturally
-                } else {
-                    keyString = normalChar
-                    hasNaturalShiftTransformation = false // shift doesn't change the character
+final class KeycodeTranslator: NSResponder, Sendable {
+    static let shared = KeycodeTranslator()
+    
+    private var jobQueue: [KeyEventJob] = []
+    private var isProcessing = false
+    private let processingQueue = DispatchQueue(label: "com.onit.keycode-translator", qos: .userInteractive)
+    
+    private override init() {
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// Returns the character for the given NSEvent, considering current modifiers, via a callback.
+    func characterForEvent(_ event: NSEvent, callback: @escaping (String?) -> Void) {
+        let job = KeyEventJob(
+            event: event,
+            callback: callback,
+            completion: { [weak self] result in
+                // Execute callback on main queue since it might update UI
+                DispatchQueue.main.async {
+                    callback(result)
                 }
-            } else {
-                keyString = "unknown(\(keyCode))"
-                hasNaturalShiftTransformation = false
+                // Continue processing next job
+                self?.processNextJob()
             }
-        } else {
-            keyString = keyCodeMap[keyCode] ?? "unknown(\(keyCode))"
-            hasNaturalShiftTransformation = false
-        }
-
-        // Add shift to modifiers only if it doesn't naturally transform the character
-        if isShiftPressed && !hasNaturalShiftTransformation {
-            modifiers.append("shift")
-        }
-
-        // Combine modifiers with the key
-        if modifiers.isEmpty {
-            return keyString
-        } else {
-            return modifiers.joined(separator: "+") + "+" + keyString
+        )
+        
+        jobQueue.append(job)
+        
+        // Start processing if not already running
+        if !isProcessing {
+            processNextJob()
         }
     }
+    
+    private func processNextJob() {
+        guard !jobQueue.isEmpty else {
+            isProcessing = false
+            return
+        }
+        
+        isProcessing = true
+        let job = jobQueue.removeFirst()
+        
+        // Process on background queue to avoid blocking main queue
+        processingQueue.async { [weak self] in
+            // Switch back to main queue for interpretKeyEvents since it needs UI context
+            DispatchQueue.main.async {
+                self?.currentJob = job
+                self?.interpretKeyEvents([job.event])
+            }
+        }
+    }
+    
+    // Track current job being processed
+    private var currentJob: KeyEventJob?
 
-    // Determines if a key combination modifies text field contents (adds or removes characters)
-    func keyProducesOutput(_ keyCode: Int64,
-                          isShiftPressed: Bool = false,
-                          isCommandPressed: Bool = false,
-                          isControlPressed: Bool = false,
-                          isOptionPressed: Bool = false) -> Bool {
+    // MARK: NSResponder
+    
+    override func insertText(_ insertString: Any) {
+        guard let job = currentJob else { return }
+        
+        // Convert insertString to String
+        let result: String?
+        if let string = insertString as? String {
+            result = string
+        } else if let attributedString = insertString as? NSAttributedString {
+            result = attributedString.string
+        } else {
+            result = String(describing: insertString)
+        }
+        // Complete the job
+        job.completion(result)
+        currentJob = nil
+    }
+    
+    override func doCommand(by selector: Selector) {
+        guard let job = currentJob else { return }
+    
+        // Concatenate any modifiers with the 'charactersIgnoringModifiers' field of the NSEvent.
+        let event = job.event
+        var keyNoModifiers = event.charactersIgnoringModifiers ?? ""
+        
+        // When there's no corresponding glyph, it generally means it's a special key.
+        if !fontHasGlyph(for: keyNoModifiers.utf16) {
+            let keyCode = event.keyCode
+            let specialKey = specialKeyLookup[keyCode]
+            if let specialKey = specialKey {
+                keyNoModifiers = specialKey
+            } else {
+                let unicodeScalar = event.charactersIgnoringModifiers?.unicodeScalars.first
+                if let unicodeScalar = unicodeScalar {
+                    keyNoModifiers = "unknown(\(keyCode), U+\(String(format: "%04X", unicodeScalar.value)))"
+                } else {
+                    keyNoModifiers = "unknown(\(keyCode), noUnicodeScalar)"
+                }
+            }
+        }
+        
+        var modifiers: [String] = []
+        if event.modifierFlags.contains(.control) { modifiers.append("ctrl") }
+        if event.modifierFlags.contains(.option) { modifiers.append("opt") }
+        if event.modifierFlags.contains(.command) { modifiers.append("cmd") }
+        if event.modifierFlags.contains(.shift) { modifiers.append("shift") }
+        let result: String
+        
+            
+        if modifiers.isEmpty {
+                        result = keyNoModifiers
+        } else {
+            result = modifiers.joined(separator: "+") + "+" + keyNoModifiers
+        }        
+        // Complete the job
+        job.completion(result)
+        currentJob = nil
+    }
+    
+    func fontHasGlyph(for utf16: String.UTF16View) -> Bool {
+        // Use NSFont on macOS instead of UIFont
+        let nsFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let ctFont = CTFontCreateWithName(nsFont.fontName as CFString, nsFont.pointSize, nil)
+        var glyphs = [CGGlyph](repeating: 0, count: utf16.count)
+        
+        // Convert UTF16 code units to glyphs
+        let foundGlyphs = CTFontGetGlyphsForCharacters(ctFont, Array(utf16), &glyphs, utf16.count)
 
-        // Keys that never modify text field contents regardless of modifiers
-        let nonOutputKeys: Set<Int64> = [
-            // Arrow keys
-            123, 124, 125, 126, // left, right, down, up
-
-            // Function keys
-            122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, // F1-F12
-            105, 107, 113, 106, 64, 79, 80, 90, // F13-F20
-
-            // Navigation keys (cursor movement only)
-            119, 115, 116, 121, // end, home, page_up, page_down
-            53, // escape
-            114, // help
-
-            // Volume controls
-            72, 73, 74, // volume_up, volume_down, mute
-
-            // Keypad operations (these perform actions rather than insert characters)
-            67, 69, 71, 75, 78, 81 // keypad_*, keypad_+, keypad_clear, keypad_/, keypad_-, keypad_=
-        ]
-
-        // If it's a non-output key, it never produces output
-        if nonOutputKeys.contains(keyCode) {
+        // Check if glyph(s) found and not 0 (0 indicates missing glyph)
+        if foundGlyphs {
+            for glyph in glyphs {
+                if glyph == 0 {
+                    return false
+                }
+            }
+            return true
+        } else {
             return false
         }
-
-        // Keys that produce output or modify text field contents
-        let outputKeys: Set<Int64> = [
-            // Letters
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, // a-t
-            31, 32, 34, 35, 37, 38, 40, 45, 46, // o, u, i, p, l, j, k, n, m
-
-            // Numbers (main keyboard)
-            18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, // 1-0 and symbols
-
-            // Numbers (keypad)
-            82, 83, 84, 85, 86, 87, 88, 89, 91, 92, // keypad 0-9
-            65, // keypad decimal point
-
-            // Symbols and punctuation
-            33, 39, 41, 42, 43, 44, 47, 50, // [, ', ;, \, ,, /, ., `
-
-            // Special output keys
-            36, 48, 49, 76, // return, tab, space, enter
-
-            // Delete keys (modify text field by removing characters)
-            51, 117 // delete, forward_delete
-        ]
-
-        // If it's a known output key, check for modifier restrictions
-        if outputKeys.contains(keyCode) {
-            // Command combinations: some DO modify text content (cut, paste, undo, etc.)
-            if isCommandPressed {
-                // Command keys that modify text content
-                let textModifyingCommandKeys: Set<Int64> = [
-                    9, // v - paste (adds text from clipboard)
-                    7, // x - cut (removes selected text)
-                    6, // z - undo (can add or remove text)
-                    16, // y - redo (can add or remove text, if app uses Cmd+Y for redo)
-                    0, // a - select all (when followed by typing, replaces all text)
-                ]
-
-                // Handle Cmd+Shift+Z for redo (more common than Cmd+Y)
-                if isShiftPressed && keyCode == 6 { // z
-                    return true
-                }
-
-                return textModifyingCommandKeys.contains(keyCode)
-            }
-
-            // Control combinations: many DO modify text content in macOS (Emacs-style bindings)
-            if isControlPressed {
-                // Control keys that modify text content (based on macOS default Emacs bindings)
-                let textModifyingControlKeys: Set<Int64> = [
-                    4, // h - delete character to left (like backspace)
-                    2, // d - delete character to right (like forward delete)
-                    40, // k - delete from cursor to end of line
-                    32, // u - delete from cursor to beginning of line (if supported)
-                    13, // w - delete word backward (if supported)
-                    17, // t - transpose characters
-                    31, // o - insert new line
-                    16, // y - yank from kill buffer
-                    // Delete keys work with Control too
-                    51, 117 // delete, forward_delete
-                ]
-
-                return textModifyingControlKeys.contains(keyCode)
-            }
-
-            // Shift and Option with output keys still produce output (shifted chars, accented chars)
-            return true
-        }
-
-        // For unknown keys, assume they don't modify text field contents
-        return false
-    }
-
-    // Convenience method for when you have all the modifier states
-    func translateKeyCodeWithModifiers(_ keyCode: Int64,
-                                     modifierStates: (command: Bool, control: Bool, shift: Bool, option: Bool)) -> String {
-        return translateKeyCode(keyCode,
-                              isShiftPressed: modifierStates.shift,
-                              isCommandPressed: modifierStates.command,
-                              isControlPressed: modifierStates.control,
-                              isOptionPressed: modifierStates.option)
-    }
-
-    // Convenience method for when you have all the modifier states
-    func keyProducesOutputWithModifiers(_ keyCode: Int64,
-                                       modifierStates: (command: Bool, control: Bool, shift: Bool, option: Bool)) -> Bool {
-        return keyProducesOutput(keyCode,
-                               isShiftPressed: modifierStates.shift,
-                               isCommandPressed: modifierStates.command,
-                               isControlPressed: modifierStates.control,
-                               isOptionPressed: modifierStates.option)
-    }
-
-    /// Converts a key name string to its actual character representation for keystroke tracking
-    /// This is used to convert strings like "space", "tab", etc. back to their actual characters
-    func keyNameToCharacter(_ keyName: String) -> String {
-        switch keyName {
-        case "space":
-            return " "
-        case "tab":
-            return "\t"
-        case "return", "enter":
-            return "\n"
-        default:
-            // For everything else, return as-is (letters, numbers, symbols)
-            return keyName
-        }
-    }
-
-    /// Converts an array of keystroke strings to actual characters for text comparison
-    /// This joins keystrokes and converts special key names to their character equivalents
-    func keystrokesToText(_ keystrokes: [String]) -> String {
-        return keystrokes.map { keyNameToCharacter($0) }.joined()
     }
 }

--- a/macos/Onit/Keystrokes/KeycodeTranslator.swift
+++ b/macos/Onit/Keystrokes/KeycodeTranslator.swift
@@ -1,0 +1,253 @@
+//
+//  KeycodeTranslator.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/24/25.
+//
+
+import Foundation
+import AppKit
+
+@MainActor
+final class KeyCodeTranslator {
+    static let shared = KeyCodeTranslator()
+
+    private let keyCodeMap: [Int64: String] = [
+        // Letters
+        0: "a", 1: "s", 2: "d", 3: "f", 4: "h", 5: "g", 6: "z", 7: "x", 8: "c", 9: "v",
+        11: "b", 12: "q", 13: "w", 14: "e", 15: "r", 16: "y", 17: "t", 18: "1", 19: "2",
+        20: "3", 21: "4", 22: "6", 23: "5", 24: "=", 25: "9", 26: "7", 27: "-", 28: "8",
+        29: "0", 30: "]", 31: "o", 32: "u", 33: "[", 34: "i", 35: "p", 37: "l", 38: "j",
+        39: "'", 40: "k", 41: ";", 42: "\\", 43: ",", 44: "/", 45: "n", 46: "m", 47: ".",
+        50: "`",
+
+        // Numbers
+        82: "0", 83: "1", 84: "2", 85: "3", 86: "4", 87: "5", 88: "6", 89: "7", 91: "8", 92: "9",
+
+        // Function keys
+        122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5", 97: "F6", 98: "F7", 100: "F8",
+        101: "F9", 109: "F10", 103: "F11", 111: "F12", 105: "F13", 107: "F14", 113: "F15",
+        106: "F16", 64: "F17", 79: "F18", 80: "F19", 90: "F20",
+
+        // Special keys
+        36: "return", 48: "tab", 49: "space", 51: "delete", 53: "escape",
+        76: "enter", 117: "forward_delete", 119: "end", 115: "home",
+        116: "page_up", 121: "page_down", 123: "left", 124: "right", 125: "down", 126: "up",
+
+        // Keypad
+        65: "keypad_.", 67: "keypad_*", 69: "keypad_+", 71: "keypad_clear", 75: "keypad_/",
+        78: "keypad_-", 81: "keypad_=",
+
+        // Other
+        114: "help", 72: "volume_up", 73: "volume_down", 74: "mute"
+    ]
+
+    private let shiftedKeyMap: [Int64: String] = [
+        // Shifted letters become uppercase automatically
+        // Shifted numbers and symbols
+        18: "!", 19: "@", 20: "#", 21: "$", 23: "%", 22: "^", 26: "&", 28: "*", 25: "(", 29: ")",
+        27: "_", 24: "+", 33: "{", 30: "}", 42: "|", 41: ":", 39: "\"", 43: "<", 47: ">", 44: "?",
+        50: "~"
+    ]
+
+    private init() {}
+
+    func translateKeyCode(_ keyCode: Int64,
+                         isShiftPressed: Bool = false,
+                         isCommandPressed: Bool = false,
+                         isControlPressed: Bool = false,
+                         isOptionPressed: Bool = false) -> String {
+
+        var modifiers: [String] = []
+        if isControlPressed { modifiers.append("ctrl") }
+        if isOptionPressed { modifiers.append("opt") }
+        if isCommandPressed { modifiers.append("cmd") }
+
+        // Only add shift to modifiers if it doesn't naturally transform the character
+        // (we'll determine this after processing the key)
+
+        var keyString: String
+
+        // Handle shifted characters
+        let hasNaturalShiftTransformation: Bool
+        if isShiftPressed {
+            if let shiftedChar = shiftedKeyMap[keyCode] {
+                keyString = shiftedChar
+                hasNaturalShiftTransformation = true // shift produces a different character naturally
+            } else if let normalChar = keyCodeMap[keyCode] {
+                // For letters, make them uppercase when shift is pressed
+                if normalChar.count == 1 && normalChar.first!.isLetter {
+                    keyString = normalChar.uppercased()
+                    hasNaturalShiftTransformation = true // shift produces uppercase naturally
+                } else {
+                    keyString = normalChar
+                    hasNaturalShiftTransformation = false // shift doesn't change the character
+                }
+            } else {
+                keyString = "unknown(\(keyCode))"
+                hasNaturalShiftTransformation = false
+            }
+        } else {
+            keyString = keyCodeMap[keyCode] ?? "unknown(\(keyCode))"
+            hasNaturalShiftTransformation = false
+        }
+
+        // Add shift to modifiers only if it doesn't naturally transform the character
+        if isShiftPressed && !hasNaturalShiftTransformation {
+            modifiers.append("shift")
+        }
+
+        // Combine modifiers with the key
+        if modifiers.isEmpty {
+            return keyString
+        } else {
+            return modifiers.joined(separator: "+") + "+" + keyString
+        }
+    }
+
+    // Determines if a key combination modifies text field contents (adds or removes characters)
+    func keyProducesOutput(_ keyCode: Int64,
+                          isShiftPressed: Bool = false,
+                          isCommandPressed: Bool = false,
+                          isControlPressed: Bool = false,
+                          isOptionPressed: Bool = false) -> Bool {
+
+        // Keys that never modify text field contents regardless of modifiers
+        let nonOutputKeys: Set<Int64> = [
+            // Arrow keys
+            123, 124, 125, 126, // left, right, down, up
+
+            // Function keys
+            122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, // F1-F12
+            105, 107, 113, 106, 64, 79, 80, 90, // F13-F20
+
+            // Navigation keys (cursor movement only)
+            119, 115, 116, 121, // end, home, page_up, page_down
+            53, // escape
+            114, // help
+
+            // Volume controls
+            72, 73, 74, // volume_up, volume_down, mute
+
+            // Keypad operations (these perform actions rather than insert characters)
+            67, 69, 71, 75, 78, 81 // keypad_*, keypad_+, keypad_clear, keypad_/, keypad_-, keypad_=
+        ]
+
+        // If it's a non-output key, it never produces output
+        if nonOutputKeys.contains(keyCode) {
+            return false
+        }
+
+        // Keys that produce output or modify text field contents
+        let outputKeys: Set<Int64> = [
+            // Letters
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, // a-t
+            31, 32, 34, 35, 37, 38, 40, 45, 46, // o, u, i, p, l, j, k, n, m
+
+            // Numbers (main keyboard)
+            18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, // 1-0 and symbols
+
+            // Numbers (keypad)
+            82, 83, 84, 85, 86, 87, 88, 89, 91, 92, // keypad 0-9
+            65, // keypad decimal point
+
+            // Symbols and punctuation
+            33, 39, 41, 42, 43, 44, 47, 50, // [, ', ;, \, ,, /, ., `
+
+            // Special output keys
+            36, 48, 49, 76, // return, tab, space, enter
+
+            // Delete keys (modify text field by removing characters)
+            51, 117 // delete, forward_delete
+        ]
+
+        // If it's a known output key, check for modifier restrictions
+        if outputKeys.contains(keyCode) {
+            // Command combinations: some DO modify text content (cut, paste, undo, etc.)
+            if isCommandPressed {
+                // Command keys that modify text content
+                let textModifyingCommandKeys: Set<Int64> = [
+                    9, // v - paste (adds text from clipboard)
+                    7, // x - cut (removes selected text)
+                    6, // z - undo (can add or remove text)
+                    16, // y - redo (can add or remove text, if app uses Cmd+Y for redo)
+                    0, // a - select all (when followed by typing, replaces all text)
+                ]
+
+                // Handle Cmd+Shift+Z for redo (more common than Cmd+Y)
+                if isShiftPressed && keyCode == 6 { // z
+                    return true
+                }
+
+                return textModifyingCommandKeys.contains(keyCode)
+            }
+
+            // Control combinations: many DO modify text content in macOS (Emacs-style bindings)
+            if isControlPressed {
+                // Control keys that modify text content (based on macOS default Emacs bindings)
+                let textModifyingControlKeys: Set<Int64> = [
+                    4, // h - delete character to left (like backspace)
+                    2, // d - delete character to right (like forward delete)
+                    40, // k - delete from cursor to end of line
+                    32, // u - delete from cursor to beginning of line (if supported)
+                    13, // w - delete word backward (if supported)
+                    17, // t - transpose characters
+                    31, // o - insert new line
+                    16, // y - yank from kill buffer
+                    // Delete keys work with Control too
+                    51, 117 // delete, forward_delete
+                ]
+
+                return textModifyingControlKeys.contains(keyCode)
+            }
+
+            // Shift and Option with output keys still produce output (shifted chars, accented chars)
+            return true
+        }
+
+        // For unknown keys, assume they don't modify text field contents
+        return false
+    }
+
+    // Convenience method for when you have all the modifier states
+    func translateKeyCodeWithModifiers(_ keyCode: Int64,
+                                     modifierStates: (command: Bool, control: Bool, shift: Bool, option: Bool)) -> String {
+        return translateKeyCode(keyCode,
+                              isShiftPressed: modifierStates.shift,
+                              isCommandPressed: modifierStates.command,
+                              isControlPressed: modifierStates.control,
+                              isOptionPressed: modifierStates.option)
+    }
+
+    // Convenience method for when you have all the modifier states
+    func keyProducesOutputWithModifiers(_ keyCode: Int64,
+                                       modifierStates: (command: Bool, control: Bool, shift: Bool, option: Bool)) -> Bool {
+        return keyProducesOutput(keyCode,
+                               isShiftPressed: modifierStates.shift,
+                               isCommandPressed: modifierStates.command,
+                               isControlPressed: modifierStates.control,
+                               isOptionPressed: modifierStates.option)
+    }
+
+    /// Converts a key name string to its actual character representation for keystroke tracking
+    /// This is used to convert strings like "space", "tab", etc. back to their actual characters
+    func keyNameToCharacter(_ keyName: String) -> String {
+        switch keyName {
+        case "space":
+            return " "
+        case "tab":
+            return "\t"
+        case "return", "enter":
+            return "\n"
+        default:
+            // For everything else, return as-is (letters, numbers, symbols)
+            return keyName
+        }
+    }
+
+    /// Converts an array of keystroke strings to actual characters for text comparison
+    /// This joins keystrokes and converts special key names to their character equivalents
+    func keystrokesToText(_ keystrokes: [String]) -> String {
+        return keystrokes.map { keyNameToCharacter($0) }.joined()
+    }
+}

--- a/macos/Onit/Keystrokes/KeystrokeNotificationDelegate.swift
+++ b/macos/Onit/Keystrokes/KeystrokeNotificationDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  KeystrokeNotificationDelegate.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/24/25.
+//
+
+import Foundation
+import AppKit
+
+@MainActor protocol KeystrokeNotificationDelegate: AnyObject {
+    func keystrokeNotificationManager(_ manager: KeystrokeNotificationManager, didReceiveKeystroke event: KeystrokeEvent)
+} 

--- a/macos/Onit/Keystrokes/KeystrokeNotificationDelegate.swift
+++ b/macos/Onit/Keystrokes/KeystrokeNotificationDelegate.swift
@@ -9,5 +9,5 @@ import Foundation
 import AppKit
 
 @MainActor protocol KeystrokeNotificationDelegate: AnyObject {
-    func keystrokeNotificationManager(_ manager: KeystrokeNotificationManager, didReceiveKeystroke event: KeystrokeEvent)
+    func keystrokeNotificationManager(_ manager: KeystrokeNotificationManager, didReceiveKeystroke event: NSEvent)
 } 

--- a/macos/Onit/Keystrokes/KeystrokeNotificationManager.swift
+++ b/macos/Onit/Keystrokes/KeystrokeNotificationManager.swift
@@ -1,0 +1,191 @@
+//
+//  KeystrokeNotificationManager.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/24/25.
+//
+
+import Foundation
+import AppKit
+import ApplicationServices
+
+// MARK: - Keystroke Event Info
+
+struct KeystrokeEvent {
+    let type: CGEventType
+    let keyCode: Int64
+    let flags: CGEventFlags
+    let modifierStates: (command: Bool, control: Bool, shift: Bool, option: Bool)
+}
+
+// MARK: - Keystroke Notification Manager
+
+@MainActor
+final class KeystrokeNotificationManager: ObservableObject {
+
+    // MARK: - Singleton instance
+
+    static let shared = KeystrokeNotificationManager()
+
+    // MARK: - Properties
+
+    private nonisolated(unsafe) var eventTap: CFMachPort?
+    private nonisolated(unsafe) var runLoopSource: CFRunLoopSource?
+
+    private var isCommandPressed: Bool = false
+    private var isControlPressed: Bool = false
+    private var isShiftPressed: Bool = false
+    private var isOptionPressed: Bool = false
+
+    private var isMonitoring: Bool = false
+
+    // MARK: - Delegates
+
+    private var delegates = NSHashTable<AnyObject>.weakObjects()
+
+    func addDelegate(_ delegate: KeystrokeNotificationDelegate) {
+        delegates.add(delegate)
+    }
+
+    func removeDelegate(_ delegate: KeystrokeNotificationDelegate) {
+        delegates.remove(delegate)
+    }
+
+    private func notifyDelegates(_ notification: (KeystrokeNotificationDelegate) -> Void) {
+        for case let delegate as KeystrokeNotificationDelegate in delegates.allObjects {
+            notification(delegate)
+        }
+    }
+
+    // MARK: - Callbacks
+
+    private var keystrokeCallbacks: [(KeystrokeEvent) -> Void] = []
+
+    // MARK: - Private initializer
+
+    private init() { }
+
+    // MARK: - Public Methods
+
+    func startMonitoring() {
+        guard !isMonitoring else {
+            print("KeystrokeNotificationManager: Already monitoring")
+            return
+        }
+
+        let eventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue) | (1 << CGEventType.flagsChanged.rawValue)
+
+        guard let eventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: { (proxy, type, event, refcon) -> Unmanaged<CGEvent>? in
+                guard let refcon = refcon else { return Unmanaged.passRetained(event) }
+
+                let manager = Unmanaged<KeystrokeNotificationManager>.fromOpaque(refcon).takeUnretainedValue()
+                manager.handleKeyboardEvent(type: type, event: event)
+
+                return Unmanaged.passRetained(event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            print("KeystrokeNotificationManager: Failed to create event tap")
+            return
+        }
+
+        self.eventTap = eventTap
+        self.runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+
+        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+
+        isMonitoring = true
+        print("KeystrokeNotificationManager: Keyboard monitoring started")
+    }
+
+    func stopMonitoring() {
+        guard isMonitoring else {
+            print("KeystrokeNotificationManager: Not monitoring")
+            return
+        }
+
+        if let eventTap = eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: false)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+
+            self.eventTap = nil
+            self.runLoopSource = nil
+        }
+
+        isMonitoring = false
+        print("KeystrokeNotificationManager: Keyboard monitoring stopped")
+    }
+
+    func addKeystrokeCallback(_ callback: @escaping (KeystrokeEvent) -> Void) {
+        keystrokeCallbacks.append(callback)
+    }
+
+    func removeAllCallbacks() {
+        keystrokeCallbacks.removeAll()
+    }
+
+    // MARK: - Private Methods
+
+    private func handleKeyboardEvent(type: CGEventType, event: CGEvent) {
+        switch type {
+        case .flagsChanged:
+            updateModifierKeys(event: event)
+        case .keyDown:
+            handleKeyDown(event: event)
+        case .tapDisabledByUserInput:
+            restartEventTapIfNeeded()
+        case .tapDisabledByTimeout:
+            restartEventTapIfNeeded()
+        default:
+            break
+        }
+    }
+
+    private func restartEventTapIfNeeded() {
+        if let eventTap = self.eventTap {
+            DispatchQueue.main.async {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+        }
+    }
+
+    private func updateModifierKeys(event: CGEvent) {
+        let flags = event.flags
+        isCommandPressed = flags.contains(.maskCommand)
+        isControlPressed = flags.contains(.maskControl)
+        isShiftPressed = flags.contains(.maskShift)
+        isOptionPressed = flags.contains(.maskAlternate)
+    }
+
+    private func handleKeyDown(event: CGEvent) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let flags = event.flags
+
+        let modifierStates = (command: isCommandPressed, control: isControlPressed, shift: isShiftPressed, option: isOptionPressed)
+
+
+        let keystrokeEvent = KeystrokeEvent(
+            type: .keyDown,
+            keyCode: keyCode,
+            flags: flags,
+            modifierStates: modifierStates
+        )
+
+        // Notify all callbacks
+        notifyDelegates { delegate in
+            delegate.keystrokeNotificationManager(self, didReceiveKeystroke: keystrokeEvent)
+        }
+    }
+
+    // MARK: - Utility Methods
+
+    func getCurrentModifierStates() -> (command: Bool, control: Bool, shift: Bool, option: Bool) {
+        return (command: isCommandPressed, control: isControlPressed, shift: isShiftPressed, option: isOptionPressed)
+    }
+}

--- a/macos/Onit/Mouse/MouseNotificationDelegate.swift
+++ b/macos/Onit/Mouse/MouseNotificationDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  MouseNotificationDelegate.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/25/25.
+//
+
+import Foundation
+import AppKit
+
+@MainActor protocol MouseNotificationDelegate: AnyObject {
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didReceiveSingleClick event: NSEvent)
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didReceiveDoubleClick event: NSEvent)
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didReceiveTripleClick event: NSEvent)
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didStartDrag event: NSEvent)
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didUpdateDrag event: NSEvent)
+    func mouseNotificationManager(_ manager: MouseNotificationManager, didEndDrag event: NSEvent)
+}
+

--- a/macos/Onit/Mouse/MouseNotificationManager.swift
+++ b/macos/Onit/Mouse/MouseNotificationManager.swift
@@ -1,0 +1,173 @@
+//
+//  MouseNotificationManager.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/25/25.
+//
+
+import Foundation
+import AppKit
+
+// MARK: - Mouse Notification Manager
+@MainActor
+final class MouseNotificationManager: ObservableObject {
+
+    // MARK: - Singleton instance
+
+    static let shared = MouseNotificationManager()
+
+    // MARK: - Properties
+
+    private var localEventMonitor: Any?
+    private var globalEventMonitor: Any?
+
+    private var isMonitoring: Bool = false
+    private var isDragging: Bool = false
+    private var lastClickTime: TimeInterval = 0
+    private var clickCount: Int = 0
+    private var dragStartLocation: NSPoint = .zero
+
+    // MARK: - Delegates
+
+    private var delegates = NSHashTable<AnyObject>.weakObjects()
+
+    func addDelegate(_ delegate: MouseNotificationDelegate) {
+        delegates.add(delegate)
+    }
+
+    func removeDelegate(_ delegate: MouseNotificationDelegate) {
+        delegates.remove(delegate)
+    }
+
+    private func notifyDelegates(_ notification: (MouseNotificationDelegate) -> Void) {
+        for case let delegate as MouseNotificationDelegate in delegates.allObjects {
+            notification(delegate)
+        }
+    }
+
+    // MARK: - Private initializer
+
+    private init() {
+        startMonitoring()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public Methods
+
+    func startMonitoring() {
+        guard !isMonitoring else { return }
+
+        // Monitor mouse events
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp, .leftMouseDragged, .rightMouseDown, .rightMouseUp, .rightMouseDragged]) { [weak self] event in
+            self?.handleMouseEvent(event)
+            return event
+        }
+
+        globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp, .leftMouseDragged, .rightMouseDown, .rightMouseUp, .rightMouseDragged]) { [weak self] event in
+            self?.handleMouseEvent(event)
+        }
+
+        isMonitoring = true
+    }
+
+    func stopMonitoring() {
+        guard isMonitoring else {
+            return
+        }
+
+        if let localEventMonitor = localEventMonitor {
+            NSEvent.removeMonitor(localEventMonitor)
+            self.localEventMonitor = nil
+        }
+
+        if let globalEventMonitor = globalEventMonitor {
+            NSEvent.removeMonitor(globalEventMonitor)
+            self.globalEventMonitor = nil
+        }
+
+        isMonitoring = false
+    }
+
+    // MARK: - Private Methods
+
+    private func handleMouseEvent(_ event: NSEvent) {
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown:
+            handleMouseDown(event: event)
+        case .leftMouseUp, .rightMouseUp:
+            handleMouseUp(event: event)
+        case .leftMouseDragged, .rightMouseDragged:
+            handleMouseDragged(event: event)
+        default:
+            break
+        }
+    }
+
+    private func handleMouseDown(event: NSEvent) {
+        // Start tracking potential drag
+        isDragging = false
+        dragStartLocation = event.locationInWindow
+        
+        // Handle click events based on click count
+        switch event.clickCount {
+        case 1:
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didReceiveSingleClick: event)
+            }
+        case 2:
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didReceiveDoubleClick: event)
+            }
+        case 3:
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didReceiveTripleClick: event)
+            }
+        default:
+            // For clicks beyond triple, treat as single click
+            break
+        }
+    }
+
+    private func handleMouseUp(event: NSEvent) {
+        if isDragging {
+            // End drag operation
+            isDragging = false
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didEndDrag: event)
+            }
+        }
+    }
+
+    private func handleMouseDragged(event: NSEvent) {
+        let dragDistance = hypot(event.locationInWindow.x - dragStartLocation.x, 
+                               event.locationInWindow.y - dragStartLocation.y)
+        
+        // Start drag if we've moved more than 3 points
+        if !isDragging && dragDistance > 3.0 {
+            isDragging = true
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didStartDrag: event)
+            }
+        }
+        
+        // Update drag if already dragging
+        if isDragging {
+            notifyDelegates { delegate in
+                delegate.mouseNotificationManager(self, didUpdateDrag: event)
+            }
+        }
+    }
+
+    // MARK: - Utility Methods
+
+    func getCurrentDragState() -> Bool {
+        return isDragging
+    }
+    
+    func getLastClickCount() -> Int {
+        return clickCount
+    }
+}


### PR DESCRIPTION
Building off PR #360 , this PR introduces a Mouse notification manager. Currently, it can only send a few events (single, double, & triple clicks plus drags) and we aren't using it anywhere, but we will want this soon in a few cases:

- Our nextgen highlighted text detection will need to listen for double/triple clicks and drags, because the kAXSelectedTextNotifications aren't reliable. 
- Cursor position detection (useful for the Typeahead UI & QuickEdit hint) will use single clicks to detect when the cursor has moved. 
- And potentially more in the future!