### PR TITLE
Pull context fetching logic into shared service

### DIFF
--- a/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
+++ b/macos/Onit/Accessibility/Notifications/AccessibilityNotificationsManager.swift
@@ -54,8 +54,6 @@ class AccessibilityNotificationsManager: ObservableObject {
     private var valueDebounceWorkItem: DispatchWorkItem?
     private var selectionDebounceWorkItem: DispatchWorkItem?
     private var parseDebounceWorkItem: DispatchWorkItem?
-    
-    private var lastActiveWindowPid: pid_t?
 
     // MARK: - Private initializer
 
@@ -139,8 +137,6 @@ class AccessibilityNotificationsManager: ObservableObject {
         selectionDebounceWorkItem?.cancel()
         parseDebounceWorkItem?.cancel()
         
-        lastActiveWindowPid = nil
-        
         ContextFetchingService.shared.reset()
     }
 
@@ -166,7 +162,7 @@ class AccessibilityNotificationsManager: ObservableObject {
         }
 
         currentSource = appName
-        lastActiveWindowPid = processID
+        ContextFetchingService.shared.setLastActive(windowPid: processID)
         
         caretPositionManager.updateCaretLost()
         

--- a/macos/Onit/Context/ContextFetchingService.swift
+++ b/macos/Onit/Context/ContextFetchingService.swift
@@ -1,0 +1,320 @@
+//
+//  ContextFetchingService.swift
+//  Onit
+//
+//  Created by Timothy Lenardo on 7/29/25.
+//
+
+import ApplicationServices
+import Defaults
+import Foundation
+import PostHog
+import SwiftUI
+
+@MainActor
+class ContextFetchingService {
+    static let shared = ContextFetchingService()
+    
+    // MARK: - Properties
+    
+    private var timedOutWindowHash: Set<UInt> = []  // Track window's hash that have timed out
+    private var lastActiveWindowPid: pid_t?
+    
+    // MARK: - Private initializer
+    
+    private init() { }
+    
+    // MARK: - Functions
+    
+    func retrieveWindowContent(
+        pid: pid_t? = nil,
+        state: OnitPanelState? = nil,
+        trackedWindow: TrackedWindow? = nil,
+        customAppBundleUrl: URL? = nil,
+        lastActiveWindowPid: pid_t? = nil
+    ) {
+        guard let pid = trackedWindow?.pid ?? pid ?? lastActiveWindowPid,
+              let mainWindow = trackedWindow?.element ?? pid.firstMainWindow,
+              let state = state ?? PanelStateCoordinator.shared.getState(for: CFHash(mainWindow))
+        else {
+            return
+        }
+        
+        let windowHash = trackedWindow?.hash ?? CFHash(mainWindow)
+        
+        state.windowContextTasks[windowHash]?.cancel()
+        
+        // This task will automatically be cleaned up way down the call stack when it hits `addAutoContext()`.
+        state.windowContextTasks[windowHash] = Task {
+            if let documentInfo = findDocument(in: mainWindow) {
+                handleWindowContent(
+                    documentInfo,
+                    for: state,
+                    trackedWindow: trackedWindow,
+                    customAppBundleUrl: customAppBundleUrl
+                )
+                // TODO: KNA - uncomment this to use WebContentFetchService with AXURL
+            } else if let url = findUrl(in: mainWindow), url.absoluteString.contains("docs.google.com") {
+                
+                let appName = mainWindow.parent()?.title() ?? ""
+                let appTitle = mainWindow.title() ?? ""
+                let startTime = CFAbsoluteTimeGetCurrent()
+                if GoogleDriveService.shared.checkAuthorizationStatus() {
+                    do {
+                        let documentContent = try await GoogleDriveService.shared.extractTextFromGoogleDrive(driveUrl: url.absoluteString)
+                        let contentArray = [
+                            AccessibilityParsedElements.applicationName: appName,
+                            AccessibilityParsedElements.applicationTitle: appTitle,
+                            AccessibilityParsedElements.elapsedTime: "\(CFAbsoluteTimeGetCurrent() - startTime)",
+                            "document": documentContent
+                        ]
+                        handleWindowContent(
+                            contentArray,
+                            for: state,
+                            customAppBundleUrl: customAppBundleUrl
+                        )
+                    } catch {
+                        // Handle error case by creating error context
+                        var appBundleUrl = customAppBundleUrl
+                        if appBundleUrl == nil {
+                            if let pid = lastActiveWindowPid,
+                            let app = NSRunningApplication(processIdentifier: pid) {
+                                appBundleUrl = app.bundleURL
+                            }
+                        }
+                        
+                        let errorMessage: String
+                        let errorCode: Int32
+                        if let googleDriveError = error as? GoogleDriveServiceError {
+                            errorMessage = googleDriveError.localizedDescription
+                            switch googleDriveError {
+                            case .notFound:
+                                errorCode = 1501
+                            default:
+                                errorCode = 1500
+                            }
+                        } else {
+                            errorMessage = "Failed to extract Google Drive document content: \(error.localizedDescription)"
+                            errorCode = 1500
+                        }
+                        
+                        // Update screenResult with error information
+                        AccessibilityNotificationsManager.shared.screenResult.applicationName = appName
+                        AccessibilityNotificationsManager.shared.screenResult.applicationTitle = appTitle
+                        AccessibilityNotificationsManager.shared.screenResult.errorMessage = errorMessage
+                        AccessibilityNotificationsManager.shared.screenResult.errorCode = errorCode
+                        AccessibilityNotificationsManager.shared.screenResult.appBundleUrl = appBundleUrl
+                        AccessibilityNotificationsManager.shared.screenResult.others = nil
+                        
+                        // Call addAutoContext to handle the error case
+                        state.addAutoContext(trackedWindow: trackedWindow)
+                    }
+                } else {
+                    // This creates an error state for when google drive is not authorized
+                    var appBundleUrl = customAppBundleUrl
+                    if appBundleUrl == nil {
+                        if let pid = lastActiveWindowPid,
+                        let app = NSRunningApplication(processIdentifier: pid) {
+                            appBundleUrl = app.bundleURL
+                        }
+                    }
+                    
+                    // Update screenResult with unauthorized error
+                    AccessibilityNotificationsManager.shared.screenResult.applicationName = appName
+                    AccessibilityNotificationsManager.shared.screenResult.applicationTitle = appTitle
+                    AccessibilityNotificationsManager.shared.screenResult.errorMessage = "Google Drive Plugin Required"
+                    AccessibilityNotificationsManager.shared.screenResult.errorCode = 1500
+                    AccessibilityNotificationsManager.shared.screenResult.appBundleUrl = appBundleUrl
+                    AccessibilityNotificationsManager.shared.screenResult.others = nil
+                    
+                    // Call addAutoContext to handle the error case
+                    state.addAutoContext(trackedWindow: trackedWindow)
+                }
+            }  else {
+                parseAccessibility(
+                    for: pid,
+                    in: mainWindow,
+                    state: state,
+                    trackedWindow: trackedWindow,
+                    customAppBundleUrl: customAppBundleUrl
+                )
+            }
+        }
+    }
+    
+    private func findDocument(in focusedWindow: AXUIElement) -> [String: String]? {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        var documentValue: CFTypeRef?
+        
+        let hasDocument = AXUIElementCopyAttributeValue(focusedWindow, kAXDocumentAttribute as CFString, &documentValue) == .success
+        
+        if hasDocument, let document = documentValue as? String,
+            document.hasPrefix("file:///"), let fileURL = URL(string: document) {
+            do {
+                let appName = focusedWindow.parent()?.title() ?? ""
+                let appTitle = focusedWindow.title() ?? ""
+                let content = try String(contentsOf: fileURL, encoding: .utf8)
+                
+                return [
+                    AccessibilityParsedElements.applicationName: appName,
+                    AccessibilityParsedElements.applicationTitle: appTitle,
+                    AccessibilityParsedElements.elapsedTime: "\(CFAbsoluteTimeGetCurrent() - startTime)",
+                    "document": content
+                ]
+            } catch {
+                return nil
+            }
+        }
+        
+        return nil
+    }
+    
+    private func findUrl(in element: AXUIElement, maxDepth: Int = 5) -> URL? {
+        func findURLInChildren(element: AXUIElement, depth: Int = 0) -> URL? {
+            if depth >= maxDepth {
+                return nil
+            }
+            
+            if let children = element.children() {
+                for child in children {
+                    if child.role() == "AXWebArea", let url = child.url() {
+                        return url
+                    }
+                    
+                    if let url = findURLInChildren(element: child, depth: depth + 1) {
+                        return url
+                    }
+                }
+            }
+            
+            return nil
+        }
+        return findURLInChildren(element: element)
+    }
+    
+    private func findUrlAndProcessURL(in focusedWindow: AXUIElement) async -> [String: String]? {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        
+        func processUrl(_ url: URL, from element: AXUIElement) async -> [String: String]? {
+            do {
+                let appName = element.parent()?.title() ?? ""
+                let appTitle = element.title() ?? ""
+                
+                let (_, content) = try await WebContentFetchService.fetchWebpageContent(websiteUrl: url)
+                
+                return [
+                    AccessibilityParsedElements.applicationName: appName,
+                    AccessibilityParsedElements.applicationTitle: appTitle,
+                    AccessibilityParsedElements.elapsedTime: "\(CFAbsoluteTimeGetCurrent() - startTime)",
+                    "url": url.absoluteString,
+                    "content": content
+                ]
+            } catch {
+                print("Error processing URL: \(error)")
+                return nil
+            }
+        }
+        
+        if let url = findUrl(in: focusedWindow) {
+            return await processUrl(url, from: focusedWindow)
+        }
+        
+        return nil
+    }
+    
+    private func parseAccessibility(
+        for pid: pid_t,
+        in window: AXUIElement,
+        state: OnitPanelState,
+        trackedWindow: TrackedWindow? = nil,
+        customAppBundleUrl: URL? = nil
+    ) {
+        let windowHash = trackedWindow?.hash ?? CFHash(window)
+        let appName = trackedWindow?.element.parent()?.title() ?? window.parent()?.title() ?? "Unknown"
+        let mainWindow = trackedWindow?.element ?? window
+        
+        if timedOutWindowHash.contains(windowHash) {
+            print("Skipping parsing for window's hash \(windowHash) due to previous timeout.")
+            return
+        }
+        
+        guard Defaults[.autoContextFromCurrentWindow] else {
+            return
+        }
+        
+        // Note: The original implementation used a debounce interval, but it's not needed here
+        // since we're not implementing the debouncing logic in this service
+        
+        Task {
+            do {
+                let (results, boundingBoxes) = try await AccessibilityParser.shared.getAllTextInElement(windowElement: mainWindow)
+                handleWindowContent(
+                    results,
+                    for: state,
+                    trackedWindow: trackedWindow,
+                    customAppBundleUrl: customAppBundleUrl
+                )
+            } catch {
+                await MainActor.run {
+                    print("Accessibility timeout")
+                    self.timedOutWindowHash.insert(windowHash)
+                    AnalyticsManager.Accessibility.parseTimedOut(appName: appName)
+                    
+                    // Update screenResult with timeout error
+                    AccessibilityNotificationsManager.shared.screenResult.applicationName = appName
+                    AccessibilityNotificationsManager.shared.screenResult.applicationTitle = ""
+                    AccessibilityNotificationsManager.shared.screenResult.errorMessage = "Timeout occurred, could not read application in reasonable amount of time."
+                    AccessibilityNotificationsManager.shared.screenResult.errorCode = 1500
+                    AccessibilityNotificationsManager.shared.screenResult.appBundleUrl = nil
+                    AccessibilityNotificationsManager.shared.screenResult.others = nil
+                    
+                    // Call addAutoContext to handle the error case
+                    state.addAutoContext(trackedWindow: trackedWindow)
+                }
+            }
+        }
+    }
+    
+    private func handleWindowContent(
+        _ results: [String: String]?,
+        for state: OnitPanelState,
+        trackedWindow: TrackedWindow? = nil,
+        customAppBundleUrl: URL? = nil
+    ) {
+        var appBundleUrl: URL? = customAppBundleUrl
+        
+        if appBundleUrl == nil,
+           let pid = lastActiveWindowPid,
+           let app = NSRunningApplication(processIdentifier: pid)
+        {
+            appBundleUrl = app.bundleURL
+        }
+        
+        let appName = results?[AccessibilityParsedElements.applicationName] ?? ""
+        let appTitle = results?[AccessibilityParsedElements.applicationTitle] ?? ""
+        
+        // Update screenResult with the parsed content
+        AccessibilityNotificationsManager.shared.screenResult.applicationName = appName
+        AccessibilityNotificationsManager.shared.screenResult.applicationTitle = appTitle
+        AccessibilityNotificationsManager.shared.screenResult.errorMessage = nil
+        AccessibilityNotificationsManager.shared.screenResult.errorCode = nil
+        AccessibilityNotificationsManager.shared.screenResult.appBundleUrl = appBundleUrl
+        AccessibilityNotificationsManager.shared.screenResult.others = results
+        
+        // Call addAutoContext to handle the context creation and cleanup
+        state.addAutoContext(trackedWindow: trackedWindow)
+    }
+    
+    func reset() {
+        timedOutWindowHash.removeAll()
+        lastActiveWindowPid = nil
+    }
+    
+    // MARK: - Debug
+    
+    private func showDebug() {
+        // This method is called to update debug information
+        // Since we're no longer using screenResult, we'll just clear the debug text
+        DebugManager.shared.debugText = "Context fetching moved to ContextFetchingService"
+    }
+}

--- a/macos/Onit/Context/ContextFetchingService.swift
+++ b/macos/Onit/Context/ContextFetchingService.swift
@@ -306,7 +306,8 @@ class ContextFetchingService {
     }
     
     func reset() {
-        timedOutWindowHash.removeAll()
+        /// I (Kevin) don't think we should reset the timed out windows
+        // timedOutWindowHash.removeAll()
         lastActiveWindowPid = nil
     }
     

--- a/macos/Onit/Context/ContextFetchingService.swift
+++ b/macos/Onit/Context/ContextFetchingService.swift
@@ -26,12 +26,15 @@ class ContextFetchingService {
     
     // MARK: - Functions
     
+    func setLastActive(windowPid: pid_t?) {
+        lastActiveWindowPid = windowPid
+    }
+    
     func retrieveWindowContent(
         pid: pid_t? = nil,
         state: OnitPanelState? = nil,
         trackedWindow: TrackedWindow? = nil,
-        customAppBundleUrl: URL? = nil,
-        lastActiveWindowPid: pid_t? = nil
+        customAppBundleUrl: URL? = nil
     ) {
         guard let pid = trackedWindow?.pid ?? pid ?? lastActiveWindowPid,
               let mainWindow = trackedWindow?.element ?? pid.firstMainWindow,

--- a/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
+++ b/macos/Onit/PanelStateManager/Pinned/PanelStatePinnedManager.swift
@@ -156,7 +156,9 @@ class PanelStatePinnedManager: PanelStateBaseManager, ObservableObject {
     }
 
     override func fetchWindowContext() {
-        AccessibilityNotificationsManager.shared.retrieveWindowContent(trackedWindow: state.trackedWindow)
+        ContextFetchingService.shared.retrieveWindowContent(
+            trackedWindow: state.trackedWindow
+        )
     }
     
     // MARK: - Functions

--- a/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
+++ b/macos/Onit/PanelStateManager/Tethered/PanelStateTetheredManager.swift
@@ -136,7 +136,9 @@ class PanelStateTetheredManager: PanelStateBaseManager, ObservableObject {
             $0.1 === self.state
         }) else { return }
         
-        AccessibilityNotificationsManager.shared.retrieveWindowContent(pid: trackedWindow.pid)
+        ContextFetchingService.shared.retrieveWindowContent(
+            pid: trackedWindow.pid
+        )
     }
     
     // MARK: - Functions

--- a/macos/Onit/UI/Panels/State/OnitPanelState+Input.swift
+++ b/macos/Onit/UI/Panels/State/OnitPanelState+Input.swift
@@ -154,7 +154,7 @@ extension OnitPanelState {
         let windowApp = WindowHelpers.getWindowApp(pid: trackedWindow.pid)
         let appBundleUrl = windowApp?.bundleURL
         
-        AccessibilityNotificationsManager.shared.retrieveWindowContent(
+        ContextFetchingService.shared.retrieveWindowContent(
             state: self,
             trackedWindow: trackedWindow,
             customAppBundleUrl: appBundleUrl

--- a/macos/Onit/UI/Windows/ContextView.swift
+++ b/macos/Onit/UI/Windows/ContextView.swift
@@ -204,7 +204,7 @@ struct ContextView: View {
 
         let trackedWindow = AccessibilityNotificationsManager.shared.windowsManager.findTrackedWindow(trackedWindowHash: autoContext.appHash)
 
-        AccessibilityNotificationsManager.shared.retrieveWindowContent(
+        ContextFetchingService.shared.retrieveWindowContent(
             state: state,
             trackedWindow: trackedWindow,
             customAppBundleUrl: autoContext.appBundleUrl


### PR DESCRIPTION
This PR shouldn't change the functionality at all - I am just pulling the 'retrieveWindowContent" logic from the AccessibilityNotificationsManager into a new "ContextFetchingService". It doesn't make sense to have this in the AccessibilityNotificationsManager, particularly now that we have different mechanisms for loading context from other types of windows (like Google Docs, etc). 

The next step will be:
1. Remove the 'screenResult' concept from AccessibilityNotificationManager- this no longer makes sense. Each context task should have its own 
2. Caches results and prevents duplicate scrapes as much as possible. 
3. (later) Split the different methods of loading Context into their helpers. For example, document reading should get its own file. Google Docs should get its own file. Etc etc. That way, as the complexity grows (Google Docs, for example, will grow in complexity as we support custom elements like tables, styling, images, etc), the logic is contained in separate files, instead of one massive Frankenfile. 
