### PR TITLE
Setup the ability to listen for AX notifications from our own process…

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsDelegate.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsDelegate.swift
@@ -18,4 +18,7 @@ import SwiftUI
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didResizeWindow window: TrackedWindow)
     
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didChangeWindowTitle window: TrackedWindow)
+
+    var wantsNotificationsFromIgnoredProcesses: Bool { get }
+    var wantsNotificationsFromOnit: Bool { get }
 }

--- a/macos/Onit/Accessibility/Notifications/WindowChangeDelegate.swift
+++ b/macos/Onit/Accessibility/Notifications/WindowChangeDelegate.swift
@@ -148,4 +148,7 @@ final class WindowChangeDelegate: AccessibilityNotificationsDelegate {
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDeminimizeWindow window: TrackedWindow) {}
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didActivateIgnoredWindow window: TrackedWindow?) {}
     func accessibilityManager(_ manager: AccessibilityNotificationsManager, didDestroyWindow window: TrackedWindow) {}
+    
+    var wantsNotificationsFromIgnoredProcesses: Bool { false }
+    var wantsNotificationsFromOnit: Bool { false }
 }

--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversDelegate.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversDelegate.swift
@@ -10,10 +10,17 @@ import Foundation
 
 @MainActor protocol AccessibilityObserversDelegate: AnyObject {
     func accessibilityObserversManager(didActivateApplication appName: String?, processID: pid_t)
-    func accessibilityObserversManager(didActivateIgnoredApplication appName: String?)
+    func accessibilityObserversManager(didActivateIgnoredApplication appName: String?, processID: pid_t)
     func accessibilityObserversManager(didReceiveNotification notification: String,
                                        element: AXUIElement,
                                        elementPid: pid_t,
                                        info: [String: Any])
     func accessibilityObserversManager(didDeactivateApplication appName: String?, processID: pid_t)
+    func accessibilityObserversManager(didDeactivateIgnoredApplication appName: String?, processID: pid_t)
+
+    // Note: because our OnitRegularPanel has styleMask [.nonactivatingPanel], these notifications are not always fired.
+    // A click on the panel does not create a notification, but clicking the icon in Dock does.
+    // These shouldn't be relied on for core logic. 
+    func accessibilityObserversManager(didActivateOnit processID: pid_t)
+    func accessibilityObserversManager(didDeactivateOnit processID: pid_t)
 }

--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversManager+Config.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversManager+Config.swift
@@ -55,5 +55,11 @@ extension AccessibilityObserversManager {
             kAXWindowDeminiaturizedNotification,
             kAXWindowMiniaturizedNotification,
         ]
+
+        // We want to collect typeahead tests from both Onit and ignore processes.
+        static let onitNotifications: [String] = [
+            kAXValueChangedNotification,
+            kAXFocusedUIElementChangedNotification,
+        ]
     }
 }

--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
@@ -21,6 +21,15 @@ class AccessibilityObserversManager {
     // MARK: - Singleton
     
     static let shared = AccessibilityObserversManager()
+
+    // Static method to get the current ignored app names (for consistency across managers)
+    static var currentIgnoredAppNames: [String] {
+    #if DEBUG
+        return ["Xcode"]
+    #else
+        return []
+    #endif
+    }
     
     // MARK: - Properties
     
@@ -122,7 +131,7 @@ class AccessibilityObserversManager {
         let currentPid = getpid()
         let appName = currentPid.appName ?? "Onit"
 
-        // This will depend on whether typeahead is enabled or not. For now, we can disable it by default.
+        // TODO: TIM - Typeahead - Enable notifications for Onit when needed
         if false {
             startNotificationsObserver(for: currentPid, notifications: Config.onitNotifications)
         }
@@ -402,15 +411,6 @@ class AccessibilityObserversManager {
         return .eligible
     }
     
-    // Static method to get the current ignored app names (for consistency across managers)
-    static var currentIgnoredAppNames: [String] {
-#if DEBUG
-        return ["Xcode"]
-#else
-        return []
-#endif
-    }
-
     private func isAXServerInitialized(pid: pid_t) -> Bool {
         func isAppleApplication(for pid: pid_t) -> Bool {
             guard let bundleIdentifier = pid.bundleIdentifier else {

--- a/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
+++ b/macos/Onit/Accessibility/Observers/AccessibilityObserversManager.swift
@@ -122,7 +122,7 @@ class AccessibilityObserversManager {
         let currentPid = getpid()
         let appName = currentPid.appName ?? "Onit"
 
-        // This will depend on whether typeahead is enabled or not. For now, we can disble it by default.
+        // This will depend on whether typeahead is enabled or not. For now, we can disable it by default.
         if false {
             startNotificationsObserver(for: currentPid, notifications: Config.onitNotifications)
         }

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager+Delegates.swift
@@ -77,6 +77,9 @@ extension PanelStatePinnedManager: AccessibilityNotificationsDelegate {
             state.foregroundWindow = window
         }
     }
+    
+    var wantsNotificationsFromIgnoredProcesses: Bool { false }
+    var wantsNotificationsFromOnit: Bool { false }
 }
 
 extension PanelStatePinnedManager: OnitPanelStateDelegate {

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Delegates.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager+Delegates.swift
@@ -101,6 +101,9 @@ extension PanelStateTetheredManager: AccessibilityNotificationsDelegate {
             }
          }
     }
+    
+    var wantsNotificationsFromIgnoredProcesses: Bool { false }
+    var wantsNotificationsFromOnit: Bool { false }
 }
 
 // MARK: - OnitPanelStateDelegate


### PR DESCRIPTION
… and ignored processes

This is the first of many PRs related to the upcoming typeahead system. For typeahead, we want to be able to listen for some notifications on both our own process and the ignored process. This PR modifies the AccessibilityNotificationsDelegate so that it can ask for notifications from either by setting `wantsNotificationsFromIgnoredProcesses` or `wantsNotificationsFromOnit` to true. 

Note:
- The .nonactivatingPanel styleMask on OnitRegularPanel prevents standard “app activated” and “deactivated” notifications. This makes it difficult to start and stop the accessibilityNotificationsManager based on Onit’s active state. Removing the .nonactivatingPanel caused significant UI issues, so as a workaround, we now continuously listen for a small subset of AXNotifications from our own process.